### PR TITLE
Turn NakamotoT from RWST to StateT

### DIFF
--- a/test/Oscoin/Test/Consensus/Nakamoto.hs
+++ b/test/Oscoin/Test/Consensus/Nakamoto.hs
@@ -1,9 +1,6 @@
 module Oscoin.Test.Consensus.Nakamoto
     ( NakamotoT
-    , NakamotoEnv(..)
-    , defaultNakamotoEnv
     , runNakamotoT
-    , evalNakamotoT
 
     , Nakamoto.epochLength
     , Nakamoto.difficulty
@@ -18,72 +15,34 @@ import           Oscoin.Prelude
 
 import           Oscoin.Consensus.BlockStore.Class (MonadBlockStore)
 import           Oscoin.Consensus.Class (MonadUpdate)
-import           Oscoin.Consensus.Evaluator (Evaluator, identityEval)
+import           Oscoin.Consensus.Evaluator (identityEval)
 import           Oscoin.Consensus.Mining (mineBlock)
 import qualified Oscoin.Consensus.Nakamoto as Nakamoto
 import           Oscoin.Consensus.Types
 import           Oscoin.Crypto.Blockchain
-import qualified Oscoin.Logging as Log
 import           Oscoin.Node.Mempool.Class (MonadMempool(..))
 
 import           Oscoin.Test.Consensus.Class
 
 import           Codec.Serialise (Serialise)
-import           Control.Monad.RWS (RWST, evalRWST, runRWST, state)
-import           Control.Monad.Writer.CPS (MonadWriter)
-import           Data.Has (Has(..))
-import           System.Random (StdGen, split)
-
-type NakamotoEval tx s = Evaluator s tx ()
-
--- | A Nakamoto mining function. Tries all nonces and returns 'Nothing' if
--- no block satisfying the difficulty was found.
-type NakamotoMiner = forall tx s a.
-       StdGen
-    -> Blockchain tx s
-    -> BlockHeader a
-    -> Maybe (BlockHeader a)
-
--- | Read-only environment for the Nakamoto consensus protocol.
-data NakamotoEnv tx s = NakamotoEnv
-    { nakEval       :: NakamotoEval tx s
-    -- ^ Evaluation function to use for expressions
-    , nakDifficulty :: Difficulty
-    -- ^ Target difficulty (Nb. this is fixed for now and does not adjust)
-    , nakMiner      :: NakamotoMiner
-    -- ^ Mining function to use
-    , nakLogger     :: Log.Logger
-    }
-
-instance Has Log.Logger (NakamotoEnv tx s) where
-    getter = nakLogger
-    modifier f env = env {nakLogger = f (nakLogger env)}
-
-defaultNakamotoEnv :: NakamotoEnv tx s
-defaultNakamotoEnv = NakamotoEnv{..}
-  where
-    nakEval       = identityEval
-    nakDifficulty = Nakamoto.easyDifficulty
-    nakLogger     = Log.noLogger
-
-    nakMiner _gen chain hdr =
-        join $ Nakamoto.mineNakamoto (const nakDifficulty) chain hdr
+import           System.Random
 
 
-nakEnvToConsensus :: Monad m => NakamotoEnv tx s -> Consensus tx (NakamotoT tx s m)
-nakEnvToConsensus NakamotoEnv{..} = Consensus
+type NakamotoConsensus tx s m = Consensus tx (NakamotoT tx s m)
+
+nakConsensus :: Monad m => NakamotoConsensus tx s m
+nakConsensus = Consensus
     { cScore = comparing Nakamoto.chainScore
-    , cMiner = \chain hdr -> (\gen -> nakMiner gen chain hdr) <$> state split
+    , cMiner = \_chain hdr -> do gen <- state split
+                                 pure $ mineBlockRandom gen hdr
     }
 
 newtype NakamotoT tx s m a =
-    NakamotoT (RWST (NakamotoEnv tx s) () StdGen m a)
+    NakamotoT (StateT StdGen m a)
     deriving ( Functor
              , Applicative
              , Monad
              , MonadIO
-             , MonadReader (NakamotoEnv tx s)
-             , MonadWriter ()
              , MonadState StdGen
              , MonadTrans
              )
@@ -95,10 +54,7 @@ instance ( MonadMempool    tx   m
          , Serialise       tx
          ) => MonadProtocol tx s (NakamotoT tx s m)
   where
-    mineM t = do
-        cons <- nakEnvToConsensus <$> ask
-        eval <- asks nakEval
-        (map . map) void $ mineBlock cons eval t
+    mineM t = (map . map) void $ mineBlock nakConsensus identityEval t
 
     reconcileM = const $ pure mempty
 
@@ -106,8 +62,15 @@ instance MonadMempool     tx   m => MonadMempool     tx   (NakamotoT tx s m)
 instance MonadBlockStore  tx s m => MonadBlockStore  tx s (NakamotoT tx s m)
 instance MonadUpdate         s m => MonadUpdate         s (NakamotoT tx s m)
 
-runNakamotoT :: NakamotoEnv tx s -> StdGen -> NakamotoT tx s m a -> m (a, StdGen, ())
-runNakamotoT env rng (NakamotoT ma) = runRWST ma env rng
+runNakamotoT :: StdGen -> NakamotoT tx s m a -> m (a, StdGen)
+runNakamotoT rng (NakamotoT ma) = runStateT ma rng
 
-evalNakamotoT :: Monad m => NakamotoEnv tx s -> StdGen -> NakamotoT tx s m a -> m (a, ())
-evalNakamotoT env rng (NakamotoT ma) = evalRWST ma env rng
+-- | Mine a block header in 10% of the cases. The forged header does
+-- not have a valid proof of work.
+mineBlockRandom :: StdGen -> BlockHeader a -> Maybe (BlockHeader a)
+mineBlockRandom stdGen bh@BlockHeader{..} =
+    let r = fst $ randomR (0, 1) stdGen
+        p = 0.1 :: Float
+     in if r < p
+           then Just bh
+           else Nothing


### PR DESCRIPTION
We change the definition of `NakamotoT` from
```hs
newtype NakamotoT tx s m a = NakamotoT (RWST (NakamotoEnv tx s) () StdGen m a)
```
to
```hs
newtype NakamotoT tx s m a = NakamotoT (StateT StdGen m a)
```

`NakamotEnv` is eliminated because we always run `NakamotoT` with a fixed environment. This is now hardcoded as `nakConsensus`.