### PR TITLE
Add 'Oscoin.API.Client' type class

### DIFF
--- a/src/Oscoin/API/Client.hs
+++ b/src/Oscoin/API/Client.hs
@@ -1,0 +1,19 @@
+module Oscoin.API.Client
+    ( MonadClient(..)
+    ) where
+
+import           Oscoin.Prelude
+import           Oscoin.API.Types
+import           Oscoin.Crypto.Hash (Hashed)
+import qualified Radicle as Rad
+
+class Monad m => MonadClient m where
+    submitTransaction :: ApiTx -> m (Result (Receipt ApiTx))
+
+    -- | Returns an error result if a transaction with the given hash
+    -- was not found.
+    getTransaction :: Hashed ApiTx -> m (Result ApiTx)
+
+    -- | Returns an error result if a value with the given key was not
+    -- found.
+    getState :: Key -> m (Result Rad.Value)

--- a/src/Oscoin/API/HTTP.hs
+++ b/src/Oscoin/API/HTTP.hs
@@ -7,6 +7,7 @@ module Oscoin.API.HTTP
 
 import           Oscoin.Prelude
 
+import           Oscoin.API.Types (ApiTx)
 import qualified Oscoin.Consensus.Evaluator.Radicle as Rad
 import           Oscoin.Environment
 
