### PR TITLE
Evaluator produces a single 'EvalError'

### DIFF
--- a/node/Main.hs
+++ b/node/Main.hs
@@ -146,6 +146,6 @@ initialBlockchain path keypair = runExceptT $ do
         buildBlockStrict Rad.txEval now' [tx] genesis
     pure $ block |> chain
   where
-    formatBuildError :: (Rad.RadTx, [EvalError]) -> Text
+    formatBuildError :: (Rad.RadTx, EvalError) -> Text
     formatBuildError (_tx, evalErrors) =
-        "Error applying initial transactions:\n" <> T.unlines (map fromEvalError evalErrors)
+        "Error applying initial transactions:\n" <> fromEvalError evalErrors

--- a/src/Oscoin/Consensus/Evaluator.hs
+++ b/src/Oscoin/Consensus/Evaluator.hs
@@ -12,7 +12,7 @@ import           Oscoin.Prelude
 newtype EvalError = EvalError { fromEvalError :: Text }
     deriving (Eq, Show, Read, Semigroup, Monoid, IsString)
 
-type EvalResult state output = Either [EvalError] (output, state)
+type EvalResult state output = Either EvalError (output, state)
 
 type Evaluator state tx output = tx -> state -> EvalResult state output
 

--- a/src/Oscoin/Consensus/Evaluator/Radicle.hs
+++ b/src/Oscoin/Consensus/Evaluator/Radicle.hs
@@ -75,7 +75,7 @@ txEval tx st = radicleEval (txToProgram tx) st
 radicleEval :: Evaluator Env Program Rad.Value
 radicleEval Program{..} (Env st) =
     case runIdentity . Rad.runLang st $ Rad.eval progValue of
-        (Left err, _)           -> Left [EvalError (show err)]
+        (Left err, _)           -> Left (EvalError (show err))
         (Right value, newState) -> Right (value, Env newState)
 
 

--- a/src/Oscoin/Crypto/Blockchain/Eval.hs
+++ b/src/Oscoin/Crypto/Blockchain/Eval.hs
@@ -18,12 +18,12 @@ import           Codec.Serialise (Serialise)
 -- part of a block.
 data Receipt tx o = Receipt
     { receiptTx       :: Crypto.Hashed tx
-    , receiptTxOutput :: Either [EvalError] o
+    , receiptTxOutput :: Either EvalError o
     , receiptTxBlock  :: BlockHash
     -- ^ Identifies the block the output was generated in
     } deriving (Show, Eq, Generic)
 
-mkReceipt :: (Crypto.Hashable tx) => Block tx s -> tx -> Either [EvalError] o -> Receipt tx o
+mkReceipt :: (Crypto.Hashable tx) => Block tx s -> tx -> Either EvalError o -> Receipt tx o
 mkReceipt block tx result = Receipt (Crypto.hash tx) result (blockHash block)
 
 
@@ -59,7 +59,7 @@ buildBlockStrict
     -> Timestamp
     -> [tx]
     -> Block tx s
-    -> Either (tx, [EvalError]) (Block tx s)
+    -> Either (tx, EvalError) (Block tx s)
 buildBlockStrict eval tick txs parent = do
     let initialState = blockState $ blockHeader parent
     newState <- foldlM step initialState txs
@@ -91,14 +91,14 @@ evalTraverse
     => Evaluator state tx output
     -> t tx
     -> state
-    -> (t (tx, Either [EvalError] output), state)
+    -> (t (tx, Either EvalError output), state)
 evalTraverse eval txs s = runState (traverse go txs) s
   where
     go tx = do
         result <- evalToState eval tx
         pure (tx, result)
 
-evalToState :: Evaluator state tx output -> tx -> State state (Either [EvalError] output)
+evalToState :: Evaluator state tx output -> tx -> State state (Either EvalError output)
 evalToState eval tx = state go
   where
     go st =

--- a/test/Oscoin/Test/Crypto/Blockchain.hs
+++ b/test/Oscoin/Test/Crypto/Blockchain.hs
@@ -41,7 +41,7 @@ testBuildBlock = testGroup "buildBlock"
     , testProperty "transactions errors recorded in receipts" $
         \txs err -> let (_, receipts) = buildTestBlock txsWithError
                         txsWithError = TxErr err : txs
-                    in (receiptTxOutput <$> head receipts) === Just (Left [EvalError (show err)])
+                    in (receiptTxOutput <$> head receipts) === Just (Left (EvalError (show err)))
     , testProperty "error transactions do not change block" $
         \txs -> let validTxs = [ TxOk out | TxOk out <- txs ]
                     (blkWithErrors, _) = buildTestBlock txs
@@ -82,7 +82,7 @@ instance Hashable Tx where
 
 eval :: Evaluator St Tx Output
 eval (TxOk output) st = Right (output, output : st)
-eval (TxErr err) _    = Left [EvalError (show err)]
+eval (TxErr err) _    = Left (EvalError (show err))
 
 
 -- | Build block on an empty genesis block with 'eval' as defined


### PR DESCRIPTION
There really is no need for evaluation errors to be a list at the moment. If we see the need later on we can change the internal representation of the `EvalError` newtype.