### PR TITLE
Use upstream version of 'wai-extra' instead of fork

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -14,11 +14,6 @@ extra-deps:
 - cborg-0.2.0.0
 - half-0.2.2.3
 
-- git: https://github.com/cloudhead/wai.git
-  commit: a3464cc76198d51ae7cf838690eadeeefd627f9c
-  subdirs:
-    - wai-extra
-
 - git: http://git.oscoin.io/radicle
   commit: 2b9ddab4963bf04f0148ff0974acdb5ebab5834f
 

--- a/test/Oscoin/Test/HTTP/Helpers.hs
+++ b/test/Oscoin/Test/HTTP/Helpers.hs
@@ -103,7 +103,15 @@ infix 1 @?=, @=?, @?
 
 
 assertStatus :: HasCallStack => HTTP.Status -> Wai.SResponse -> Wai.Session ()
-assertStatus status = Wai.assertStatus $ HTTP.statusCode status
+assertStatus expected response = io $ Tasty.assertBool msg (actual == expected)
+  where
+    actual = Wai.simpleStatus response
+    msg = concat
+        [ "Expected status code "
+        , show expected
+        , ", but received "
+        , show actual
+        ]
 
 -- | Assert that the response can be deserialised to @API.Ok actual@
 -- and @actual@ equals @expected@.


### PR DESCRIPTION
Our forked version of `wai-extra` only added [this commit][1] which added the `HasCallstack` constraint to assertions. The intention is that, if an assertion fails, the test runner prints the location in the test instead of the location of the assertion code.

However we currently do not use any of the assertion functions exposed by `Network.Wai.Test`. We use wrapped functions from `Oscoin.Test.HTTP.Helpers` that replicate the same behavior. This means there is no need to use the forked version of `wai-extra`.

[1]: https://github.com/cloudhead/wai/commit/a3464cc76198d51ae7cf838690eadeeefd627f9c