### PR TITLE
Define 'Rad.txEval' and type aliases

### DIFF
--- a/node/Main.hs
+++ b/node/Main.hs
@@ -9,6 +9,7 @@ import           Oscoin.Clock
 import qualified Oscoin.Consensus as Consensus
 import           Oscoin.Consensus.BlockStore (genesisBlockStore)
 import           Oscoin.Consensus.Evaluator (fromEvalError)
+import qualified Oscoin.Consensus.Evaluator.Radicle as Rad
 import           Oscoin.Crypto.Blockchain (Difficulty)
 import           Oscoin.Crypto.Blockchain.Block (genesisBlock)
 import           Oscoin.Data.Tx (createTx)
@@ -24,11 +25,9 @@ import qualified Oscoin.P2P as P2P
 import           Oscoin.Storage (hoistStorage)
 import qualified Oscoin.Storage.Block as BlockStore
 
-import qualified Oscoin.Consensus.Evaluator.Radicle as Rad
 
 import qualified Control.Concurrent.Async as Async
 import           Control.Monad.Except (ExceptT(..), runExceptT, withExceptT)
-import           Data.Default (def)
 import qualified Data.Text as T
 import qualified Data.Yaml as Yaml
 import           GHC.Generics (Generic)
@@ -88,13 +87,12 @@ main = do
     Args{..} <- execParser args
 
     let consensus = Consensus.nakamotoConsensus difficulty
-    let eval      = Node.defaultEval
 
     keys     <- readKeyPair
     nid      <- pure (mkNodeId $ fst keys)
     mem      <- Mempool.newIO
-    stree    <- STree.new def
-    gen      <- either die pure =<< genesisFromPath eval prelude keys
+    stree    <- STree.new Rad.pureEnv
+    gen      <- either die pure =<< genesisFromPath prelude keys
     blkStore <- BlockStore.newIO $ genesisBlockStore gen
     seeds'   <- Yaml.decodeFileThrow seeds
 
@@ -104,7 +102,7 @@ main = do
                    mem
                    stree
                    blkStore
-                   eval
+                   Rad.txEval
                    consensus                                      $ \nod ->
         withAPI    Testing                                        $ \api ->
         withGossip lgr
@@ -124,11 +122,11 @@ main = do
         , Node.cfgLogger = lgr
         }
 
-    genesisFromPath eval path kp = runExceptT $ do
+    genesisFromPath path kp = runExceptT $ do
         val <- ExceptT $ Rad.parseValue (T.pack path) <$> readFile path
         withExceptT (T.unlines . map fromEvalError) . ExceptT $ do
             tx <- liftIO $ createTx kp val
-            pure $ genesisBlock def eval epoch [tx]
+            pure $ genesisBlock Rad.pureEnv Rad.txEval epoch [tx]
 
     miner nod gos = runGossipT gos . runNodeT nod $ Node.miner
     storage nod   = hoistStorage (runNodeT nod) Node.storage

--- a/src/Oscoin/Data/Tx.hs
+++ b/src/Oscoin/Data/Tx.hs
@@ -2,7 +2,6 @@ module Oscoin.Data.Tx where
 
 import           Oscoin.Prelude
 
-import qualified Oscoin.Consensus.Evaluator.Radicle as Rad
 import           Oscoin.Crypto.Blockchain.Block (BlockHash)
 import           Oscoin.Crypto.Hash (toHashed, zeroHash)
 import qualified Oscoin.Crypto.Hash as Crypto
@@ -62,16 +61,6 @@ mkTx sm pk = Tx
 
 txMessageContent :: Tx a -> a
 txMessageContent = sigMessage . txMessage
-
--- | Convert a 'Tx' to a Radicle 'Program'.
-toProgram :: Tx Rad.Value -> Rad.Program
-toProgram Tx{..} =
-    Rad.Program
-        { Rad.progValue   = unsign txMessage
-        , Rad.progAuthor  = Crypto.hash txPubKey
-        , Rad.progChainId = txChainId
-        , Rad.progNonce   = txNonce
-        }
 
 -- | Create a 'Tx' from a 'Serialise' message and key pair.
 createTx :: (Serialise msg, MonadRandom m) => (PublicKey, PrivateKey) -> msg -> m (Tx msg)

--- a/src/Oscoin/Node.hs
+++ b/src/Oscoin/Node.hs
@@ -4,7 +4,6 @@ module Oscoin.Node
     , NodeT
 
     , withNode
-    , defaultEval
 
     , runNodeT
 
@@ -25,13 +24,11 @@ import           Oscoin.Consensus.BlockStore.Class
                  (MonadBlockStore(..), chainState, maximumChainBy)
 import           Oscoin.Consensus.Class
                  (MonadClock(..), MonadQuery(..), MonadUpdate(..))
-import           Oscoin.Consensus.Evaluator (EvalError, Evaluator)
-import qualified Oscoin.Consensus.Evaluator.Radicle as Eval
+import           Oscoin.Consensus.Evaluator (Evaluator)
 import           Oscoin.Crypto.Blockchain (Blockchain, height)
 import           Oscoin.Crypto.Blockchain.Block (prettyBlock)
 import           Oscoin.Crypto.Hash (Hashable)
 import           Oscoin.Data.Query
-import           Oscoin.Data.Tx (Tx, toProgram)
 import           Oscoin.Environment
 import qualified Oscoin.Logging as Log
 import           Oscoin.Node.Mempool (Mempool)
@@ -88,9 +85,6 @@ withNode hConfig hNodeId hMempool hStateTree hBlockStore hEval hConsensus =
         pure Handle{..}
 
     close = const $ pure ()
-
-defaultEval :: Tx Rad.Value -> Eval.Env -> Either [EvalError] (Rad.Value, Eval.Env)
-defaultEval tx st = Eval.radicleEval (toProgram tx) st
 
 -------------------------------------------------------------------------------
 

--- a/test/Oscoin/Test/Data/Rad/Arbitrary.hs
+++ b/test/Oscoin/Test/Data/Rad/Arbitrary.hs
@@ -23,7 +23,7 @@ data Leniency = Lenient | Strict
     deriving (Eq, Show, Ord, Enum, Bounded)
 
 instance Arbitrary OscoinRad.Env where
-    arbitrary = pure $ OscoinRad.Env pureEnv
+    arbitrary = pure $ OscoinRad.pureEnv
 
 instance Arbitrary r => Arbitrary (Rad.Env r) where
     arbitrary = Rad.Env <$> arbitrary

--- a/test/Oscoin/Test/HTTP/Helpers.hs
+++ b/test/Oscoin/Test/HTTP/Helpers.hs
@@ -118,7 +118,7 @@ withNode NodeState{..} k = do
         mph
         sth
         bsh
-        Node.defaultEval
+        Rad.txEval
         (Consensus.nakamotoConsensus (Just Nakamoto.easyDifficulty))
         k
 


### PR DESCRIPTION
Consolidate code in the `Evaluator.Radicle` module and makes code in `node/Main` less generic.

Also removes unused `fromSource`.