### PR TITLE
Test client uses code from real HTTP client

### DIFF
--- a/src/Oscoin/API/HTTP/Client.hs
+++ b/src/Oscoin/API/HTTP/Client.hs
@@ -1,15 +1,21 @@
-{-# LANGUAGE UndecidableInstances #-}
-
--- | Implementation of 'MonadClient' using the HTTP API.
--- @
---      foo :: MonadClient m => m a
+-- | Implementation of 'MonadClient' using the HTTP API and
+-- "Network.Http.Client".
 --
---      main = runHttpClient "http://localhost:8080" foo
 -- @
+-- foo :: 'MonadClient' m => m a
+-- main = 'runHttpClientT' "http://localhost:8080" foo
+-- @
+--
+-- 'runHttpClientT'' allows you to use a custom request function.
 module Oscoin.API.HTTP.Client
-    ( MonadClient(..)
+    ( runHttpClientT
     , HttpClientT
-    , runHttpClientT
+    , MonadClient(..)
+
+    -- * Custom HTTP client
+    , runHttpClientT'
+    , Request(..)
+    , Response(..)
     ) where
 
 import           Oscoin.Prelude hiding (get)
@@ -19,23 +25,33 @@ import           Oscoin.API.Types
 import           Oscoin.Crypto.Hash (fromHashed)
 
 import           Codec.Serialise
-import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Text as T
-import           Network.HTTP.Client hiding (Proxy)
+import qualified Network.HTTP.Client as Client
 import           Network.HTTP.Types.Header
 import           Network.HTTP.Types.Method
+import           Network.HTTP.Types.Status
 import           Web.HttpApiData (toUrlPiece)
 
 
-data HttpClient = HttpClient
-    { httpClientBaseRequest :: Request
-    , httpClientManager     :: Manager
+type Requester m = Request -> m Response
+
+data Request = Request
+    { requestMethod  :: Method
+    , requestPath    :: Text
+    , requestHeaders :: RequestHeaders
+    , requestBody    :: LByteString
     }
 
+data Response = Response
+    { responseBody   :: LByteString
+    , responseStatus :: Status
+    }
 
-newtype HttpClientT m a = HttpClientT (ReaderT HttpClient m a)
-    deriving (Functor, Applicative, Monad, MonadMask, MonadCatch, MonadThrow, MonadTrans, MonadIO)
+newtype HttpClientT m a = HttpClientT (ReaderT (Requester m) m a)
+    deriving (Functor, Applicative, Monad, MonadMask, MonadCatch, MonadThrow, MonadIO)
 
+instance MonadTrans HttpClientT where
+    lift ma = HttpClientT $ lift ma
 
 instance (Monad m, MonadIO m) => MonadClient (HttpClientT m) where
     submitTransaction tx =
@@ -47,49 +63,63 @@ instance (Monad m, MonadIO m) => MonadClient (HttpClientT m) where
     getState key =
         get $ "/state?q=[" <> T.intercalate "," key <> "]"
 
-type Uri = String
 
 -- | @runHttpClientT uri@ throws an exception if @uri@ is not a valid URI.
-runHttpClientT :: (MonadIO m) => Uri -> HttpClientT m a -> m a
+runHttpClientT :: (MonadIO m) => Text -> HttpClientT m a -> m a
 runHttpClientT uri (HttpClientT m) = do
-    client <- liftIO $ createHttpClient uri
+    client <- newHttpClient uri
     runReaderT m client
 
+runHttpClientT' :: (Request -> m Response) -> HttpClientT m a -> m a
+runHttpClientT' mkRequest (HttpClientT m) = runReaderT m mkRequest
 
-createHttpClient :: Uri -> IO HttpClient
-createHttpClient uri = do
-    manager <- newManager defaultManagerSettings
-    baseRequest <- parseRequest uri
-    pure HttpClient { httpClientBaseRequest = baseRequest
-                    , httpClientManager = manager
-                    }
+------------------------------------------------------------------------------
+
+newHttpClient :: (MonadIO m) => Text -> m (Requester m)
+newHttpClient uri = liftIO $ do
+    manager <- Client.newManager Client.defaultManagerSettings
+    baseRequest <- Client.parseRequest (toS uri)
+    pure $ liftIO . makeHttpRequest manager baseRequest
+
+makeHttpRequest :: Client.Manager -> Client.Request -> Request -> IO Response
+makeHttpRequest manager baseRequest Request{..} = do
+    let req = baseRequest
+            { Client.method = methodGet
+            , Client.path = encodeUtf8 requestPath
+            , Client.requestHeaders = requestHeaders
+            , Client.requestBody = Client.RequestBodyLBS $ requestBody
+            }
+    res <- Client.httpLbs req manager
+    pure $ Response
+        { responseStatus = Client.responseStatus res
+        , responseBody = Client.responseBody res
+        }
 
 
-makeRequest :: (MonadIO m, Serialise a) => (Request -> Request) -> HttpClientT m (Result a)
-makeRequest buildRequest = HttpClientT $ do
-    HttpClient{..} <- ask
-    let req = buildRequest httpClientBaseRequest
-    deserialiseResponse <$> liftIO (httpLbs req httpClientManager)
+makeRequest :: forall a m. (Serialise a, MonadIO m) => Request -> HttpClientT m (Result a)
+makeRequest req = HttpClientT $ do
+    mkRequest <- ask
+    Response{..} <- lift $ mkRequest req
+    pure $ case deserialiseOrFail $ responseBody of
+        Left _    -> Err "Failed to deserialise response"
+        Right val -> val
 
 get :: (MonadIO m, Serialise a) => Text -> HttpClientT m (Result a)
 get reqPath =
-    makeRequest $ \req ->
-        req { method = methodGet
-            , path = encodeUtf8 reqPath
+    makeRequest
+        Request
+            { requestMethod = methodGet
+            , requestPath = reqPath
             , requestHeaders = [(hAccept, "application/cbor")]
+            , requestBody = mempty
             }
 
 post :: (MonadIO m, Serialise a, Serialise b) => Text -> a ->  HttpClientT m (Result b)
 post reqPath reqBody =
-    makeRequest $ \req ->
-        req { method = methodPost
-            , path = encodeUtf8 reqPath
+    makeRequest
+        Request
+            { requestMethod = methodPost
+            , requestPath = reqPath
             , requestHeaders = [(hAccept, "application/cbor"), (hContentType, "application/cbor")]
-            , requestBody = RequestBodyLBS $ serialise reqBody
+            , requestBody = serialise reqBody
             }
-
-deserialiseResponse :: (Serialise a) => Response LBS.ByteString -> Result a
-deserialiseResponse response =
-    case deserialiseOrFail $ responseBody response of
-        Left _    -> Err "Failed to deserialise response"
-        Right val -> val

--- a/test/Oscoin/Test/API/HTTP/TestClient.hs
+++ b/test/Oscoin/Test/API/HTTP/TestClient.hs
@@ -17,54 +17,28 @@ module Oscoin.Test.API.HTTP.TestClient
 import           Oscoin.Prelude hiding (get)
 
 import           Oscoin.API.Client
-import           Oscoin.API.Types
-import           Oscoin.Crypto.Hash (fromHashed)
+import           Oscoin.API.HTTP.Client
 
-import           Codec.Serialise
-import qualified Data.Text as T
-import           Network.HTTP.Types.Header
-import           Network.HTTP.Types.Method
-import           Network.Wai
-import           Network.Wai.Test
-import           Web.HttpApiData (toUrlPiece)
+import qualified Network.Wai as Wai
+import qualified Network.Wai.Test as Wai
 
 
+type TestClient = HttpClientT Wai.Session
 
-newtype TestClient a = TestClient { run :: Session a }
-    deriving (Functor, Applicative, Monad, MonadIO)
+run :: TestClient a -> Wai.Session a
+run = runHttpClientT' makeWaiRequest
 
-instance MonadClient TestClient where
-    submitTransaction tx =
-        post "/transactions" tx
-
-    getTransaction txId =
-        get $ "/transactions/" <> toUrlPiece (fromHashed txId)
-
-    getState key =
-        get $ "/state?q=[" <> T.intercalate "," key <> "]"
-
-
-get :: (Serialise a) => Text -> TestClient (Result a)
-get reqPath = TestClient $ deserialiseResponse <$> request req
+makeWaiRequest :: Request -> Wai.Session Response
+makeWaiRequest Request{..} = fromSresp <$> Wai.srequest sreq
   where
-    req = flip setPath (encodeUtf8 reqPath) $ defaultRequest
-        { requestMethod = methodGet
-        , rawPathInfo = encodeUtf8 reqPath
-        , requestHeaders = [(hAccept, "application/cbor")]
+    sreq = Wai.SRequest req requestBody
+    req = Wai.defaultRequest
+        { Wai.requestMethod = requestMethod
+        , Wai.requestHeaders = requestHeaders
         }
-
-post :: (Serialise a, Serialise b) => Text -> a -> TestClient (Result b)
-post reqPath reqBody = TestClient $ deserialiseResponse <$> srequest sreq
-  where
-    sreq = SRequest req (serialise reqBody)
-    req = flip setPath (encodeUtf8 reqPath) $ defaultRequest
-        { requestMethod = methodPost
-        , rawPathInfo = encodeUtf8 reqPath
-        , requestHeaders = [(hAccept, "application/cbor"), (hContentType, "application/cbor")]
-        }
-
-deserialiseResponse :: (Serialise a) => SResponse -> Result a
-deserialiseResponse response =
-    case deserialiseOrFail $ simpleBody response of
-        Left _    -> Err $ "Failed to deserialise response: " <> show (simpleBody response)
-        Right val -> val
+        & flip Wai.setPath (encodeUtf8 requestPath)
+    fromSresp Wai.SResponse {..} =
+        Response
+            { responseStatus = simpleStatus
+            , responseBody = simpleBody
+            }


### PR DESCRIPTION
We generalize `HttpClientT` so that the test client can use most of its logic. This reduces the code duplication between the two clients.

Follo-up to #261