### PR TITLE
Move from 'Data.Binary' to 'Codec.Serialise'

### DIFF
--- a/src/Oscoin/Consensus/Evaluator/Radicle.hs
+++ b/src/Oscoin/Consensus/Evaluator/Radicle.hs
@@ -11,9 +11,8 @@ import           Oscoin.Crypto.PubKey (PublicKey)
 import           Oscoin.Crypto.Hash (Hashed, toHashed, zeroHash)
 
 import qualified Radicle as Rad
-import           Codec.Serialise (serialise, deserialise)
+import           Codec.Serialise (Serialise, serialise, deserialise)
 import qualified Data.ByteString.Lazy as LBS
-import           Data.Binary
 import qualified Data.Map as Map
 
 newtype Env = Env { fromEnv :: Rad.Bindings Identity }
@@ -33,7 +32,7 @@ data Program = Program
     , progNonce   :: Word32
     } deriving (Show, Generic)
 
-instance Binary Program
+instance Serialise Program
 
 fromSource :: Text -> Text -> Either Text Program
 fromSource name src = do

--- a/src/Oscoin/Consensus/Nakamoto.hs
+++ b/src/Oscoin/Consensus/Nakamoto.hs
@@ -37,7 +37,7 @@ import qualified Oscoin.P2P as P2P
 
 import           Control.Monad.RWS (RWST, evalRWST, runRWST, state)
 import           Crypto.Number.Serialize (os2ip)
-import           Data.Binary (Binary)
+import           Codec.Serialise (Serialise)
 import           Data.Functor (($>))
 import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Maybe (maybeToList, catMaybes)
@@ -75,7 +75,7 @@ instance Has Log.Logger (NakamotoEnv tx s) where
     getter         = nakLogger
     modifier f env = env { nakLogger = f (nakLogger env) }
 
