### PR TITLE
Rename blockDifficulty into blockTargetDifficulty.

### DIFF
--- a/src/Oscoin/Crypto/Blockchain/Block.hs
+++ b/src/Oscoin/Crypto/Blockchain/Block.hs
@@ -110,12 +110,12 @@ type Score = Integer
 
 -- | Block header.
 data BlockHeader s = BlockHeader
-    { blockPrevHash   :: Crypto.Hash
-    , blockDataHash   :: Crypto.Hash
-    , blockStateHash  :: Crypto.Hash
-    , blockTimestamp  :: Timestamp
-    , blockDifficulty :: TargetDifficulty
-    , blockSeal       :: s
+    { blockPrevHash         :: Crypto.Hash
+    , blockDataHash         :: Crypto.Hash
+    , blockStateHash        :: Crypto.Hash
+    , blockTimestamp        :: Timestamp
+    , blockTargetDifficulty :: Difficulty
+    , blockSeal             :: s
     } deriving (Show, Generic, Functor, Foldable, Traversable)
 
 deriving instance Ord s => Ord (BlockHeader s)
@@ -128,22 +128,22 @@ instance Serialise s => Crypto.Hashable (BlockHeader s) where
 
 instance ToJSON s => ToJSON (BlockHeader s) where
     toJSON BlockHeader{..} = object
-        [ "parentHash" .= blockPrevHash
-        , "timestamp"  .= blockTimestamp
-        , "dataHash"   .= blockDataHash
-        , "stateHash"  .= blockStateHash
-        , "seal"       .= blockSeal
-        , "difficulty" .= blockDifficulty
+        [ "parentHash"       .= blockPrevHash
+        , "timestamp"        .= blockTimestamp
+        , "dataHash"         .= blockDataHash
+        , "stateHash"        .= blockStateHash
+        , "seal"             .= blockSeal
+        , "targetDifficulty" .= blockTargetDifficulty
         ]
 
 instance FromJSON s => FromJSON (BlockHeader s) where
   parseJSON = withObject "BlockHeader" $ \o -> do
-        blockPrevHash   <- o .: "parentHash"
-        blockTimestamp  <- o .: "timestamp"
-        blockDataHash   <- o .: "dataHash"
-        blockStateHash  <- o .: "stateHash"
-        blockSeal       <- o .: "seal"
-        blockDifficulty <- o .: "difficulty"
+        blockPrevHash         <- o .: "parentHash"
+        blockTimestamp        <- o .: "timestamp"
+        blockDataHash         <- o .: "dataHash"
+        blockStateHash        <- o .: "stateHash"
+        blockSeal             <- o .: "seal"
+        blockTargetDifficulty <- o .: "targetDifficulty"
 
         pure BlockHeader{..}
 
@@ -155,7 +155,7 @@ emptyHeader = BlockHeader
     , blockStateHash = Crypto.zeroHash
     , blockSeal = ()
     , blockTimestamp = epoch
-    , blockDifficulty = 0
+    , blockTargetDifficulty = 0
     }
 
 headerHash :: Serialise s => BlockHeader s -> BlockHash
@@ -282,7 +282,7 @@ sealBlock seal blk =
     blk' = blk { blockHeader = (blockHeader blk) { blockSeal = seal } }
 
 blockScore :: Block tx s -> Integer
-blockScore = fromDifficulty . blockDifficulty . blockHeader
+blockScore = fromDifficulty . blockTargetDifficulty . blockHeader
 
 hashState :: Crypto.Hashable st => st -> StateHash
 hashState = Crypto.fromHashed . Crypto.hash

--- a/src/Oscoin/Crypto/Blockchain/Eval.hs
+++ b/src/Oscoin/Crypto/Blockchain/Eval.hs
@@ -181,11 +181,11 @@ mkUnsealedBlock parent blockTimestamp txs blockState = mkBlock header txs
   where
     header =
          BlockHeader
-            { blockPrevHash     = parent
-            , blockDataHash     = hashTxs txs
-            , blockStateHash    = Crypto.fromHashed (Crypto.hash blockState)
-            , blockSeal         = ()
-            , blockDifficulty   = 0
+            { blockPrevHash          = parent
+            , blockDataHash          = hashTxs txs
+            , blockStateHash         = Crypto.fromHashed (Crypto.hash blockState)
+            , blockSeal              = ()
+            , blockTargetDifficulty  = 0
             , blockTimestamp
             }
 

--- a/src/Oscoin/Storage/Block/SQLite/Internal.hs
+++ b/src/Oscoin/Storage/Block/SQLite/Internal.hs
@@ -174,7 +174,7 @@ storeBlock' Handle{..} blk@Block{blockHeader = BlockHeader{..}, blockData} = do
           , blockParent
           , blockDataHash
           , blockStateHash
-          , blockDifficulty
+          , blockTargetDifficulty
           , blockSeal
           , hScoreFn blk
           )

--- a/test/Oscoin/Test/Crypto/Blockchain/Arbitrary.hs
+++ b/test/Oscoin/Test/Crypto/Blockchain/Arbitrary.hs
@@ -75,12 +75,12 @@ arbitraryValidNakamotoBlock prefix@(parent:|_) | prevHeader <- blockHeader paren
     blockSeal  <- arbitrary
     blockDiffi <- pure $ Nakamoto.chainDifficulty (toList prefix)
     let header = emptyHeader
-               { blockPrevHash   = headerHash prevHeader
-               , blockDataHash   = hashTxs txs
-               , blockStateHash  = hashState blockState
+               { blockPrevHash         = headerHash prevHeader
+               , blockDataHash         = hashTxs txs
+               , blockStateHash        = hashState blockState
                , blockSeal
-               , blockTimestamp  = blockTimestamp prevHeader `timeAdd` elapsed
-               , blockDifficulty = blockDiffi
+               , blockTimestamp        = blockTimestamp prevHeader `timeAdd` elapsed
+               , blockTargetDifficulty = blockDiffi
                }
     pure $ mkBlock header txs
 
@@ -108,7 +108,7 @@ arbitraryBlockWith txs = do
                , blockStateHash  = stateHash
                , blockSeal
                , blockTimestamp  = timestamp
-               , blockDifficulty = diffi
+               , blockTargetDifficulty = diffi
                }
     pure $ mkBlock header txs
 
@@ -124,12 +124,12 @@ arbitraryValidBlockWith prevHeader txs = do
     blockSeal  <- arbitrary
     blockDiffi <- Difficulty <$> choose (1, 3)
     let header = emptyHeader
-               { blockPrevHash   = headerHash prevHeader
-               , blockDataHash   = hashTxs txs
-               , blockStateHash  = hashState blockState
+               { blockPrevHash         = headerHash prevHeader
+               , blockDataHash         = hashTxs txs
+               , blockStateHash        = hashState blockState
                , blockSeal
-               , blockTimestamp  = blockTimestamp prevHeader `timeAdd` elapsed
-               , blockDifficulty = blockDifficulty prevHeader + blockDiffi
+               , blockTimestamp        = blockTimestamp prevHeader `timeAdd` elapsed
+               , blockTargetDifficulty = blockTargetDifficulty prevHeader + blockDiffi
                }
     pure $ mkBlock header txs
 

--- a/test/Oscoin/Test/Storage/Block.hs
+++ b/test/Oscoin/Test/Storage/Block.hs
@@ -215,4 +215,4 @@ withDifficulty :: Serialise s => Difficulty -> Block tx s -> Block tx s
 withDifficulty d blk =
     blk { blockHeader = header, blockHash = headerHash header }
   where
-    header = (blockHeader blk) { blockDifficulty = d }
+    header = (blockHeader blk) { blockTargetDifficulty = d }


### PR DESCRIPTION
Fixes #332 .

This commit replaces all the occurrences of `blockDifficulty` in the codebase with `blockTargetDifficulty`, to better state the intent.