### PR TITLE
CI: Always publish Haddocks

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -99,7 +99,7 @@ steps:
     - |
       set -euo pipefail
 
-      gsutil -m cp -r api-docs gs://oscoin-apidocs/${COMMIT_SHA}
+      gsutil -m rsync -d -r api-docs gs://oscoin-apidocs/${COMMIT_SHA}
 
   - id: "Save cache"
     name: gcr.io/cloud-builders/gsutil


### PR DESCRIPTION
A fast-forward merge will not trigger a new build, which may mean that the Haddocks for HEAD are not published.

This reverts commit bcd676f818b3d1de0a7608e4d5798a34c6765ce4.