### PR TITLE
Oscoin.Node.storage takes params from Node

### DIFF
--- a/exe/node/Main.hs
+++ b/exe/node/Main.hs
@@ -144,7 +144,7 @@ main = do
                                             , P2P.nodePort = gossipPort
                                             }
                                seeds
-                               (storage nod config)
+                               (storage nod)
                                (Handshake.simpleHandshake keys)         $ \gos ->
                         Async.runConcurrently $
                                  Async.Concurrently (HTTP.run (fromIntegral apiPort) nod)
@@ -158,5 +158,5 @@ main = do
         }
 
     miner nod gos = runGossipT gos . runNodeT nod $ Node.miner
-    storage nod config =
-        hoistStorage (runNodeT nod) (Node.storage Rad.txEval Nakamoto.validateBasic config)
+    storage nod =
+        hoistStorage (runNodeT nod) (Node.storage Nakamoto.validateBasic)


### PR DESCRIPTION
`Oscoin.Node.storage` now takes parameters from the `NodeT` environment instead of arguments. This ensures that configuration and evaluation are the same.