### PR TITLE
Rename API.Receipt to API.TxSubmitResponse

### DIFF
--- a/src/Oscoin/API/Client.hs
+++ b/src/Oscoin/API/Client.hs
@@ -8,7 +8,7 @@ import           Oscoin.Prelude
 import qualified Radicle as Rad
 
 class Monad m => MonadClient m where
-    submitTransaction :: RadTx -> m (Result (Receipt RadTx))
+    submitTransaction :: RadTx -> m (Result (TxSubmitResponse RadTx))
 
     -- | Returns an error result if a transaction with the given hash
     -- was not found.

--- a/src/Oscoin/API/HTTP/Handlers.hs
+++ b/src/Oscoin/API/HTTP/Handlers.hs
@@ -48,7 +48,7 @@ submitTransaction = do
     tx <- getVerifiedTxBody
     receipt <- node $ do
         Mempool.addTxs [tx]
-        pure $ Receipt (hash tx)
+        pure $ TxSubmitResponse (hash tx)
 
     respond accepted202 $ body (Ok receipt)
   where

--- a/src/Oscoin/API/Types.hs
+++ b/src/Oscoin/API/Types.hs
@@ -5,13 +5,13 @@ module Oscoin.API.Types
     , isOk
     , isErr
     , resultToEither
-    , Receipt(..)
+    , TxSubmitResponse(..)
     , Key
     , Query(..)
     ) where
 
 import           Oscoin.Crypto.Blockchain.Block (BlockHash)
-import           Oscoin.Crypto.Hash (Hashable, Hashed, toHex)
+import           Oscoin.Crypto.Hash (Hashable, Hashed)
 import           Oscoin.Data.Query (Query(..))
 import           Oscoin.Data.Tx (Tx)
 import           Oscoin.Prelude
@@ -72,15 +72,15 @@ instance FromJSON TxLookupResponse
 instance Serial.Serialise TxLookupResponse
 
 -- | A transaction receipt. Contains the hashed transaction.
-newtype Receipt tx = Receipt { fromReceipt :: Hashed tx }
+newtype TxSubmitResponse tx = TxSubmitResponse (Hashed tx)
     deriving (Show, Eq)
 
-deriving instance Serial.Serialise (Receipt tx)
+deriving instance Serial.Serialise (TxSubmitResponse tx)
 
-instance Hashable tx => ToJSON (Receipt tx) where
-    toJSON (Receipt tx) =
-        object [ "tx" .= decodeUtf8 (toHex tx) ]
+instance Hashable tx => ToJSON (TxSubmitResponse tx) where
+    toJSON (TxSubmitResponse tx) =
+        object [ "tx" .= toJSON tx ]
 
-instance Hashable tx => FromJSON (Receipt tx) where
-    parseJSON = withObject "Receipt" $ \o ->
-        Receipt <$> o .: "tx"
+instance Hashable tx => FromJSON (TxSubmitResponse tx) where
+    parseJSON = withObject "TxSubmitResponse" $ \o ->
+        TxSubmitResponse <$> o .: "tx"

--- a/src/Oscoin/CLI/Command.hs
+++ b/src/Oscoin/CLI/Command.hs
@@ -78,7 +78,7 @@ submitTransaction rval confirmations = do
     tx <- signTransaction rval
     API.submitTransaction tx >>= \case
         API.Err err -> pure $ ResultError err
-        API.Ok (API.Receipt txHash) -> waitConfirmations confirmations 500 txHash
+        API.Ok (API.TxSubmitResponse txHash) -> waitConfirmations confirmations 500 txHash
 
 signTransaction :: MonadCLI m => Rad.Value -> m API.RadTx
 signTransaction v = do

--- a/src/Oscoin/Crypto/Hash.hs
+++ b/src/Oscoin/Crypto/Hash.hs
@@ -117,7 +117,7 @@ instance Serialise (Digest HashAlgorithm) where
 
 instance ToJSON (Digest HashAlgorithm) where
     toJSON =
-        String . decodeUtf8 . toHex . LBS.toStrict . Binary.encode
+        String . toHexText . LBS.toStrict . Binary.encode
 
 instance FromJSON (Digest HashAlgorithm) where
     parseJSON = withText "Hash" $ \t ->

--- a/test/Oscoin/Test/API.hs
+++ b/test/Oscoin/Test/API.hs
@@ -95,7 +95,7 @@ smokeTestOscoinAPI codec = httpTest emptyNodeState $ do
     -- Submit the transaction to the mempool.
     post codec "/transactions" tx >>=
         assertStatus accepted202 <>
-        assertResultOK API.Receipt {fromReceipt = Crypto.hash tx}
+        assertResultOK (API.TxSubmitResponse $ Crypto.hash tx)
 
     -- Get the mempool once again, make sure the transaction is in there.
     get codec "/transactions" >>=

--- a/test/Oscoin/Test/CLI/Helpers.hs
+++ b/test/Oscoin/Test/CLI/Helpers.hs
@@ -102,7 +102,7 @@ instance MonadKeyStore TestCommandRunner where
 instance MonadClient TestCommandRunner where
     submitTransaction tx = do
         modify (\s -> s { transactions = Map.insert (hash tx) tx (transactions s) })
-        pure $ Ok $ Receipt $ hash tx
+        pure $ Ok $ TxSubmitResponse $ hash tx
 
     getTransaction _txHash = Map.lookup _txHash <$> gets transactions >>= \case
         Nothing -> pure $ Err "not found"


### PR DESCRIPTION
This makes the naming of API responses consistent and frees the name `Receipt` up for correct use later.

We also fix the `ToJSON` instance of `TxSubmitTransaction` making sure that it is inverse to the `FromJSON` instance.