@@ -40,4 +41,3 @@ api env = do
     -- /state/:key -------------------------------------------------------
 
     get ("state" <//> wildcard) Handlers.getStatePath
-

--- a/src/Oscoin/API/HTTP/Handlers.hs
+++ b/src/Oscoin/API/HTTP/Handlers.hs
@@ -5,7 +5,7 @@ import           Oscoin.Prelude
 import           Oscoin.Crypto.Hash (Hashed, hash)
 import           Oscoin.Data.Query
 import           Oscoin.API.HTTP.Internal
-import qualified Oscoin.API.HTTP.Result as Result
+import           Oscoin.API.Types
 import qualified Oscoin.Node as Node
 import           Oscoin.Node.Mempool.Class (lookupTx, addTxs)
 import           Oscoin.State.Tree (Key, keyToPath)
@@ -19,13 +19,13 @@ root = respond ok200 noBody
 getAllTransactions :: ApiAction s i ()
 getAllTransactions = do
     mp <- node Node.getMempool
-    respond ok200 $ body (Result.ok mp)
+    respond ok200 $ body (Ok mp)
 
 getTransaction :: Hashed ApiTx -> ApiAction s i ()
 getTransaction txId = do
     mtx <- node (lookupTx txId)
     case mtx of
-        Just tx -> respond ok200 $ body (Result.ok tx)
+        Just tx -> respond ok200 $ body (Ok tx)
         Nothing -> respond notFound404 noBody
 
 submitTransaction :: ApiAction s i a
@@ -36,7 +36,7 @@ submitTransaction = do
         addTxs [tx]
         pure $ Node.Receipt (hash tx)
 
-    respond accepted202 $ body (Result.ok receipt)
+    respond accepted202 $ body (Ok receipt)
 
 getStatePath
     :: (Serialise (QueryVal s), Query s)
@@ -45,7 +45,7 @@ getStatePath k = do
     result <- node $ Node.getPath (keyToPath k)
     case result of
         Just val ->
-            respondBytes ok200 CBOR (serialise $ Result.ok val)
+            respondBytes ok200 CBOR (serialise $ Ok val)
         Nothing ->
             respond notFound404 noBody
 

--- a/src/Oscoin/API/HTTP/Internal.hs
+++ b/src/Oscoin/API/HTTP/Internal.hs
@@ -4,9 +4,7 @@ import           Oscoin.Prelude
 
 import           Oscoin.Environment
 import qualified Oscoin.Node as Node
-import           Oscoin.Data.Tx (Tx)
-
-import qualified Radicle as Rad
+import           Oscoin.API.Types
 
 import           Codec.Serialise (Serialise)
 import qualified Codec.Serialise as Serialise
@@ -35,9 +33,6 @@ data State = State ()
 
 -- | The type of all actions (effects) in our HTTP handlers.
 type ApiAction s i = SpockAction (Node.Handle ApiTx s i) () State
-
--- | The type of a block transaction in the API.
-type ApiTx = Tx Rad.Value
 
 instance MonadFail (ApiAction s i) where
     fail = error "failing!"

--- a/src/Oscoin/API/HTTP/Response.hs
+++ b/src/Oscoin/API/HTTP/Response.hs
@@ -2,7 +2,7 @@ module Oscoin.API.HTTP.Response where
 
 import           Oscoin.Prelude
 
-import           Oscoin.API.HTTP.Internal (ApiTx)
+import           Oscoin.API.Types (ApiTx)
 import           Oscoin.Crypto.Hash (Hashed)
 import           Oscoin.Crypto.Blockchain.Block (BlockHash)
 

--- a/src/Oscoin/API/Types.hs
+++ b/src/Oscoin/API/Types.hs
@@ -1,9 +1,25 @@
-module Oscoin.API.HTTP.Result where
+module Oscoin.API.Types
+    ( ApiTx
+    , Result(..)
+    , isOk
+    , isErr
+    , Receipt
+    , Key
+    , Query(..)
+    ) where
 
 import           Oscoin.Prelude
+import           Oscoin.Data.Query (Query(..))
+import           Oscoin.Data.Tx (Tx)
+import           Oscoin.Node (Receipt)
+import           Oscoin.State.Tree (Key)
+import qualified Radicle as Rad
 
 import qualified Data.Aeson as Aeson
 import qualified Codec.Serialise as Serial
+
+-- | The type of a block transaction in the API.
+type ApiTx = Tx Rad.Value
 
 data Result a =
       Ok  a
@@ -13,12 +29,6 @@ data Result a =
 instance Aeson.ToJSON a => Aeson.ToJSON (Result a)
 instance Aeson.FromJSON a => Aeson.FromJSON (Result a)
 instance Serial.Serialise a => Serial.Serialise (Result a)
-
-ok :: a -> Result a
-ok = Ok
-
-err :: Text -> Result b
-err = Err
 
 isOk :: Result a -> Bool
 isOk (Ok _) = True

--- a/src/Oscoin/CLI/Backend/HTTP.hs
+++ b/src/Oscoin/CLI/Backend/HTTP.hs
@@ -10,8 +10,8 @@ import           Oscoin.CLI.Radicle
 
 import           Oscoin.Data.Tx
 import qualified Oscoin.Node as Node
-import qualified Oscoin.API.HTTP.Result as API
-import           Oscoin.API.HTTP (ApiTx)
+import qualified Oscoin.API.Types as API
+import           Oscoin.API.Types (ApiTx)
 import           Oscoin.Crypto.PubKey
 import           Oscoin.Crypto.Hash (hash)
 

--- a/test/Oscoin/Test/API.hs
+++ b/test/Oscoin/Test/API.hs
@@ -9,7 +9,7 @@ import qualified Oscoin.Logging as Log
 import           Oscoin.Environment (Environment(Testing))
 import           Oscoin.Data.Tx (mkTx)
 import           Oscoin.Test.HTTP.Helpers
-import qualified Oscoin.API.HTTP.Result as Result
+import qualified Oscoin.API.Types as API
 import           Oscoin.API.HTTP.Internal (ContentType(..))
 import           Oscoin.Test.Data.Rad.Arbitrary ( )
 
@@ -47,7 +47,7 @@ smokeTestOscoinAPI codec@(Codec content accept) = do
     -- The mempool is empty.
     get accept "/transactions" >>=
         assertStatus 200 <>
-        assertBody (Result.ok ([] @DummyTx))
+        assertBody (API.Ok ([] @DummyTx))
 
     -- Generate a dummy transaction
     (txHash, tx) <- io $ genDummyTx
@@ -55,16 +55,16 @@ smokeTestOscoinAPI codec@(Codec content accept) = do
     -- Submit the transaction to the mempool.
     request POST "/transactions" (codecHeaders codec) (encodeBody content tx) >>=
         assertStatus 202 <>
-        assertBody (Result.Ok Node.Receipt {fromReceipt = Crypto.hash tx})
+        assertBody (API.Ok Node.Receipt{fromReceipt = Crypto.hash tx})
 
     -- Get the mempool once again, make sure the transaction is in there.
     get accept "/transactions" >>=
         assertStatus 200 <>
-        assertBody (Result.Ok [tx])
+        assertBody (API.Ok [tx])
 
     get accept ("/transactions/" <> txHash) >>=
         assertStatus 200 <>
-        assertBody (Result.Ok tx)
+        assertBody (API.Ok tx)
 
 getTransaction404NotFound :: Codec -> Session ()
 getTransaction404NotFound (Codec _ accept) = do


### PR DESCRIPTION
Add a type class that defines the abstract interface of a client for a Oscoin node. We will follow this up with a concrete implementation of a client for the HTTP API.

This commit also moves all types used by the client into the `Oscoin.API.Types` module. These types are not specific to the implementation (i.e. HTTP). As part of this we removed the `ok` and `err` constructor aliases for API results. We now simply use the `Ok` and `Err` constructors.

I will follow up with a concrete HTTP client implementation in a future PR.