### PR TITLE
Fixed #346 (Improve the internal representation of an 'Histogram')

### DIFF
--- a/src/Oscoin/Telemetry/Metrics/Internal.hs
+++ b/src/Oscoin/Telemetry/Metrics/Internal.hs
@@ -62,21 +62,23 @@ data Gauge  = Gauge {
 -- | An histogram type modeled after Prometheus' one. It allows sampling the
 -- phi-percentile for a given  number of buckets.
 data Histogram = Histogram {
-    _histCount   :: !MonotonicCounter
-  , _histSum     :: !(TVar Double)
-  , _histBuckets :: !(TVar Buckets)
+    _histSum         :: !(TVar Double)
+  , _histCount       :: !MonotonicCounter
+  , _histBuckets     :: !(Map UpperInclusiveBound MonotonicCounter)
+  , _histUpperBounds :: !Buckets
   }
 
 -- | A \"snapshot\" of an 'Histogram' at a certain point in time.
 data HistogramSample = HistogramSample {
     hsCount   :: !Int64
   , hsSum     :: !Double
-  , hsBuckets :: !Buckets
+  , hsBuckets :: ![(UpperInclusiveBound, Int64)]
   } deriving (Show, Eq, Ord)
 
 type UpperInclusiveBound = Double
 
-newtype Buckets = Buckets (Map UpperInclusiveBound Double)
+-- A /sorted/ set of 'UpperInclusiveBound's.
+newtype Buckets = Buckets { fromBuckets :: Set UpperInclusiveBound }
     deriving (Show, Eq, Ord)
 
 -- | A set of 'Action's that a 'NotableEvent' might trigger.

--- a/src/Oscoin/Telemetry/Middleware.hs
+++ b/src/Oscoin/Telemetry/Middleware.hs
@@ -138,10 +138,11 @@ renderBuckets metric HistogramSample{..} =
     let userBuckets = foldl' f mempty sortedBuckets
     in userBuckets <> bprint (plusInfBucket % " " % int % "\n") metric hsCount
   where
-    f :: Builder -> (Internal.UpperInclusiveBound, Double) -> Builder
+    f :: Builder -> (Internal.UpperInclusiveBound, Int64) -> Builder
     f acc (le, value) =
         let extraLabel = labelsFromList [("le", sformat float le)]
-        in  acc <> bprint (fmtBucket extraLabel % " " % float) metric value <> newline
+        in  acc <> bprint (fmtBucket extraLabel % " " % float) metric (fromIntegral value :: Double)
+                <> newline
 
     fmtBucket :: Labels -> Format r (Metric -> r)
     fmtBucket extraLabels =
@@ -152,9 +153,9 @@ renderBuckets metric HistogramSample{..} =
 
     -- Buckets must be sorted in their upper bounds, in
     -- increasing order.
-    sortedBuckets :: [(Internal.UpperInclusiveBound, Double)]
+    sortedBuckets :: [(Internal.UpperInclusiveBound, Int64)]
     sortedBuckets =
-        sortBy (\(le1,_) (le2,_) -> compare le1 le2) . readBuckets $ hsBuckets
+        sortBy (\(le1,_) (le2,_) -> compare le1 le2) $ hsBuckets
 
     plusInfBucket = fmtBucket (labelsFromList [("le", "+Inf")])
 

--- a/test/Oscoin/Test/Telemetry.hs
+++ b/test/Oscoin/Test/Telemetry.hs
@@ -34,12 +34,12 @@ testHistogram = do
     HistogramSample{..} <- readHistogram =<< newExampleHistogram
     hsCount @?= 1000
     hsSum @?= 29969.50000000001
-    readBuckets hsBuckets @?= [
-        (20.0, 192.0)
-      , (25.0, 366.0)
-      , (30.0, 501.0)
-      , (35.0, 638.0)
-      , (40.0, 816.0)
+    hsBuckets @?= [
+        (20.0, 192)
+      , (25.0, 366)
+      , (30.0, 501)
+      , (35.0, 638)
+      , (40.0, 816)
       ]
 
 exampleLabels :: Labels


### PR DESCRIPTION
This commit moves to be using a different internal representation for an
'Histogram' where buckets are read in a cumulative fashion only when we
sample them using `readHistogram`.

It tries to follow the same spirit of the [go implementation](https://github.com/prometheus/client_golang/blob/master/prometheus/histogram.go) (modulo that hot/cold complication that I don't think we need for our use case). The only thing I couldn't replicate was the fact the Go histograms store each bucket's value into a `uint64` and use the reinterpret-cast trick to convert this to a `float64`, but with @kim we are still discussing whether or not is safe to do the same for own `Gauge` by using something like `GHC.Float.castWord64ToDouble` and `GHC.Float.castDoubleToWord64`. For now, I have simply used a `MonotonicCounter` and thus all the measures must be in `Int64` ( 💔).