### PR TITLE
Add 'runGossip' function

### DIFF
--- a/src/Oscoin/P2P/Gossip/IO.hs
+++ b/src/Oscoin/P2P/Gossip/IO.hs
@@ -43,6 +43,7 @@ import           Control.Monad.IO.Unlift
 import           Data.Conduit (runConduit, transPipe, (.|))
 import qualified Data.Conduit.Combinators as Conduit
 import           Data.Hashable
+import           Data.Void
 import           Formatting (mapf, (%))
 import           Lens.Micro (Lens', lens)
 import           Lens.Micro.Mtl (view)
@@ -200,7 +201,7 @@ listen
        )
     => Sock.HostName
     -> Sock.PortNumber
-    -> NetworkT r ()
+    -> NetworkT r Void
 listen host port = do
     addr <- io $ resolve host port
     E.bracket (io $ open addr) (io . Sock.close) accept


### PR DESCRIPTION
The new `runGossip` function is intended to be used by the node exe. To avoid `MonadUnliftIO` we sitch from `Gossip e a` as the argument to `Handle -> IO a` for `withGossip`