### PR TITLE
Start extracting common consensus code

### DIFF
--- a/src/Oscoin/Consensus/Nakamoto.hs
+++ b/src/Oscoin/Consensus/Nakamoto.hs
@@ -4,22 +4,18 @@
 module Oscoin.Consensus.Nakamoto
     ( NakamotoT
     , NakamotoEnv(..)
-
     , defaultNakamotoEnv
-
     , runNakamotoT
     , evalNakamotoT
-
     , epochLength
     , score
-
     , difficulty
     , minDifficulty
     , easyDifficulty
     , defaultGenesisDifficulty
     , chainDifficulty
-
     , mineBlock
+    , hasPoW
     ) where
 
 import           Oscoin.Prelude
@@ -28,8 +24,10 @@ import           Oscoin.Consensus.BlockStore.Class (MonadBlockStore)
 import qualified Oscoin.Consensus.BlockStore.Class as BlockStore
 import           Oscoin.Consensus.Class
 import           Oscoin.Consensus.Evaluator
+import           Oscoin.Consensus.Shared (mineBlock)
+import           Oscoin.Consensus.Types
 import           Oscoin.Crypto.Blockchain
-import           Oscoin.Crypto.Hash (Hashable, Hashed, hash, zeroHash)
+import           Oscoin.Crypto.Hash (Hashable, Hashed, hash)
 import qualified Oscoin.Logging as Log
 import           Oscoin.Node.Mempool.Class (MonadMempool(..))
 import qualified Oscoin.Node.Mempool.Class as Mempool
@@ -72,11 +70,24 @@ defaultNakamotoEnv :: NakamotoEnv tx s
 defaultNakamotoEnv = NakamotoEnv
     { nakEval = identityEval
     , nakDifficulty = easyDifficulty
-    , nakMiner = mineBlock
+    , nakMiner = mineBlockHeader
     , nakLogger = Log.noLogger
     }
 
