### PR TITLE
Resolve radicle references when querying state

### DIFF
--- a/src/Oscoin/Crypto/Blockchain.hs
+++ b/src/Oscoin/Crypto/Blockchain.hs
@@ -5,6 +5,7 @@ module Oscoin.Crypto.Blockchain
     , (|>)
     , tip
     , genesis
+    , fromGenesis
     , blocks
     , takeBlocks
     , height
@@ -66,6 +67,9 @@ tip (Blockchain blks) = NonEmpty.head blks
 
 genesis :: Blockchain tx s -> Block tx s
 genesis = NonEmpty.last . fromBlockchain
+
+fromGenesis :: Block tx s -> Blockchain tx s
+fromGenesis g = Blockchain (g :| [])
 
 height :: Blockchain tx s -> Int
 height = length . fromBlockchain


### PR DESCRIPTION
When we query the blockchain state through the API we want to resolve references. This means if the queried value binds to a reference we get the value the Reference points to instead of the reference itself.

We also do some cleanup of the test helper functions to avoid code duplication.