### PR TITLE
CI: Sanitize Docker tags with slashes

### DIFF
--- a/scripts/publish-image.sh
+++ b/scripts/publish-image.sh
@@ -14,8 +14,10 @@ COPY $bin /bin/$bin
 ENTRYPOINT ["/bin/$bin"]
 EOF
 
+branch_name_tag=$(echo "$BRANCH_NAME" | tr "/" "-")
+
 docker build --label "version=$COMMIT_SHA" \
-             --tag "$img:$BRANCH_NAME" \
+             --tag "$img:$branch_name_tag" \
              --tag "$img:$COMMIT_SHA" .
 
 if [[ "$BRANCH_NAME" == "master" ]]; then


### PR DESCRIPTION
With #260, we introduce publishing of Docker images in CI, but,
soon after merging it in, @geigerzaehler found out that branch names
with forward slashed were failing to build due to Docker tags not
supporting them.

This PR makes the branch name Docker tag be computed with slashed
replaced with dashes.