### PR TITLE
CI: Fix cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,3 +1,4 @@
+timeout: 30m # Cache misses are slow to rebuild
 steps:
   - id: "Load cache"
     name: gcr.io/cloud-builders/gsutil
@@ -5,10 +6,8 @@ steps:
     args:
     - '-c'
     - |
-      cache="stack-$$(cat stack.yaml package.yaml | sha256sum | cut -d ' ' -f 1)".tar.gz
-      if gsutil -m cp "gs://oscoin-build-cache/$$cache" $$cache; then
-        tar xzf $$cache
-      fi
+      source scripts/ci.sh
+      load-cache
 
   - id: "Build deps"
     name: 'haskell:8.4.3'
@@ -42,8 +41,6 @@ steps:
     args:
     - '-c'
     - |
-      cache="stack-$$(cat stack.yaml package.yaml | sha256sum | cut -d ' ' -f 1)".tar.gz
-      gsutil ls "gs://oscoin-build-cache/$$cache" && echo "Cache is up to date" && exit 0
-      rm -rf .stack/indices/Hackage/00-index.tar*
-      tar czf $$cache .stack .stack-work
-      gsutil -m cp $$cache "gs://oscoin-build-cache/$$cache" || true
+      source scripts/ci.sh
+      save-cache
+

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -euo pipefail
+
+function load-cache() {
+    bucket="gs://oscoin-build-cache"
+    key="stack-work-$(cat stack.yaml | sha256sum | cut -d ' ' -f 1)".tar.gz
+    gsutil -m cp "$bucket/stack.tar.gz" "$bucket/$key" . || true
+    for f in stack.tar.gz $key; do
+      if [[ -e $f ]]; then
+        tar xzf $f
+      fi
+    done
+}
+
+function save-cache() {
+    bucket="gs://oscoin-build-cache"
+    key="stack-work-$(cat stack.yaml | sha256sum | cut -d ' ' -f 1)".tar.gz
+    if ! gsutil ls "$bucket/$key"; then
+      tar czf $key .stack-work
+      gsutil -m cp $key "$bucket/$key" || true
+    fi
+
+    rm -rf .stack/indices/Hackage/00-index.tar*
+    tar czf stack.tar.gz .stack
+    gsutil -m cp stack.tar.gz "$bucket/stack.tar.gz" || true
+}


### PR DESCRIPTION
1. Cache misses are expensive and slow to rebuild, so we need to raise the timeout.
2. We split the caching of `.stack` and `.stack-work`.
2. Github triggered builds are not executed with a git repo so we had to change how we detect misformatted files.
