### PR TITLE
'Program' holds 'Rad.Value' instead of 'ByteString'

### DIFF
--- a/src/Oscoin/Data/Tx.hs
+++ b/src/Oscoin/Data/Tx.hs
@@ -6,6 +6,7 @@ import           Oscoin.Crypto.PubKey
 import           Oscoin.Crypto.Hash
 import           Oscoin.Crypto.Blockchain.Block (BlockHash)
 import qualified Oscoin.Consensus.Evaluator.Radicle as Rad
+import qualified Radicle as Rad
 
 import           Codec.Serialise
 import           Data.Aeson
@@ -17,7 +18,7 @@ data Tx msg = Tx
     , txChainId :: Word16
     , txNonce   :: Word32
     , txContext :: BlockHash
-    } deriving (Show, Eq, Ord, Generic)
+    } deriving (Show, Eq, Ord, Generic, Functor)
 
 instance Binary msg => Binary (Tx msg)
 
@@ -54,10 +55,10 @@ mkTx sm p = Tx
     }
 
 -- | Convert a 'Tx' to a Radicle 'Program'.
-toProgram :: Tx ByteString -> Rad.Program
+toProgram :: Tx Rad.Value -> Rad.Program
 toProgram Tx{..} =
     Rad.Program
-        { Rad.progSource  = unsign txMessage
+        { Rad.progValue   = unsign txMessage
         , Rad.progAuthor  = txPubKey
         , Rad.progChainId = txChainId
         , Rad.progNonce   = txNonce

--- a/src/Oscoin/Node.hs
+++ b/src/Oscoin/Node.hs
@@ -46,6 +46,7 @@ import           Codec.Serialise
 import           Control.Exception.Safe (bracket)
 import           Control.Monad.IO.Class (MonadIO(..))
 import           Data.Aeson (ToJSON, toJSON, object, (.=))
+import qualified Data.ByteString.Lazy as LBS
 import qualified Network.Socket as NS
 
 -- | Node static config.
@@ -119,7 +120,7 @@ step = do
     Log.debugM ("State: " % Log.shown) st
 
 nodeEval :: Tx ByteString -> Eval.Env -> Maybe ((), Eval.Env)
-nodeEval tx st = Eval.radicleEval (toProgram tx) st
+nodeEval tx st = Eval.radicleEval (toProgram $ deserialise . LBS.fromStrict <$> tx) st
 
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
* `Program` has better type information
* Avoids unncecessary (de)serialisation
* Step towards using `Tx Rad.Value` in more places

This is picked from #114 