### PR TITLE
Basic CLI test setup

### DIFF
--- a/src/Oscoin/CLI/Command/Result.hs
+++ b/src/Oscoin/CLI/Command/Result.hs
@@ -10,7 +10,7 @@ data Result a =
     | ResultValue a
     | ResultValues [a]
     | ResultError Text
-    deriving (Show)
+    deriving (Show, Eq, Functor)
 
 printResult :: Show a => Result a -> IO ()
 printResult ResultOk          = putStrLn "<ok>"

--- a/test/Oscoin/Test/CLI.hs
+++ b/test/Oscoin/Test/CLI.hs
@@ -1,0 +1,57 @@
+module Oscoin.Test.CLI
+    ( tests
+    ) where
+
+import           Oscoin.Prelude
+
+import           Oscoin.API.Client
+import           Oscoin.API.Types hiding (Result)
+
+import           Oscoin.Node (Receipt(..))
+import           Oscoin.Crypto.Hash (hash)
+
+import           Oscoin.CLI
+import           Oscoin.CLI.Command.Result
+
+import           Control.Monad.State
+
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+
+tests :: [TestTree]
+tests =
+    [ testRevisionCreate
+    ]
+
+newtype TestApiClient a = TestApiClient { runTestApiClient :: StateT TestApiClientState IO a }
+    deriving (Functor, Applicative, Monad, MonadIO, MonadState TestApiClientState)
+
+instance MonadClient TestApiClient where
+    submitTransaction tx = do
+        modify (\s -> s { submitTransactionCalls = tx : submitTransactionCalls s })
+        pure $ Ok $ Receipt $ hash tx
+
+    getTransaction _txHash =
+        pure $ Err "transaction not found"
+
+    getState _key =
+        pure $ Err "state not found"
+
+
+data TestApiClientState = TestApiClientState
+    { submitTransactionCalls :: [ RadTx ] }
+
+
+runCommandTest :: Command -> Options -> IO (Result Text, TestApiClientState)
+runCommandTest cmd opts =
+    runStateT (runTestApiClient $ runCommand cmd opts) (TestApiClientState [])
+
+assertResultValue :: (Show a) => Result a -> Assertion
+assertResultValue (ResultValue _) = pure ()
+assertResultValue result = assertFailure $ "Expected ResultValue, got " <> show result
+
+testRevisionCreate :: TestTree
+testRevisionCreate = testCase "revision create" $ do
+    (result, TestApiClientState{..}) <- runCommandTest RevisionCreate defaultOptions
+    assertResultValue result

--- a/test/Oscoin/Tests.hs
+++ b/test/Oscoin/Tests.hs
@@ -12,6 +12,7 @@ import qualified Oscoin.Crypto.PubKey as Crypto
 import qualified Oscoin.Node.Mempool as Mempool
 import qualified Oscoin.Node.Mempool.Event as Mempool
 
+import qualified Oscoin.Test.CLI as CLI
 import qualified Oscoin.Test.Consensus as Consensus
 import           Oscoin.Test.Crypto.Blockchain.Arbitrary (arbitraryGenesisWith, arbitraryValidBlockWith, arbitraryValidBlockchain)
 import           Oscoin.Test.Crypto.BlockStore.Arbitrary ()
@@ -36,6 +37,7 @@ import qualified Data.List.NonEmpty as NonEmpty
 tests :: TestTree
 tests = testGroup "Oscoin"
     [ testGroup      "API"                            API.tests
+    , testGroup      "CLI"                            CLI.tests
     , testCase       "Crypto"                         testOscoinCrypto
     , testCase       "Mempool"                        testOscoinMempool
     , testCase       "Blockchain"                     testOscoinBlockchain


### PR DESCRIPTION
We add one test case for the "revision create" command. We implement the test using a mock api client.