### PR TITLE
Drop Binary instances and add JSON instances for PubKey

### DIFF
--- a/src/Codec/Serialise/JSON.hs
+++ b/src/Codec/Serialise/JSON.hs
@@ -1,0 +1,47 @@
+-- | This module exports functions that allow one to define generic
+-- `ToJSON` and `FromJSON` instances for values that are an instance of
+-- `Serialise`.
+--
+-- @
+--      data Foo
+--
+--      instance Serialise Foo
+--
+--      instance ToJSON where
+--          toJSON = serialiseToJSON
+--
+--      instance FromJSON where
+--          parseJSON = deserialiseParseJSON
+-- @
+--
+-- This generic JSON serialisation scheme is unstructured. The value is
+-- encoded into a CBOR bytestring which is encoded as base64 which can
+-- be represented as a JSON string.
+--
+-- When possible we should provide custom JSON instances that are
+-- easier to read and more structure.
+module Codec.Serialise.JSON
+    ( serialiseToJSON
+    , deserialiseParseJSON
+    ) where
+
+import           Oscoin.Prelude
+
+import           Codec.Serialise
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Types as Aeson
+import qualified Data.ByteString.Base64.Extended as Base64 hiding (decode)
+import qualified Data.ByteString.Lazy as LBS
+
+serialiseToJSON :: (Serialise a) => a -> Aeson.Value
+serialiseToJSON = Aeson.toJSON . Base64.encodeLazy . serialise
+
+deserialiseParseJSON :: (Serialise a) => Aeson.Value -> Aeson.Parser a
+deserialiseParseJSON val = do
+    base64 <- Aeson.parseJSON val
+    bs <- case Base64.decodeOrFail base64 of
+        Left err -> fail $ "Failed to decode base64 string: " <> err
+        Right a -> pure a
+    case deserialiseOrFail $ LBS.fromStrict bs of
+        Left err -> fail $ show err
+        Right a -> pure a

--- a/src/Data/ByteString/Base64/Extended.hs
+++ b/src/Data/ByteString/Base64/Extended.hs
@@ -4,6 +4,7 @@ module Data.ByteString.Base64.Extended
     , encodeLazy
     , encodeBinary
     , decode
+    , decodeOrFail
     , decodeLazy
     , fromText
     ) where
@@ -39,6 +40,9 @@ encodeBinary x = encodeLazy (Binary.encode x)
 
 decode :: Base64 a -> ByteString
 decode (Base64 bs) = Base64.decodeLenient bs
+
+decodeOrFail :: Base64 a -> Either String ByteString
+decodeOrFail (Base64 bs) = Base64.decode bs
 
 decodeLazy :: Base64 a -> LBS.ByteString
 decodeLazy (Base64 bs) = LBS.fromStrict $ Base64.decodeLenient bs

--- a/src/Oscoin/Data/Tx.hs
+++ b/src/Oscoin/Data/Tx.hs
@@ -11,7 +11,6 @@ import           Codec.Serialise
 import           Crypto.Random.Types (MonadRandom(..))
 import           Data.Aeson
 import qualified Data.ByteString.Lazy as LBS
-import           Data.Binary
 import           Data.Text.Prettyprint.Doc
 
 data Tx msg = Tx
@@ -21,8 +20,6 @@ data Tx msg = Tx
     , txNonce   :: Word32
     , txContext :: BlockHash
     } deriving (Show, Eq, Ord, Generic, Functor)
-
-instance Binary msg => Binary (Tx msg)
 
 instance Serialise msg => Hashable (Tx msg) where
     hash = hashSerial


### PR DESCRIPTION
This commit changes the following things

* We drop a couple of `Binary` instances. `Binary` is deprecated in favor of `Code.Serialise`
* We add the `Codec.Serialise.JSON` module. This module provides an easy way to create `ToJSON` and `FromJSON` instances for instances of `Serialise`.
* Use `Codec.Serialise.JSON` to create JSON instances for `PublicKey` and simplify the JSON instances for `signature`.