-newtype NakamotoT tx s m a = NakamotoT (RWST (NakamotoEnv tx s) () StdGen m a)
+nakEnvToConsensus ::
+       Monad m => NakamotoEnv tx s -> Consensus tx s (NakamotoT tx s m)
+nakEnvToConsensus NakamotoEnv {..} =
+    Consensus
+    { cScore = comparing height
+    , cMiner =
+          \bh -> do
+              let bh' = bh { blockDifficulty = nakDifficulty }
+              stdGen <- state split
+              pure $ nakMiner stdGen bh'
+    }
+
+newtype NakamotoT tx s m a =
+    NakamotoT (RWST (NakamotoEnv tx s) () StdGen m a)
     deriving ( Functor
              , Applicative
              , Monad
@@ -91,7 +102,6 @@ instance (Monad m, MonadClock m) => MonadClock (NakamotoT tx s m)
 
 score :: Blockchain tx s -> Blockchain tx s -> Ordering
 score = comparing height
-
 
 instance ( MonadMempool    tx   m
          , MonadBlockStore tx s m
@@ -122,41 +132,10 @@ instance ( MonadMempool    tx   m
             pure . maybeToList . map (P2P.BlockMsg . void) $ mblk
 
     tickM t = do
-        NakamotoEnv{..} <- ask
-        txs             <- map snd <$> getTxs
-        parent          <- tip <$> BlockStore.maximumChainBy (comparing height)
-        let (results, newState) = applyValidExprs txs (blockState . blockHeader $ parent) nakEval
-            validTxs = map fst (rights results)
-            headerWithoutPoW = BlockHeader
-                { blockPrevHash     = blockHash parent
-                , blockDataHash     = hashTxs validTxs
-                , blockState        = newState
-                , blockStateHash    = zeroHash
-                , blockDifficulty   = nakDifficulty
-                , blockTimestamp    = fromIntegral $ fromEnum t
-                , blockNonce        = 0
-                }
-
-        minerStdGen <- state split
-        case nakMiner minerStdGen headerWithoutPoW of
-            Just header -> do
-                delTxs txs
-                let blk = mkBlock header txs
-                -- When mining a block, we've already computed the final state
-                -- of that block, but when storing a block received from the
-                -- network, we havent't, we just have `s -> Maybe s`.
-                --
-                -- It's nice to think of mined and network blocks uniformly,
-                -- so we have the same interface for both with 'BlockStore.storeBlock',
-                -- but as an optimization, with mined blocks we just have a
-                -- `(const . Just)` with the `s` we have already computed.
-                -- This way, the state is only computed once, even when the
-                -- BlockStore attempts to recompute it when linking the block
-                -- to its parent.
-                BlockStore.storeBlock $ map (\s -> \_ -> Just s) blk
-                pure [P2P.BlockMsg (void blk)]
-            Nothing ->
-                pure mempty
+        consensus' <- asks nakEnvToConsensus
+        eval <- asks nakEval
+        maybeBlk <- mineBlock consensus' eval t
+        pure $ P2P.BlockMsg . void <$> maybeToList maybeBlk
 
     {-# INLINE stepM #-}
     {-# INLINE tickM #-}
@@ -183,12 +162,12 @@ evalNakamotoT env rng (NakamotoT ma) = evalRWST ma env rng
 
 -- | Try different nonces until we find a block header that has a valid
 -- proof of work. See 'hasPow'
-mineBlock :: StdGen -> BlockHeader a -> Maybe (BlockHeader a)
-mineBlock stdGen bh@BlockHeader { blockNonce }
+mineBlockHeader :: StdGen -> BlockHeader a -> Maybe (BlockHeader a)
+mineBlockHeader stdGen bh@BlockHeader { blockNonce }
     | hasPoW bh =
         Just bh
     | blockNonce < maxBound =
-        mineBlock stdGen bh { blockNonce = blockNonce + 1 }
+        mineBlockHeader stdGen bh { blockNonce = blockNonce + 1 }
     | otherwise =
         Nothing
 
@@ -197,9 +176,7 @@ mineBlock stdGen bh@BlockHeader { blockNonce }
 -- such that the block header hash is smaller than its
 -- 'blockDifficulty'
 hasPoW :: BlockHeader s -> Bool
-hasPoW header =
-    difficulty header < blockDifficulty header
-
+hasPoW header = difficulty header < blockDifficulty header
 
 -- | Calculate block difficulty.
 difficulty :: BlockHeader s -> Difficulty

--- a/src/Oscoin/Consensus/Shared.hs
+++ b/src/Oscoin/Consensus/Shared.hs
@@ -1,0 +1,51 @@
+module Oscoin.Consensus.Shared
+    ( mineBlock
+    ) where
+
+import           Oscoin.Prelude
+
+import           Oscoin.Consensus.BlockStore.Class (MonadBlockStore)
+import qualified Oscoin.Consensus.BlockStore.Class as BlockStore
+import           Oscoin.Consensus.Evaluator (Evaluator, applyValidExprs)
+import           Oscoin.Consensus.Types
+
+import           Oscoin.Clock (Tick)
+import           Oscoin.Crypto.Blockchain hiding (lookupTx)
+import qualified Oscoin.Crypto.Hash as Crypto
+import           Oscoin.Node.Mempool.Class (MonadMempool)
+import qualified Oscoin.Node.Mempool.Class as Mempool
+
+import           Codec.Serialise (Serialise)
+
+-- | Mine a block with the given 'Consensus' on top of the best chain obtained from
+-- 'MonadBlockStore' using all transactions from 'MonadMempool'.
+mineBlock
+    :: ( MonadBlockStore tx s m
+       , MonadMempool    tx   m
+       , Serialise       tx
+       )
+    => Consensus tx s m
+    -> Evaluator s tx b
+    -> Tick
+    -> m (Maybe (Block tx s))
+mineBlock Consensus{..} eval tick = do
+    txs    <- (map . map) snd Mempool.getTxs
+    parent <- tip <$> BlockStore.maximumChainBy cScore
+    let (results, newState) = applyValidExprs txs (blockState . blockHeader $ parent) eval
+        validTxs = map fst (rights results)
+        headerCandidate = BlockHeader
+            { blockPrevHash     = blockHash parent
+            , blockDataHash     = hashTxs validTxs
+            , blockState        = newState
+            , blockStateHash    = Crypto.zeroHash
+            , blockDifficulty   = 0
+            , blockTimestamp    = fromIntegral $ fromEnum tick
+            , blockNonce        = 0
+            }
+
+    maybeBlockHeader <- cMiner headerCandidate
+    for maybeBlockHeader $ \header -> do
+        let blk = mkBlock header txs
+        Mempool.delTxs (blockData blk)
+        BlockStore.storeBlock $ map (const . Just) blk
+        pure blk

--- a/src/Oscoin/Consensus/Types.hs
+++ b/src/Oscoin/Consensus/Types.hs
@@ -1,0 +1,18 @@
+module Oscoin.Consensus.Types
+    ( Consensus(..)
+    , ChainScore
+    , Miner
+    ) where
+
+import           Oscoin.Prelude
+
+import           Oscoin.Crypto.Blockchain
+
+data Consensus tx s m = Consensus
+    { cScore :: ChainScore tx s
+    , cMiner :: Miner m
+    }
+
+type ChainScore tx s = Blockchain tx s -> Blockchain tx s -> Ordering
+
+type Miner m = forall a. BlockHeader a -> m (Maybe (BlockHeader a))


### PR DESCRIPTION
To integrate networking we will need to reorganize the `step` and `tick` functions. To this end we start extracting common code from the `tickM` and `stepM` for the two consesuses and create a new `Consensus` type.