### PR TITLE
Relax crypto hashing constraints

### DIFF
--- a/src/Oscoin/Crypto/Hash.hs
+++ b/src/Oscoin/Crypto/Hash.hs
@@ -82,7 +82,7 @@ class HasHashing crypto where
     -- the hash pre-image is not known or cannot be typed.
     data family Hash crypto :: *
 
-    fromByteArray :: forall ba. ByteArray.ByteArray ba => ba -> Hash crypto
+    fromByteArray :: forall ba. ByteArray.ByteArrayAccess ba => ba -> Hash crypto
 
     hashAlgorithm :: HashAlgorithm crypto
 

--- a/src/Oscoin/Crypto/Hash.hs
+++ b/src/Oscoin/Crypto/Hash.hs
@@ -82,7 +82,7 @@ class HasHashing crypto where
     -- the hash pre-image is not known or cannot be typed.
     data family Hash crypto :: *
 
-    fromByteArray :: forall ba. ByteArray.ByteArrayAccess ba => ba -> Hash crypto
+    hashByteArray :: forall ba. ByteArray.ByteArrayAccess ba => ba -> Hash crypto
 
     hashAlgorithm :: HashAlgorithm crypto
 
@@ -126,11 +126,11 @@ formatHashed = Fmt.mapf fromHashed fmtB58
 
 -- | Hash a value's 'Binary' represenation.
 hashBinary :: (HasHashing crypto, Binary a) => a -> Hashed crypto a
-hashBinary = Hashed . fromByteArray . LBS.toStrict . Binary.encode
+hashBinary = Hashed . hashByteArray . LBS.toStrict . Binary.encode
 
 -- | Hash a values's 'Serialise' (CBOR) representation.
 hashSerial :: (HasHashing crypto, Serialise a) => a -> Hashed crypto a
-hashSerial = Hashed . fromByteArray . LBS.toStrict . Serial.serialise
+hashSerial = Hashed . hashByteArray . LBS.toStrict . Serial.serialise
 
 instance HasHashing crypto => Hashable crypto () where
     hash () = toHashed zeroHash

--- a/src/Oscoin/Crypto/Hash/Mock.hs
+++ b/src/Oscoin/Crypto/Hash/Mock.hs
@@ -50,7 +50,7 @@ instance HasHashing MockCrypto where
         deriving (Eq, Ord)
 
     -- | Hash anything which is an instance of 'ByteArray' into a 'Word64' using
-    -- the xxhash.
+    -- FNV-1.
     hashByteArray = FnvHash . fnv1a_64Hash
 
     hashAlgorithm = MockHash

--- a/src/Oscoin/Crypto/Hash/Mock.hs
+++ b/src/Oscoin/Crypto/Hash/Mock.hs
@@ -63,7 +63,7 @@ instance HasHashing MockCrypto where
 
 -- | Hash anything which is an instance of 'ByteArray' into a 'Word64' using
 -- the xxhash.
-hashByteArray :: ByteArray ba => ba -> FnvHash64
+hashByteArray :: ByteArrayAccess ba => ba -> FnvHash64
 hashByteArray = fnv1a_64Hash
 
 {------------------------------------------------------------------------------

--- a/src/Oscoin/Crypto/Hash/RealWorld.hs
+++ b/src/Oscoin/Crypto/Hash/RealWorld.hs
@@ -56,7 +56,7 @@ instance HasHashing Crypto where
         Hash { fromHash :: Digest (HashAlgorithm Crypto) }
         deriving (Eq, Ord, ByteArrayAccess)
 
-    fromByteArray = Hash . Crypto.hash
+    hashByteArray = Hash . Crypto.hash
 
     hashAlgorithm = Blake2b_256
 
@@ -167,4 +167,3 @@ shortHashRealWorld (Hash d) =
     . BaseN.encodeBase58
     . convert
     $ d
-

--- a/test/Oscoin/Test/Crypto.hs
+++ b/test/Oscoin/Test/Crypto.hs
@@ -37,8 +37,8 @@ instance Semigroup (Hash MockCrypto) where
         FnvHash $ FnvHash64 $ a + b -- Sums the `Word64` together.
 
 instance Semigroup (Hash Crypto) where
-    (<>) a b = fromByteArray @Crypto @ByteString $ on (<>) convert a b
-    sconcat  = fromByteArray @Crypto @ByteString . foldMap convert
+    (<>) a b = hashByteArray @Crypto @ByteString $ on (<>) convert a b
+    sconcat  = hashByteArray @Crypto @ByteString . foldMap convert
 
 instance (HasHashing c, Semigroup (Hash c)) => Monoid (Hash c) where
     mempty = zeroHash


### PR DESCRIPTION
We rename `fromByteArray` to `hashByteArray` and relax the constraint from `ByteArray` to `ByteArrayAccess`.