### PR TITLE
Provide default implementation for 'MonadClock' class

### DIFF
--- a/src/Oscoin/Clock.hs
+++ b/src/Oscoin/Clock.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DefaultSignatures #-}
+
 module Oscoin.Clock
     ( Tick
     , MonadClock (..)
@@ -12,6 +14,13 @@ type Tick = NominalDiffTime
 
 class Monad m => MonadClock m where
     currentTick :: m Tick
+
+    default currentTick
+        :: (MonadTrans t, m ~ t m', MonadClock m')
+        => m Tick
+    currentTick = lift currentTick
+    {-# INLINE currentTick #-}
+
 
 instance MonadClock IO where
     currentTick = getPOSIXTime

--- a/src/Oscoin/Consensus/Nakamoto.hs
+++ b/src/Oscoin/Consensus/Nakamoto.hs
@@ -91,18 +91,14 @@ newtype NakamotoT tx s m a = NakamotoT (RWST (NakamotoEnv tx s) () StdGen m a)
              , MonadReader (NakamotoEnv tx s)
              , MonadWriter ()
              , MonadState StdGen
+             , MonadTrans
              )
+
+instance (Monad m, MonadClock m) => MonadClock (NakamotoT tx s m)
 
 score :: Blockchain tx s -> Blockchain tx s -> Ordering
 score = comparing height
 
-instance MonadTrans (NakamotoT tx s) where
-    lift = NakamotoT . lift
-    {-# INLINE lift #-}
-
-instance MonadClock m => MonadClock (NakamotoT tx s m) where
-    currentTick = lift currentTick
-    {-# INLINE currentTick #-}
 
 instance ( MonadMempool    tx   m
          , MonadBlockStore tx s m

--- a/src/Oscoin/Node.hs
+++ b/src/Oscoin/Node.hs
@@ -152,6 +152,7 @@ newtype NodeT tx s i m a = NodeT (ReaderT (Handle tx s i) m a)
              , Monad
              , MonadReader (Handle tx s i)
              , MonadTrans
+             , MonadIO
              )
 
 runNodeT :: Handle tx s i -> NodeT tx s i m a -> m a
@@ -229,13 +230,7 @@ instance (Monad m, MonadIO m, Query s) => MonadQuery (NodeT tx s i m) where
         lift $ STree.getPath st k
     {-# INLINE queryM #-}
 
-instance MonadClock m => MonadClock (NodeT tx s i m) where
-    currentTick = lift currentTick
-    {-# INLINE currentTick #-}
-
-instance MonadIO m => MonadIO (NodeT tx s i m) where
-    liftIO = lift . liftIO
-    {-# INLINE liftIO #-}
+instance MonadClock m => MonadClock (NodeT tx s i m)
 
 instance MonadNetwork tx m => MonadNetwork tx (NodeT tx s i m)
 

--- a/src/Oscoin/P2P.hs
+++ b/src/Oscoin/P2P.hs
@@ -99,9 +99,7 @@ instance (Serialise tx, Show tx, MonadIO m) => MonadNetwork tx (NetworkT tx m) w
     sendM msgs = ask >>= io . (`send` msgs)
     recvM      = ask >>= io . receive
 
-instance MonadClock m => MonadClock (NetworkT tx m) where
-    currentTick = lift currentTick
-    {-# INLINE currentTick #-}
+instance MonadClock m => MonadClock (NetworkT tx m)
 
 runNetworkT :: Handle -> NetworkT tx m a -> m a
 runNetworkT h (NetworkT ma) = runReaderT ma h


### PR DESCRIPTION
We provide a default implementation for 'MonadClock' class. This allows us to omit method definitions when defining instances.

We also use newtype deriving for MonadIO for NodeT.