### PR TITLE
Eliminate similar methods of 'TestableNode' class

### DIFF
--- a/test/Oscoin/Test/Consensus/Node.hs
+++ b/test/Oscoin/Test/Consensus/Node.hs
@@ -5,6 +5,8 @@ module Oscoin.Test.Consensus.Node
 
     , TestNodeState(..)
     , TestNodeT
+    , HasTestNodeState(..)
+    , tnsBlockstoreL
     , emptyTestNodeState
     , runTestNodeT
     ) where
@@ -55,6 +57,9 @@ data TestNodeState = TestNodeState
     , tnsBlockstore :: BlockStore.BlockStore DummyTx ()
     , tnsNodeId     :: DummyNodeId
     } deriving (Show)
+
+class HasTestNodeState a where
+    testNodeStateL :: Lens' a TestNodeState
 
 tnsMempoolL :: Lens' TestNodeState (Mempool.Mempool DummyTx)
 tnsMempoolL = lens tnsMempool (\s a -> s { tnsMempool = a })


### PR DESCRIPTION
Some of the methods in `TestableNode` always had the same implemenation. To fix that we removed these methods and introduced a new `testableScore` method. The removed methods are now simply functions with the `TestableNode` constraint.