### PR TITLE
Remove unused depedencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,9 @@ jobs:
             - checkout
             - restore_cache:
                 keys:
-                  - stack-work-v2-{{ checksum "stack.yaml" }}-{{ checksum "package.yaml" }}
+                  - stack-work-v3-{{ checksum "stack.yaml" }}-{{ checksum "package.yaml" }}
                   # If an exact match is unavailable, use the most recent one
-                  - stack-work-v2-
+                  - stack-work-v3-
                 paths:
                     - ~/.stack
             - run: stack install hlint
@@ -27,6 +27,6 @@ jobs:
                 # These files are large (~600MB) and are not needed
                 command: rm ~/.stack/indices/Hackage/00-index.tar* || true
             - save_cache:
-                key: stack-work-v2-{{ checksum "stack.yaml" }}-{{ checksum "package.yaml" }}
+                key: stack-work-v3-{{ checksum "stack.yaml" }}-{{ checksum "package.yaml" }}
                 paths:
                     - ~/.stack

--- a/package.yaml
+++ b/package.yaml
@@ -12,7 +12,6 @@ dependencies:
   - aeson
   - async
   - base16-bytestring
-  - base58-bytestring
   - base64-bytestring
   - binary
   - bytestring
@@ -42,12 +41,10 @@ dependencies:
   - network
   - network-multicast
   - optparse-applicative
-  - primitive
   - prettyprinter
   - radicle
   - random
   - random-shuffle
-  - recursion-schemes
   - safe-exceptions
   - scientific
   - serialise
@@ -64,7 +61,6 @@ dependencies:
   - unordered-containers
   - wai
   - wai-extra
-  - wai-middleware-static
   - writer-cps-mtl
   - yaml
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,7 +7,6 @@ extra-deps:
 - algebraic-graphs-0.1.1.1
 - cborg-0.2.0.0
 - merkle-tree-0.1.0
-- base58-bytestring-0.1.0
 - reroute-0.5.0.0
 - Spock-0.13.0.0
 - Spock-core-0.13.0.0


### PR DESCRIPTION
Remove dependencies that were not used. Also bump the cache version to avoid keeping the removed deps in the build cache.