### PR TITLE
Fixes #304 - Use a more robust way to load data/blockstore.sql

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -11,6 +11,7 @@ dependencies:
   - base >=4.11.1.0 && <4.12
 
 data-files:
+  - data/blockstore.sql
   - data/rad/prelude.rad
   - data/genesis.yaml
 

--- a/src/Oscoin/Storage/Block/SQLite.hs
+++ b/src/Oscoin/Storage/Block/SQLite.hs
@@ -31,6 +31,8 @@ import qualified Oscoin.Crypto.Hash as Crypto
 
 import           Oscoin.Storage.Block.SQLite.Internal
 
+import           Paths_oscoin
+
 import           Control.Concurrent.STM
 
 import           Database.SQLite.Simple ((:.)(..), Only(..))
@@ -70,7 +72,8 @@ withBlockStore path score = bracket (open path score) close
 -- multiple times.
 initialize :: (ToRow tx, ToField s) => Block tx s -> Handle tx s -> IO (Handle tx s)
 initialize gen h@Handle{hConn} =
-    readFile "data/blockstore.sql" >>=
+    getDataFileName "data/blockstore.sql" >>=
+        readFile >>=
         Sql3.exec (Sql.connectionHandle hConn) >>
             storeBlock' h gen >>
                 pure h


### PR DESCRIPTION
This commit switch to use `getDataFileName` as provided by Paths_oscoin,
thus making loading blockstore.sql more resilient.

This implies adding `data/blockstore.sql` to the `data-files`, otherwise this won't work (tried on my own skin as forgetting that line caused 10 tests to fail 😅 )

Fixes #304.