### PR TITLE
Remove unused files from cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,9 @@ jobs:
             - checkout
             - restore_cache:
                 keys:
-                  - stack-work-v1-{{ checksum "stack.yaml" }}-{{ checksum "package.yaml" }}
+                  - stack-work-v2-{{ checksum "stack.yaml" }}-{{ checksum "package.yaml" }}
                   # If an exact match is unavailable, use the most recent one
-                  - stack-work-v1-
+                  - stack-work-v2-
                 paths:
                     - ~/.stack
             - run: stack install hlint
@@ -22,7 +22,11 @@ jobs:
             - run:
                 name: Test
                 command: stack test --no-terminal
+            - run:
+                name: Clean cache
+                # These files are large (~600MB) and are not needed
+                command: rm ~/.stack/indices/Hackage/00-index.tar* || true
             - save_cache:
-                key: stack-work-v1-{{ checksum "stack.yaml" }}-{{ checksum "package.yaml" }}
+                key: stack-work-v2-{{ checksum "stack.yaml" }}-{{ checksum "package.yaml" }}
                 paths:
                     - ~/.stack


### PR DESCRIPTION
We add a CI command that deletes unused large files from the folder that is used as a build cache.

We also update the cache version to rebuild it from scratch and not include unused data from previous caches.

All this results in a compressed cache size of 180MB instead of 1.2GB and improves CI times significantly.