### PR TITLE
Prelude: Export Protolude.Exceptions

### DIFF
--- a/src/Oscoin/Prelude.hs
+++ b/src/Oscoin/Prelude.hs
@@ -70,6 +70,7 @@ import           Protolude.Applicative as X
 import           Protolude.Bool as X
 import           Protolude.Conv as X
 import           Protolude.Either as X
+import           Protolude.Exceptions as X hiding (tryIO)
 import           Protolude.Functor as X
 import           Protolude.List as X
 import           Protolude.Monad as X


### PR DESCRIPTION
Seems like I forgot that. Exports the cutely named

```haskell
hush :: Alternative m => Either e a -> m a
```

and the quite handy

```haskell
note :: (MonadError e m) => e -> Maybe a -> m a
```

Note the hiding of `tryIO`: we already export

```haskell
tryIO :: MonadCatch m => m a -> m (Either IOException a) 
```

from `safe-exceptions`, vs.

```haskell
tryIO :: MonadIO m => IO a -> ExceptT IOException m a
```

which is a bit dubious.