### PR TITLE
Mine quickly and only non-empty blocks

### DIFF
--- a/node/Main.hs
+++ b/node/Main.hs
@@ -8,6 +8,7 @@ import qualified Oscoin.Consensus as Consensus
 import qualified Oscoin.Consensus.BlockStore as BlockStore
 import           Oscoin.Consensus.Evaluator (EvalError, fromEvalError)
 import qualified Oscoin.Consensus.Evaluator.Radicle as Rad
+import qualified Oscoin.Consensus.Nakamoto as Nakamoto
 import           Oscoin.Crypto.Blockchain
                  (Blockchain, Difficulty, fromGenesis, (|>))
 import           Oscoin.Crypto.Blockchain.Block (emptyGenesisBlock)
@@ -91,7 +92,7 @@ main :: IO ()
 main = do
     Args{..} <- execParser args
 
-    let consensus = Consensus.nakamotoConsensus difficulty
+    let consensus = Consensus.nakamotoConsensus (Just Nakamoto.minDifficulty)
 
     keys     <- readKeyPair
     nid      <- pure (mkNodeId $ fst keys)


### PR DESCRIPTION
To improve the development experience of the node we reduce the time it takes to mine blocks and we stop mining empty blocks.