### PR TITLE
Use smaller 'haskell' docker image on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
     build:
         docker:
-            - image: fpco/stack-build:lts-11.5
+          - image: haskell:8.4.3
         steps:
             - checkout
             - restore_cache:

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,7 +14,7 @@ extra-deps:
 - cborg-0.2.0.0
 - half-0.2.2.3
 
-- git: git@github.com:cloudhead/wai
+- git: https://github.com/cloudhead/wai.git
   commit: a3464cc76198d51ae7cf838690eadeeefd627f9c
   subdirs:
     - wai-extra


### PR DESCRIPTION
We use the smaller 'haskell' docker image on CircleCI instead of the large stack one. This makes the build around three minutes faster.