### PR TITLE
Allow the environment to be externally-configurable.

### DIFF
--- a/exe/cli/Main.hs
+++ b/exe/cli/Main.hs
@@ -6,8 +6,8 @@ import           Oscoin.CLI
 
 main :: IO ()
 main = do
-    (mbKeysPath, cmd) <- execParser
-    result <- runCommand mbKeysPath cmd
+    CLI{..} <- execParser
+    result <- runCommand cliKeyPath cliCommand
     case result of
         ResultOk      -> pure ()
         ResultError e -> die e

--- a/src/Oscoin/CLI.hs
+++ b/src/Oscoin/CLI.hs
@@ -3,6 +3,7 @@ module Oscoin.CLI
     , module Oscoin.CLI.User
     , module Oscoin.CLI.Command
     , module Oscoin.CLI.Parser
+    , CLI(..)
     , CommandRunner
     , runCommand
     ) where
@@ -11,7 +12,7 @@ import qualified Oscoin.API.Client as API
 import           Oscoin.API.HTTP.Client (HttpClientT, runHttpClientT)
 import           Oscoin.CLI.Command
 import           Oscoin.CLI.KeyStore
-import           Oscoin.CLI.Parser (execParser, execParserPure)
+import           Oscoin.CLI.Parser (CLI(..), execParser, execParserPure)
 import           Oscoin.CLI.Revision
 import qualified Oscoin.CLI.Spinner as Spinner
 import           Oscoin.CLI.User

--- a/src/Oscoin/Environment.hs
+++ b/src/Oscoin/Environment.hs
@@ -3,7 +3,7 @@ module Oscoin.Environment where
 import           Oscoin.Prelude
 
 data Environment = Production | Development | Testing
-    deriving (Show, Enum, Bounded)
+    deriving (Show, Eq, Enum, Bounded)
 
 -- | A list of all the possible environments.
 allEnvironments :: [Environment]
@@ -14,3 +14,10 @@ toText :: Environment -> Text
 toText Development = "development"
 toText Production  = "production"
 toText Testing     = "testing"
+
+-- | Constructs an 'Environment' from a 'Text'.
+fromText :: Text -> Maybe Environment
+fromText "development" = Just Development
+fromText "production"  = Just Production
+fromText "testing"     = Just Testing
+fromText _             = Nothing

--- a/src/Oscoin/Node.hs
+++ b/src/Oscoin/Node.hs
@@ -28,7 +28,8 @@ import           Oscoin.Crypto.Blockchain.Block
 import           Oscoin.Crypto.Blockchain.Eval (Evaluator)
 import           Oscoin.Crypto.Hash (Hashable, formatHash)
 import           Oscoin.Data.Query
-import           Oscoin.Logging ((%))
+import qualified Oscoin.Environment as Env
+import           Oscoin.Logging (stext, (%))
 import qualified Oscoin.Logging as Log
 import           Oscoin.Node.Mempool (Mempool)
 import qualified Oscoin.Node.Mempool as Mempool
@@ -69,6 +70,7 @@ withNode hConfig hNodeId hMempool hStateStore hBlockStore hEval hConsensus =
     open = do
         hReceiptStore <- ReceiptStore.newHandle
         gen <- runNodeT Handle{..} BlockStore.getGenesisBlock
+        Log.info (cfgLogger hConfig) ("running in " % stext % " mode") (Env.toText $ cfgEnv hConfig)
         Log.info (cfgLogger hConfig) ("genesis is " % formatHash) (blockHash gen)
         pure Handle{..}
 

--- a/test/Integration/Test/Executable.hs
+++ b/test/Integration/Test/Executable.hs
@@ -31,4 +31,4 @@ testStartsOK =
                 -- TODO(adn) In the future we want a better handshake string here.
                 actual <- C8.hGet stdoutHandle 100
                 assertBool ("oscoin started but gave unexpected output: " <> C8.unpack actual)
-                           ("genesis is" `C8.isInfixOf` actual)
+                           ("running in" `C8.isInfixOf` actual)

--- a/test/Oscoin/Test/CLI/Helpers.hs
+++ b/test/Oscoin/Test/CLI/Helpers.hs
@@ -56,8 +56,8 @@ runCLIWithState args setupState = do
     -- We don't seem to care about overriding the location of the keys for
     -- the 'TestCommandState', as the 'HOME' env var is overwritten with a
     -- throwaway temporary directory.
-    (_mbKeysPath, cmd) <- case execParserPure args of
-        Options.Success cmd -> pure $ cmd
+    cli <- case execParserPure args of
+        Options.Success cli -> pure cli
         Options.CompletionInvoked _ -> assertFailure "Unexpected CLI completion invoked"
         Options.Failure failure ->
             let failureMessage = fst $ Options.renderFailure failure ""
@@ -67,7 +67,7 @@ runCLIWithState args setupState = do
                                         , commandOutput = ""
                                         }
     (result, cliState) <- runStateT
-        (modify setupState >> fromTestCommandRunner (dispatchCommand cmd))
+        (modify setupState >> fromTestCommandRunner (dispatchCommand $ cliCommand cli))
         initialState
     assertResultOk result
     pure cliState

--- a/test/Oscoin/Test/Environment.hs
+++ b/test/Oscoin/Test/Environment.hs
@@ -1,0 +1,29 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Oscoin.Test.Environment
+    ( tests
+    ) where
+
+import           Oscoin.Prelude
+
+import           Oscoin.Environment
+
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+instance Arbitrary Environment where
+    arbitrary = arbitraryBoundedEnum
+
+
+tests :: [TestTree]
+tests =
+    [ testProperty "toText . fromText == id" roundtripProperty
+    ]
+
+-- We don't need the full 100 tests here, 10 is enough provided
+-- the underlying generator even distributes the test data (it does).
+roundtripProperty :: Environment -> Property
+roundtripProperty e = withMaxSuccess 10 $
+    classify (e == Testing) "Testing" $
+    classify (e == Development) "Development" $
+    classify (e == Production) "Production"  $
+        (fromText . toText $ e) === Just e

--- a/test/Oscoin/Tests.hs
+++ b/test/Oscoin/Tests.hs
@@ -27,6 +27,7 @@ import           Oscoin.Test.Crypto.Blockchain.Arbitrary
 import           Oscoin.Test.Crypto.PubKey.Arbitrary (arbitrarySigned)
 import           Oscoin.Test.Data.Rad.Arbitrary ()
 import           Oscoin.Test.Data.Tx.Arbitrary ()
+import qualified Oscoin.Test.Environment as Environment
 import qualified Oscoin.Test.P2P as P2P
 import qualified Oscoin.Test.Storage.Block as BlockStore
 import           Oscoin.Test.Storage.Block.Arbitrary ()
@@ -60,6 +61,7 @@ tests config = testGroup "Oscoin"
     , testGroup      "Storage"                        BlockStore.tests
     , testBlockchain config
     , testGroup      "Telemetry"                      Telemetry.tests
+    , testGroup      "Environment"                    Environment.tests
     ]
 
 testOscoinCrypto :: Assertion


### PR DESCRIPTION
Took a slight detour from the telemetry/logging stuff while I wait for consensus on #349 .

This PR allows the `Environment` to be configured via the CLI, as previously discussed with @cloudhead and @kim . I also took a little gamble and refactored the return type for `execParser` as I thought that in the future we would probably want to do different things according to different environments, so I also extended the `oscoin-cli` parser to deal with that (if that's a problem, I can revert that bit).