### PR TITLE
CLI uses keypair from file

### DIFF
--- a/cli/Main.hs
+++ b/cli/Main.hs
@@ -4,10 +4,9 @@ import           Oscoin.Prelude
 
 import           Oscoin.CLI
 import           Oscoin.CLI.Command.Result (printResult)
-import           Oscoin.API.HTTP.Client (runHttpClientT)
 
 main :: IO ()
 main = do
     cmd <- execParser
-    result <- runHttpClientT "http://127.0.0.1:8080" $ runCommand cmd
+    result <- runCommand cmd
     printResult result

--- a/package.yaml
+++ b/package.yaml
@@ -16,13 +16,16 @@ dependencies:
   - base64-bytestring
   - binary
   - bytestring
+  - cborg
   - conduit
   - containers
   - cryptonite
   - data-default
   - data-has
+  - directory
   - dlist
   - fast-logger
+  - filepath
   - focus
   - formatting
   - hashable

--- a/src/Oscoin/CLI.hs
+++ b/src/Oscoin/CLI.hs
@@ -3,9 +3,27 @@ module Oscoin.CLI
     , module Oscoin.CLI.User
     , module Oscoin.CLI.Command
     , module Oscoin.CLI.Parser
+    , CommandRunner
+    , runCommand
     ) where
 
-import Oscoin.CLI.Command
-import Oscoin.CLI.Revision
-import Oscoin.CLI.User
-import Oscoin.CLI.Parser (execParser, execParserPure)
+import           Oscoin.Prelude
+import qualified Oscoin.API.Client as API
+import           Oscoin.API.HTTP.Client (HttpClientT, runHttpClientT)
+import           Oscoin.CLI.Command
+import           Oscoin.CLI.Command.Result
+import           Oscoin.CLI.Revision
+import           Oscoin.CLI.User
+import           Oscoin.CLI.Parser (execParser, execParserPure)
+import           Oscoin.CLI.KeyStore
+
+type CommandRunner a = CommandRunnerT IO a
+
+runCommand :: Command -> IO (Result Text)
+runCommand cmd =
+    runHttpClientT "http://127.0.0.1:8080" $ runCommandRunnerT $ dispatchCommand cmd
+
+newtype CommandRunnerT m a = CommandRunnerT { runCommandRunnerT :: HttpClientT m a }
+    deriving (Functor, Applicative, Monad, MonadIO, MonadTrans, API.MonadClient)
+
+instance MonadKeyStore m => MonadKeyStore (CommandRunnerT m)

