### PR TITLE
Use 'optparse-applicative' for 'oscoin-cli'

### DIFF
--- a/cli/Main.hs
+++ b/cli/Main.hs
@@ -2,54 +2,12 @@ module Main (main) where
 
 import           Oscoin.Prelude
 
-import           Oscoin.CLI (Command(..), runCommand, Options(..), defaultOptions)
+import           Oscoin.CLI
 import           Oscoin.CLI.Command.Result (printResult)
-
 import           Oscoin.API.HTTP.Client (runHttpClientT)
-
-import           System.Environment
-import           System.Console.GetOpt
-import           System.IO
-import           System.Exit
-
-options :: [OptDescr (Options -> Options)]
-options =
-    [ Option [] ["id"]
-        (OptArg (\o opts -> opts { optsRevisionId = readStr <$> o })   "<revision-id>")     "Revision ID"
-    ]
-
-readCommand :: IO (Command, Options)
-readCommand = do
-    a <- getArgs
-    case getOpt RequireOrder options a of
-        (_, [], []) ->
-            printUsage
-        (flags, [command], []) ->
-            pure (readStr command, foldr ($) defaultOptions flags)
-        (_, _, msgs) -> do
-            fatal ["oscoin-cli:", head msgs]
-            printUsage
-  where
-    printUsage = do
-        hPutStr stderr $ usageInfo (unlines
-            [ "usage: oscoin-cli <command> [<args>]"
-            , ""
-            , "Revisions CLI"
-            , ""
-            , "commands:"
-            , ""
-            , "    create \t Create a new revision"
-            , "    list   \t List known revisions"
-            , ""
-            , "args:"
-            ]) options
-        exitWith $ ExitFailure 1
-
-fatal :: [String] -> IO ()
-fatal = void . die . unwords
 
 main :: IO ()
 main = do
-    (!cmd, opts) <- readCommand
-    result <- runHttpClientT "http://127.0.0.1:8080" $ runCommand cmd opts
+    cmd <- execParser
+    result <- runHttpClientT "http://127.0.0.1:8080" $ runCommand cmd
     printResult result

--- a/package.yaml
+++ b/package.yaml
@@ -34,6 +34,7 @@ dependencies:
   - mtl
   - network
   - network-multicast
+  - optparse-applicative
   - primitive
   - prettyprinter
   - radicle

--- a/src/Oscoin/CLI.hs
+++ b/src/Oscoin/CLI.hs
@@ -2,9 +2,10 @@ module Oscoin.CLI
     ( module Oscoin.CLI.Revision
     , module Oscoin.CLI.User
     , module Oscoin.CLI.Command
+    , module Oscoin.CLI.Parser
     ) where
 
 import Oscoin.CLI.Command
 import Oscoin.CLI.Revision
 import Oscoin.CLI.User
-
+import Oscoin.CLI.Parser (execParser, execParserPure)

--- a/src/Oscoin/CLI/Command.hs
+++ b/src/Oscoin/CLI/Command.hs
@@ -1,9 +1,6 @@
 module Oscoin.CLI.Command
     ( Command(..)
     , runCommand
-
-    , Options(..)
-    , defaultOptions
     ) where
 
 import           Oscoin.Prelude
@@ -24,23 +21,9 @@ data Command =
     | RevisionStatus
     deriving (Show)
 
-instance Read Command where
-    readsPrec _ "create" = [(RevisionCreate, "")]
-    readsPrec _ "list"   = [(RevisionList, "")]
-    readsPrec _ "status" = [(RevisionStatus, "")]
-    readsPrec _ cmd      = error $ "Invalid command '" ++ cmd ++ "'"
 
-data Options = Options
-    { optsRevisionId :: Maybe RevisionId
-    } deriving (Show)
-
-defaultOptions :: Options
-defaultOptions = Options
-    { optsRevisionId = Nothing
-    }
-
-runCommand :: (MonadIO m, API.MonadClient m) => Command -> Options -> m (Result Text)
-runCommand RevisionCreate _opts = do
+runCommand :: (MonadIO m, API.MonadClient m) => Command -> m (Result Text)
+runCommand RevisionCreate = do
     tx <- io createTransaction
     result <- API.submitTransaction tx
     pure $ case result of
@@ -55,4 +38,5 @@ runCommand RevisionCreate _opts = do
         msg <- sign sk msgContent
         pure $ mkTx msg (hash pk)
 
-runCommand _ _ = notImplemented
+
+runCommand _ = notImplemented

--- a/src/Oscoin/CLI/Parser.hs
+++ b/src/Oscoin/CLI/Parser.hs
@@ -1,0 +1,34 @@
+module Oscoin.CLI.Parser
+    ( execParser
+    , execParserPure
+    ) where
+
+import           Oscoin.Prelude
+
+import           Oscoin.CLI.Command
+
+import           Options.Applicative hiding (execParser, execParserPure)
+import qualified Options.Applicative as Options
+
+
+execParser :: IO Command
+execParser = Options.execParser mainParserInfo
+
+execParserPure :: [String] -> ParserResult Command
+execParserPure = Options.execParserPure defaultPrefs mainParserInfo
+
+mainParserInfo :: ParserInfo Command
+mainParserInfo =
+    info (helper <*> mainParser)
+    $ progDesc "Revision CLI"
+
+mainParser :: Parser Command
+mainParser = subparser $ createRevision
+
+
+createRevision :: Mod CommandFields Command
+createRevision =
+    command "create"
+    (info (helper <*> parser) (progDesc "Create a new revision"))
+  where
+    parser = pure RevisionCreate


### PR DESCRIPTION
We use the `optparse-applicative` package to do command line parsing for `oscoin-cli`. We also test the command line arguments.