-defaultNakamotoEnv :: Binary tx => NakamotoEnv tx s
+defaultNakamotoEnv :: Serialise tx => NakamotoEnv tx s
 defaultNakamotoEnv = NakamotoEnv
     { nakEval = identityEval
     , nakDifficulty = easyDifficulty
@@ -181,7 +181,7 @@ evalNakamotoT env rng (NakamotoT ma) = evalRWST ma env rng
 
 -- | Attempt to mine a 'Block'. Returns 'Nothing' if all nonces were tried
 -- unsuccessfully.
-mineBlock :: Binary tx => NakamotoMiner tx s
+mineBlock :: Serialise tx => NakamotoMiner tx s
 mineBlock tick _ evalFn d txs parent = do
     let (results, s') = applyValidExprs txs (blockState . blockHeader $ parent) evalFn
         validTxs      = map fst (rights results)
@@ -190,7 +190,7 @@ mineBlock tick _ evalFn d txs parent = do
 
 -- | Like 'mineBlock', but attempts to mine a block only 10% of the time it
 -- is called. Useful for test environments with very low difficulty.
-mineBlockRandom :: Binary tx => NakamotoMiner tx s
+mineBlockRandom :: Serialise tx => NakamotoMiner tx s
 mineBlockRandom t rng evalFn d txs parent =
     let (r, rng') = randomR (0, 1) rng
         p = 0.1 :: Float
@@ -253,7 +253,7 @@ findPoW bh@BlockHeader { blockNonce }
         Nothing
 
 findBlock
-    :: (Foldable t, Binary tx)
+    :: (Foldable t, Serialise tx)
     => Tick
     -> BlockHash
     -> s

--- a/src/Oscoin/Consensus/Simple.hs
+++ b/src/Oscoin/Consensus/Simple.hs
@@ -30,7 +30,7 @@ import           Oscoin.Node.Mempool.Class (MonadMempool(..))
 import qualified Oscoin.P2P as P2P
 
 import           Control.Monad.State
-import           Data.Binary (Binary)
+import           Codec.Serialise (Serialise)
 import           Data.Bool (bool)
 import           Data.Functor (($>))
 import           Data.Maybe (maybeToList)
@@ -63,7 +63,7 @@ instance MonadTrans (SimpleT tx i) where
 
 instance ( MonadMempool    tx    m
          , MonadBlockStore tx () m
-         , Binary          tx
+         , Serialise       tx
          , Ord i
          ) => MonadProtocol tx (SimpleT tx i m)
   where

--- a/src/Oscoin/Crypto/Blockchain.hs
+++ b/src/Oscoin/Crypto/Blockchain.hs
@@ -18,8 +18,8 @@ import           Oscoin.Prelude hiding (toList)
 
 import qualified Prelude
 
+import           Codec.Serialise (Serialise)
 import           Data.Bifunctor (Bifunctor(..))
-import           Data.Binary (Binary)
 import qualified Data.ByteString.Char8 as C8
 import           Data.List.NonEmpty ((<|))
 import qualified Data.List.NonEmpty as NonEmpty
@@ -31,7 +31,7 @@ import           GHC.Exts (IsList(toList))
 newtype Blockchain tx s = Blockchain { fromBlockchain :: NonEmpty (Block tx s) }
     deriving (Functor, Traversable, Foldable)
 
-instance (Hashable s, Binary tx) => Show (Blockchain tx s) where
+instance (Hashable s, Serialise tx) => Show (Blockchain tx s) where
     show = showBlockchain
 
 instance Semigroup (Blockchain tx s) where
@@ -96,7 +96,7 @@ showBlockDigest b@Block{blockHeader} =
   where
     time :: NominalDiffTime = toEnum (fromIntegral $ blockTimestamp blockHeader)
 
-showBlockchain :: Binary tx => Blockchain tx s -> String
+showBlockchain :: Serialise tx => Blockchain tx s -> String
 showBlockchain chain = execWriter $ do
     tell "\n"
     for_ (zip heights (toList chain)) $ \(h, Block bh@BlockHeader{..} txs) -> do

--- a/test/Oscoin/Test/Consensus/Node.hs
+++ b/test/Oscoin/Test/Consensus/Node.hs
@@ -19,6 +19,7 @@ import           Oscoin.Node.Mempool.Class (MonadMempool(..))
 import qualified Oscoin.Node.Mempool.Internal as Mempool
 import qualified Oscoin.State.Tree as STree
 
+import           Codec.Serialise (Serialise)
 import           Control.Monad.State.Strict
 import           Data.Binary (Binary)
 import qualified Data.Hashable as Hashable
@@ -27,7 +28,7 @@ import           Lens.Micro
 import           Test.QuickCheck
 
 newtype DummyTx = DummyTx Word8
-    deriving (Eq, Ord, Hashable.Hashable, Hashable, Binary)
+    deriving (Eq, Ord, Hashable.Hashable, Hashable, Binary, Serialise)
 
 instance Show DummyTx where
     show (DummyTx x) = show x

--- a/test/Oscoin/Test/Crypto/BlockStore/Arbitrary.hs
+++ b/test/Oscoin/Test/Crypto/BlockStore/Arbitrary.hs
@@ -7,10 +7,10 @@ import Oscoin.Prelude
 import Oscoin.Test.Crypto.Blockchain.Arbitrary
 import Oscoin.Consensus.BlockStore
 
-import Data.Binary (Binary)
+import Codec.Serialise (Serialise)
 
 import Test.QuickCheck
 
-instance (Binary tx, Arbitrary tx, Default s) => Arbitrary (BlockStore tx s) where
+instance (Serialise tx, Arbitrary tx, Default s) => Arbitrary (BlockStore tx s) where
     arbitrary =
         genesisBlockStore <$> arbitraryGenesis


### PR DESCRIPTION
Move from 'Data.Binary' to 'Codec.Serialise' in some parts of the codebase. This backports changes from #114.

The rational behind this it to move everything to the more portable CBOR format so that we don’t lock ourselves into Haskell-specific serialization