### PR TITLE
Align 'stepM' code by eliminating msg complexity test

### DIFF
--- a/test/Oscoin/Test/Consensus/Class.hs
+++ b/test/Oscoin/Test/Consensus/Class.hs
@@ -8,8 +8,10 @@ module Oscoin.Test.Consensus.Class
 import           Oscoin.Prelude hiding (show)
 
 import           Oscoin.Clock (MonadClock(..), Tick)
+import           Oscoin.Consensus.BlockStore.Class (MonadBlockStore)
 import           Oscoin.Crypto.Blockchain (showBlockDigest)
 import           Oscoin.Crypto.Blockchain.Block (Block, BlockHash)
+import           Oscoin.Node.Mempool.Class (MonadMempool(..))
 
 import           Formatting (formatToString, (%))
 import qualified Formatting as F
@@ -26,8 +28,7 @@ instance Show tx => Show (Msg tx) where
     show (TxMsg     txs) = "TxMsg " ++ show txs
     show (ReqBlockMsg h) = "ReqBlockMsg " ++ show h
 
-class Monad m => MonadProtocol tx s m | m -> tx s where
-    stepM      :: Tick -> Msg tx -> m [Msg tx]
+class (MonadMempool tx m, MonadBlockStore tx s m) => MonadProtocol tx s m | m -> tx s where
     mineM      :: Tick -> m (Maybe (Block tx ()))
     reconcileM :: Tick -> m [BlockHash]
 

--- a/test/Oscoin/Test/Consensus/Nakamoto.hs
+++ b/test/Oscoin/Test/Consensus/Nakamoto.hs
@@ -17,17 +17,14 @@ module Oscoin.Test.Consensus.Nakamoto
 import           Oscoin.Prelude
 
 import           Oscoin.Consensus.BlockStore.Class (MonadBlockStore)
-import qualified Oscoin.Consensus.BlockStore.Class as BlockStore
 import           Oscoin.Consensus.Class (MonadUpdate)
 import           Oscoin.Consensus.Evaluator (Evaluator, identityEval)
 import           Oscoin.Consensus.Mining (mineBlock)
 import qualified Oscoin.Consensus.Nakamoto as Nakamoto
 import           Oscoin.Consensus.Types
 import           Oscoin.Crypto.Blockchain
-import           Oscoin.Crypto.Hash (Hashable)
 import qualified Oscoin.Logging as Log
 import           Oscoin.Node.Mempool.Class (MonadMempool(..))
-import qualified Oscoin.Storage as Storage
 
 import           Oscoin.Test.Consensus.Class
 
@@ -35,7 +32,6 @@ import           Codec.Serialise (Serialise)
 import           Control.Monad.RWS (RWST, evalRWST, runRWST, state)
 import           Control.Monad.Writer.CPS (MonadWriter)
 import           Data.Has (Has(..))
-import           Data.Maybe (maybeToList)
 import           System.Random (StdGen, split)
 
 type NakamotoEval tx s = Evaluator s tx ()
@@ -96,14 +92,9 @@ instance (Monad m, MonadClock m) => MonadClock (NakamotoT tx s m)
 
 instance ( MonadMempool    tx   m
          , MonadBlockStore tx s m
-         , Hashable        tx
          , Serialise       tx
          ) => MonadProtocol tx s (NakamotoT tx s m)
   where
-    stepM _ msg = do
-        eval <- asks nakEval
-        respond eval msg
-
     mineM t = do
         cons <- nakEnvToConsensus <$> ask
         eval <- asks nakEval
@@ -120,22 +111,3 @@ runNakamotoT env rng (NakamotoT ma) = runRWST ma env rng
 
 evalNakamotoT :: Monad m => NakamotoEnv tx s -> StdGen -> NakamotoT tx s m a -> m (a, ())
 evalNakamotoT env rng (NakamotoT ma) = evalRWST ma env rng
-
-respond
-    :: ( MonadBlockStore tx s m
-       , MonadMempool    tx   m
-       , Hashable tx
-       )
-    => Evaluator s tx ()
-    -> Msg tx
-    -> m [Msg tx]
-respond eval msg = go msg
-  where
-    go (TxMsg tx)     = resp <$> Storage.applyTx tx
-    go (BlockMsg blk) = resp <$> Storage.applyBlock eval blk
-    go (ReqBlockMsg blk) = do
-            mblk <- BlockStore.lookupBlock blk
-            pure . maybeToList . map (BlockMsg . void) $ mblk
-
-    resp Storage.Applied = [msg]
-    resp _               = []


### PR DESCRIPTION
The goal of this commit is to make the `stepM` method the same for both Nakamot and Simple consensus in the tests. There was a subtle difference in the previous implementation where the Simple consensus would not propagate messages. Changing this breaks the message complexity tests which we also remove since they provide no value.

This all allows us to unify the `stepM` code in `applyMessage` and eliminate `stepM` as a method. Note that we always use `identityEval` in `applyMessage`. Theoretically the Nakamot allows configuration of the evaluator, but this was not used and will be removed in the future.