### PR TITLE
Evaluator outputs radicle value

### DIFF
--- a/src/Oscoin/Consensus/Evaluator/Radicle.hs
+++ b/src/Oscoin/Consensus/Evaluator/Radicle.hs
@@ -64,11 +64,11 @@ fromSource name src = do
         }
 
 -- | A radicle evaluator.
-radicleEval :: Evaluator Env Program ()
+radicleEval :: Evaluator Env Program Rad.Value
 radicleEval Program{..} (Env st) =
     case runIdentity . Rad.runLang st $ Rad.eval progValue of
-        (Left err, _) -> Left [evalError (show err)]
-        (Right _, s)  -> Right ((), Env s)
+        (Left err, _)           -> Left [evalError (show err)]
+        (Right value, newState) -> Right (value, Env newState)
 
 lookupReference :: Rad.Reference -> Rad.Bindings m -> Maybe Rad.Value
 lookupReference (Rad.Reference r) Rad.Bindings{..} =

--- a/src/Oscoin/Crypto/Blockchain/Block.hs
+++ b/src/Oscoin/Crypto/Blockchain/Block.hs
@@ -187,7 +187,7 @@ mkBlock header txs =
 genesisBlock
     :: (Foldable t, Serialise tx)
     => s
-    -> Evaluator s tx ()
+    -> Evaluator s tx a
     -> Timestamp
     -> t tx
     -> Either [EvalError] (Block tx s)
@@ -219,7 +219,7 @@ isGenesisBlock :: Block tx s -> Bool
 isGenesisBlock blk =
     (blockPrevHash . blockHeader) blk == Crypto.toHashed Crypto.zeroHash
 
-toOrphan :: Evaluator s tx () -> Block tx s' -> Block tx (Orphan s)
+toOrphan :: Evaluator s tx a -> Block tx s' -> Block tx (Orphan s)
 toOrphan eval blk =
     blk $> \s -> rightToMaybe (evals (blockData blk) s eval)
 

--- a/src/Oscoin/Node.hs
+++ b/src/Oscoin/Node.hs
@@ -63,7 +63,7 @@ data Handle tx s i = Handle
     , hStateTree  :: STree.Handle s
     , hBlockStore :: BlockStore.Handle tx s
     , hMempool    :: Mempool.Handle tx
-    , hEval       :: Evaluator s tx ()
+    , hEval       :: Evaluator s tx Rad.Value
     , hConsensus  :: Consensus tx (NodeT tx s i IO)
     }
 
@@ -74,7 +74,7 @@ withNode
     -> Mempool.Handle tx
     -> STree.Handle s
     -> BlockStore.Handle tx s
-    -> Evaluator s tx ()
+    -> Evaluator s tx Rad.Value
     -> Consensus tx (NodeT tx s i IO)
     -> (Handle tx s i -> IO c)
     -> IO c
@@ -89,7 +89,7 @@ withNode hConfig hNodeId hMempool hStateTree hBlockStore hEval hConsensus =
 
     close = const $ pure ()
 
-defaultEval :: Tx Rad.Value -> Eval.Env -> Either [EvalError] ((), Eval.Env)
+defaultEval :: Tx Rad.Value -> Eval.Env -> Either [EvalError] (Rad.Value, Eval.Env)
 defaultEval tx st = Eval.radicleEval (toProgram tx) st
 
 -------------------------------------------------------------------------------

--- a/src/Oscoin/Storage.hs
+++ b/src/Oscoin/Storage.hs
@@ -54,7 +54,7 @@ applyBlock
     :: ( MonadBlockStore tx s m
        , MonadMempool    tx   m
        )
-    => Evaluator s tx ()
+    => Evaluator s tx a
     -> Block       tx ()
     -> m ApplyResult
 applyBlock eval blk = do


### PR DESCRIPTION
The radicle evaluator now output radicle values. This requires us to make some signatures that take an `Evaluator` more polymorphic.