--- a/src/Oscoin/CLI/KeyStore.hs
+++ b/src/Oscoin/CLI/KeyStore.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE DefaultSignatures #-}
+-- | The 'MonadKeyStore' type class provides an interface to store and
+-- retrieve a key pair. The instance for IO which is used by the CLI
+-- uses the file system for persistence and stores the keys in
+-- @~/.config/oscoin/id.{key,pub}`@. We use 'getXdgDirectory' to
+-- deterimine the directory to store keys in.
+module Oscoin.CLI.KeyStore
+    ( MonadKeyStore(..)
+    ) where
+
+import           Oscoin.Prelude
+
+import qualified Oscoin.Crypto.PubKey as Crypto
+
+import           Codec.Serialise (serialise, deserialiseOrFail)
+import           Control.Exception.Safe
+import qualified Data.ByteString.Lazy as LBS
+import           System.Directory
+import           System.FilePath
+
+
+class Monad m => MonadKeyStore m where
+    writeKeyPair :: (Crypto.PublicKey, Crypto.PrivateKey) -> m ()
+
+    default writeKeyPair
+        :: (MonadKeyStore m', MonadTrans t, m ~ t m')
+        => (Crypto.PublicKey, Crypto.PrivateKey) -> m ()
+    writeKeyPair = lift . writeKeyPair
+
+    readKeyPair :: m (Crypto.PublicKey, Crypto.PrivateKey)
+    default readKeyPair
+        :: (MonadKeyStore m', MonadTrans t, m ~ t m')
+        => m (Crypto.PublicKey, Crypto.PrivateKey)
+    readKeyPair = lift readKeyPair
+
+
+getConfigPath :: MonadIO m => FilePath -> m FilePath
+getConfigPath path = io $ getXdgDirectory XdgConfig $ "oscoin" </> path
+
+ensureConfigDir :: MonadIO m => m ()
+ensureConfigDir = do
+    configDir <- getConfigPath ""
+    io $ createDirectoryIfMissing True configDir
+
+instance MonadKeyStore IO where
+    writeKeyPair (pk, sk) =  do
+        ensureConfigDir
+        skPath <- getConfigPath "id.key"
+        io $ LBS.writeFile skPath $ Crypto.serialisePrivateKey sk
+        pkPath <- getConfigPath "id.pub"
+        io $ LBS.writeFile pkPath (serialise pk)
+
+    readKeyPair = do
+        skPath <- getConfigPath "id.key"
+        sk <- fromRightThrow =<< Crypto.deserialisePrivateKey <$> LBS.readFile skPath
+        pkPath <- getConfigPath "id.pub"
+        pk <- fromRightThrow =<< deserialiseOrFail <$> LBS.readFile pkPath
+        pure (pk, sk)
+      where
+        fromRightThrow = either throwM pure

--- a/src/Oscoin/CLI/Parser.hs
+++ b/src/Oscoin/CLI/Parser.hs
@@ -23,7 +23,10 @@ mainParserInfo =
     $ progDesc "Revision CLI"
 
 mainParser :: Parser Command
-mainParser = subparser $ createRevision
+mainParser =
+    subparser
+     $ createRevision
+    <> generateKeyPair
 
 
 createRevision :: Mod CommandFields Command
@@ -32,3 +35,13 @@ createRevision =
     (info (helper <*> parser) (progDesc "Create a new revision"))
   where
     parser = pure RevisionCreate
+
+
+generateKeyPair :: Mod CommandFields Command
+generateKeyPair =
+    command "generate-keypair"
+    (info (helper <*> parser) $
+        progDesc "Generate keypair to use with the other commands"
+    )
+  where
+    parser = pure GenerateKeyPair

--- a/test/Oscoin/Test/CLI.hs
+++ b/test/Oscoin/Test/CLI.hs
@@ -4,17 +4,11 @@ module Oscoin.Test.CLI
 
 import           Oscoin.Prelude
 
-import           Oscoin.API.Client
-import           Oscoin.API.Types hiding (Result)
 import           Oscoin.CLI
-import           Oscoin.CLI.Command.Result
 import qualified Oscoin.CLI.Radicle as Rad
-import           Oscoin.Crypto.Hash (hash)
 import           Oscoin.Data.Tx (txMessageContent)
-import           Oscoin.Node (Receipt(..))
 
-import           Control.Monad.State
-import qualified Options.Applicative as Options
+import           Oscoin.Test.CLI.Helpers
 
 import           Test.Tasty
 import           Test.Tasty.HUnit
@@ -23,45 +17,20 @@ import           Test.Tasty.HUnit
 tests :: [TestTree]
 tests =
     [ testRevisionCreate
+    , testGenerateKeyPair
     ]
-
-newtype TestApiClient a = TestApiClient { runTestApiClient :: StateT TestApiClientState IO a }
-    deriving (Functor, Applicative, Monad, MonadIO, MonadState TestApiClientState)
-
-instance MonadClient TestApiClient where
-    submitTransaction tx = do
-        modify (\s -> s { submitTransactionCalls = tx : submitTransactionCalls s })
-        pure $ Ok $ Receipt $ hash tx
-
-    getTransaction _txHash =
-        pure $ Err "transaction not found"
-
-    getState _key =
-        pure $ Err "state not found"
-
-
-data TestApiClientState = TestApiClientState
-    { submitTransactionCalls :: [ RadTx ] }
-
-
-runTest :: [String] -> IO (Result Text, TestApiClientState)
-runTest args = do
-    cmd <- case execParserPure args of
-        Options.Success cmd -> pure $ cmd
-        Options.CompletionInvoked _ -> assertFailure "Unexpected CLI completion invoked"
-        Options.Failure failure ->
-            let failureMessage = fst $ Options.renderFailure failure ""
-            in assertFailure $ "Failed to parse CLI arguments: \n" <> failureMessage
-    runStateT (runTestApiClient $ runCommand cmd ) (TestApiClientState [])
-
-assertResultValue :: (Show a) => Result a -> Assertion
-assertResultValue (ResultValue _) = pure ()
-assertResultValue result = assertFailure $ "Expected ResultValue, got " <> show result
 
 testRevisionCreate :: TestTree
 testRevisionCreate = testCase "revision create" $ do
-    (result, TestApiClientState{..}) <- runTest ["create"]
-    let submittedMsg = txMessageContent $ head submitTransactionCalls
+    (result, TestCommandState{..}) <- runCLI ["create"]
+    let submittedMsg = txMessageContent $ head submittedTransactions
     let expectedMessage = Rad.fnApply "create-revision" [Rad.toRadicle emptyRevision]
     assertEqual "Expected message to be an empty revision" expectedMessage submittedMsg
     assertResultValue result
+
+testGenerateKeyPair :: TestTree
+testGenerateKeyPair = testCase "generate-keypair" $ do
+    let setNoKeyPair s = s { storedKeyPair = Nothing }
+    (result, TestCommandState{..}) <- runCLIWithState ["generate-keypair"] setNoKeyPair
+    assertBool "No keypair was stored" $ isJust storedKeyPair
+    assertResultOk result

--- a/test/Oscoin/Test/CLI/Helpers.hs
+++ b/test/Oscoin/Test/CLI/Helpers.hs
@@ -1,0 +1,99 @@
+-- | This module provides the 'runCLI' and 'runCLIWithState' functions
+-- to run the CLI in a test environment. The test environment is a
+-- state monad that mocks the API client and the Key Store.
+--
+-- The module also exports assertions to test CLI behavior.
+module Oscoin.Test.CLI.Helpers
+    (
+    -- * Run the CLI
+      runCLI
+    , runCLIWithState
+    , TestCommandState(..)
+
+    -- * Assertions
+    , assertResultOk
+    , assertResultValue
+    ) where
+
+import           Oscoin.Prelude
+
+import           Oscoin.API.Client
+import           Oscoin.API.Types hiding (Result)
+import           Oscoin.CLI
+import           Oscoin.CLI.KeyStore
+import           Oscoin.CLI.Command.Result
+import           Oscoin.Crypto.Hash (hash)
+import qualified Oscoin.Crypto.PubKey as Crypto
+import           Oscoin.Node (Receipt(..))
+
+import           Control.Monad.State
+import qualified Options.Applicative as Options
+
+import           Test.Tasty.HUnit
+
+
+-- | Run the CLI in a test environment and print the result and the
+-- final TestCommandState
+runCLI :: [String] -> IO (Result Text, TestCommandState)
+runCLI args = runCLIWithState args identity
+
+-- | Same as @runCLI@ but accepts an additional function that allows
+-- you to modify the initial state of the test environment before
+-- running the command.
+runCLIWithState
+    :: [String] -> (TestCommandState -> TestCommandState) -> IO (Result Text, TestCommandState)
+runCLIWithState args setupState = do
+    storedKeyPair <- Crypto.generateKeyPair
+    cmd <- case execParserPure args of
+        Options.Success cmd -> pure $ cmd
+        Options.CompletionInvoked _ -> assertFailure "Unexpected CLI completion invoked"
+        Options.Failure failure ->
+            let failureMessage = fst $ Options.renderFailure failure ""
+            in assertFailure $ "Failed to parse CLI arguments: \n" <> failureMessage
+    let initialState = TestCommandState { submittedTransactions = []
+                                        , storedKeyPair = Just storedKeyPair
+                                        }
+    runStateT
+        (modify setupState >> fromTestCommandRunner (dispatchCommand cmd))
+        initialState
+
+-- | Monad to run the CLI for testing purposes. It mocks both the API
+-- client and the Key Store by providing `MonadClient` and
+-- `MonadKeyStore` instances.
+newtype TestCommandRunner a = TestCommandRunner { fromTestCommandRunner :: StateT TestCommandState IO a }
+    deriving (Functor, Applicative, Monad, MonadIO, MonadState TestCommandState)
+
+
+data TestCommandState = TestCommandState
+    { submittedTransactions :: [ RadTx ]
+    , storedKeyPair :: Maybe (Crypto.PublicKey, Crypto.PrivateKey)
+    }
+
+instance MonadKeyStore TestCommandRunner where
+    writeKeyPair kp = modify (\s -> s { storedKeyPair = Just kp  })
+    readKeyPair = do
+        TestCommandState{..} <- get
+        case storedKeyPair of
+            Just kp -> pure $ kp
+            Nothing -> error "No keypair stored"
+
+instance MonadClient TestCommandRunner where
+    submitTransaction tx = do
+        modify (\s -> s { submittedTransactions = tx : submittedTransactions s })
+        pure $ Ok $ Receipt $ hash tx
+
+    getTransaction _txHash =
+        pure $ Err "transaction not found"
+
+    getState _key =
+        pure $ Err "state not found"
+
+----------------------------------------------------
+
+assertResultValue :: (Show a) => Result a -> Assertion
+assertResultValue (ResultValue _) = pure ()
+assertResultValue result = assertFailure $ "Expected ResultValue, got " <> show result
+
+assertResultOk :: (Show a) => Result a -> Assertion
+assertResultOk ResultOk = pure ()
+assertResultOk result = assertFailure $ "Expected ResultOk, got " <> show result


### PR DESCRIPTION
With this commit the CLI commands will be able to read the users keypair from disk. We also introduce a `generate-keypair` command that creates a new keypair and writes it to disk.

To implement this we chose to add another `MonadKeyStore` class and add it as a constraint to `runCommand`. This approach was chosen to facilitate testing: Almost all of the tests we will write for the CLI will not be concerned with key pairs. We just want to ensure that a key pair is avialable. To this end we provide a lightweight instance for `MonadKeyStore` that just reads a key pair from memory.

*I will add some documentation once the first round of reviews has passed*