### PR TITLE
Provide transaction output in transaction lookup response

### DIFF
--- a/test/Oscoin/Test/API.hs
+++ b/test/Oscoin/Test/API.hs
@@ -63,13 +63,15 @@ tests =
             let expected = API.TxLookupResponse
                     { txHash = Crypto.hash tx
                     , txBlockHash = Nothing
+                    , txOutput = Nothing
                     , txConfirmations = 0
                     , txPayload = tx
                     }
             response @?= API.Ok expected
 
         , testCase "confirmed transaction" $ runEmptySession $ do
-            (txHash, tx) <- createValidTx (Rad.String "jo")
+            let radValue = Rad.String "jo"
+            (txHash, tx) <- createValidTx radValue
             Just blk <- liftNode $ do
                 Mempool.addTxs [tx]
                 blk <- Node.mineBlock
@@ -80,6 +82,7 @@ tests =
                     { txHash = Crypto.hash tx
                     , txBlockHash = Just (blockHash blk)
                     , txConfirmations = 6
+                    , txOutput = Just (Right radValue)
                     , txPayload = tx
                     }
             response @?= API.Ok expected

--- a/test/Oscoin/Test/API/HTTP.hs
+++ b/test/Oscoin/Test/API/HTTP.hs
@@ -97,6 +97,7 @@ unconfirmedTx :: API.RadTx -> API.TxLookupResponse
 unconfirmedTx tx = API.TxLookupResponse
     { txHash = Crypto.hash tx
     , txBlockHash = Nothing
+    , txOutput = Nothing
     , txConfirmations = 0
     , txPayload = tx
     }

--- a/test/Oscoin/Test/CLI/Helpers.hs
+++ b/test/Oscoin/Test/CLI/Helpers.hs
@@ -108,6 +108,7 @@ instance MonadClient TestCommandRunner where
         Just tx -> pure $ Ok TxLookupResponse
             { txHash = _txHash
             , txBlockHash = Nothing
+            , txOutput = Nothing
             , txConfirmations = 1
             , txPayload = tx
             }


### PR DESCRIPTION
`TxLookupResponse` returned from the `/transactions` endpoint now provides the transaction output if the transaction has been evaluated as part of a block.