### PR TITLE
Replace RadTx with DummyTx in BlockStore tests

### DIFF
--- a/src/Database/SQLite/Simple/Orphans.hs
+++ b/src/Database/SQLite/Simple/Orphans.hs
@@ -8,7 +8,6 @@ import           Oscoin.Prelude
 import           Oscoin.Crypto.Blockchain.Block
 import qualified Oscoin.Crypto.Hash as Crypto
 import qualified Oscoin.Crypto.PubKey as Crypto
-import           Oscoin.Data.RadicleTx
 
 import qualified Codec.Serialise as CBOR
 import qualified Data.ByteString.Lazy as LBS
@@ -39,18 +38,6 @@ instance ( Crypto.HasHashing c
         <*> field
         <*> field
 
-instance ( CBOR.Serialise (Crypto.PublicKey c)
-         , CBOR.Serialise (Crypto.Signature c)
-         , Typeable c
-         , FromField (BlockHash c)
-         ) => FromRow (RadTx c) where
-    fromRow = Tx
-        <$> field
-        <*> field
-        <*> field
-        <*> field
-        <*> field
-
 -- | Convert a SQL parent hash field to a 'Crypto.Hash'. The SQL value is
 -- 'SQLNull' in the case of the genesis block.
 fromPrevHashField
@@ -63,17 +50,6 @@ fromPrevHashField f =
     case fieldData f of
         SQLNull -> Ok Crypto.zeroHash
         _       -> fromField f
-
-instance ( Crypto.HasHashing c
-         , ToField (Crypto.Hashed c (RadTx c))
-         , ToField (BlockHash c)
-         , CBOR.Serialise (BlockHash c)
-         , CBOR.Serialise (Crypto.PublicKey c)
-         , CBOR.Serialise (Crypto.Signature c)
-         ) => ToRow (RadTx c) where
-    toRow tx@Tx{..} =
-        [ toField (Crypto.hash @c tx), toField txMessage, toField txPubKey
-        , toField txChainId, toField txNonce, toField txContext ]
 
 instance ( CBOR.Serialise (Crypto.Signature c)
          , CBOR.Serialise msg

--- a/src/Oscoin/Storage/Block/SQLite/Transaction.hs
+++ b/src/Oscoin/Storage/Block/SQLite/Transaction.hs
@@ -1,0 +1,143 @@
+{-# LANGUAGE QuasiQuotes          #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Store and retrieve transaction.
+--
+-- The store can store a transaction type @tx@ with a crypto @c@ if
+-- they satisfy the @'StorableTx' c tx@ constraint. This requires @tx@
+-- to implement 'IsTxRow'. We provide such an instance for 'Tx'.
+module Oscoin.Storage.Block.SQLite.Transaction
+    ( StorableTx
+    , IsTxRow(..)
+    , TxRow(..)
+    , TxRowDecodeError
+    , getTx
+    , getBlockTxs
+    , storeTxs
+    ) where
+
+import           Oscoin.Prelude
+
+import           Oscoin.Crypto.Blockchain.Block (BlockHash)
+import           Oscoin.Crypto.Hash (Hash, Hashable, hash)
+import           Oscoin.Crypto.PubKey
+import           Oscoin.Data.Tx
+
+import           Codec.Serialise
+import qualified Data.ByteString.Lazy as LBS
+
+import           Database.SQLite.Simple as Sql (Connection, Only(..))
+import qualified Database.SQLite.Simple as Sql
+import           Database.SQLite.Simple.FromRow (FromRow, field)
+import           Database.SQLite.Simple.Orphans ()
+import           Database.SQLite.Simple.QQ
+import           Database.SQLite.Simple.ToField (ToField, toField)
+
+
+data TxRow = TxRow
+    { txRowMessage :: ByteString
+    , txRowAuthor  :: ByteString
+    , txRowChainId :: Word16
+    , txRowNonce   :: Word32
+    , txRowContext :: ByteString
+    }
+
+instance FromRow TxRow where
+    fromRow = do
+        txRowMessage <- field
+        txRowAuthor <- field
+        txRowChainId <- field
+        txRowNonce <- field
+        txRowContext <- field
+        pure $ TxRow{..}
+
+
+newtype TxRowDecodeError = TxRowDecodeError String
+    deriving (Show, Eq)
+
+instance Exception TxRowDecodeError where
+    displayException (TxRowDecodeError msg) =
+        "Failed to decode transaction row: " <> msg
+
+
+
+-- | Contraints that need to be satisfied for storing and retriving
+-- transactions. @c@ is the crypto and @tx@ the transaction data type.
+-- This implies the @'IsTxRow' tx@ constraint.
+type StorableTx c tx = (Hashable c tx, ToField (Hash c), Serialise (Hash c), IsTxRow tx)
+
+class IsTxRow a where
+    toTxRow :: a -> TxRow
+    fromTxRow :: TxRow -> Either TxRowDecodeError a
+
+instance
+    ( Serialise (Hash c)
+    , Serialise (PublicKey c)
+    , Serialise (Signature c)
+    , Serialise msg
+    ) => IsTxRow (Tx c msg) where
+    toTxRow Tx{..} = TxRow
+        { txRowContext = LBS.toStrict $ serialise txContext
+        , txRowMessage = LBS.toStrict $ serialise txMessage
+        , txRowAuthor = LBS.toStrict $ serialise txPubKey
+        , txRowChainId = txChainId
+        , txRowNonce = txNonce
+        }
+
+    fromTxRow TxRow{..} = first toDecodeError $ do
+        txMessage <- deserialiseOrFail $ LBS.fromStrict txRowMessage
+        txPubKey <- deserialiseOrFail $ LBS.fromStrict txRowAuthor
+        txContext <- deserialiseOrFail $ LBS.fromStrict txRowContext
+        pure $ Tx
+            { txMessage
+            , txPubKey
+            , txChainId = txRowChainId
+            , txNonce = txRowNonce
+            , txContext
+            }
+      where
+        toDecodeError :: DeserialiseFailure -> TxRowDecodeError
+        toDecodeError = TxRowDecodeError . displayException
+
+getTx :: forall c tx. (StorableTx c tx) => Sql.Connection -> Hash c -> IO (Maybe tx)
+getTx conn hash' = do
+    rows <- Sql.query conn
+        [sql| SELECT message, author, chainid, nonce, context
+                FROM transactions
+               WHERE hash = ? |] (Only $ serialise hash')
+    forM (listToMaybe rows) fromTxRowThrow
+
+
+storeTxs :: forall c tx. (StorableTx c tx) => Sql.Connection -> Hash c -> [tx] -> IO ()
+storeTxs conn blockHash txs =
+    -- Nb. To relate transactions with blocks, we store an extra block hash field
+    -- for each row in the transactions table.
+    Sql.executeMany conn
+        [sql| INSERT INTO transactions  (message, author, chainid, nonce, context, hash, blockhash)
+              VALUES                    (?, ?, ?, ?, ?, ?, ?) |] (map toTxRowValues txs)
+  where
+    toTxRowValues tx =
+        let TxRow {..} = toTxRow  tx
+        in
+            [ toField txRowMessage
+            , toField txRowAuthor
+            , toField txRowChainId
+            , toField txRowNonce
+            , toField txRowContext
+            , toField $ serialise $ hash @c tx
+            , toField blockHash
+            ]
+
+-- | Get the transactions belonging to a block.
+getBlockTxs :: (StorableTx c tx) => Connection -> BlockHash c -> IO [tx]
+getBlockTxs conn h = do
+    txRows <- Sql.query conn
+        [sql| SELECT message, author, chainid, nonce, context
+                FROM transactions
+               WHERE blockhash = ? |] (Only h)
+    traverse fromTxRowThrow txRows
+
+fromTxRowThrow :: (IsTxRow tx) => TxRow -> IO tx
+fromTxRowThrow txRow = case fromTxRow txRow of
+    Left err -> throw err
+    Right tx -> pure tx

--- a/test/Oscoin/Test/Consensus/Node.hs
+++ b/test/Oscoin/Test/Consensus/Node.hs
@@ -25,7 +25,6 @@ import           Oscoin.Consensus.Types (Validate)
 import           Oscoin.Crypto.Blockchain.Block
                  (Block, BlockHash, Score, Sealed, Unsealed)
 import qualified Oscoin.Crypto.Blockchain.Block as Block
-import           Oscoin.Crypto.Blockchain.Eval (Evaluator)
 import           Oscoin.Crypto.Hash (HasHashing, Hash, Hashable(..))
 import           Oscoin.Node.Mempool.Class (MonadMempool(..))
 import qualified Oscoin.Node.Mempool.Internal as Mempool
@@ -48,13 +47,13 @@ import           Oscoin.Test.Crypto
 import           Oscoin.Time
 import           Oscoin.Time.Chrono as Chrono
 
-import           Codec.Serialise (Serialise)
 import           Control.Monad.State.Strict
 import           Data.Binary (Binary)
 import qualified Data.Hashable as Hashable
 import           Lens.Micro
 import           Text.Show (Show(..))
 
+import           Test.Oscoin.DummyLedger
 import           Test.QuickCheck
 
 -- Type class which serves as an evidence that we can hoist a 'TestNodeT'
@@ -128,26 +127,7 @@ stepTestProtocol fullBlockStore fetchNextBlock validateFull scoreBlock = do
          liftTestNodeT $ modify' $ \st -> st { tnsOrphanage = protoOrphanage protocol' }
 
 
-newtype DummyTx = DummyTx Word8
-    deriving (Eq, Ord, Hashable.Hashable, Binary, Serialise)
-
-deriving instance (HasHashing c, Hashable c Word8) => Hashable c DummyTx
-
-type DummyState = ()
-
-type DummyOutput = ()
-
 type DummySeal = Text
-
-
-dummyEval :: Evaluator DummyState DummyTx DummyOutput
-dummyEval _ s = Right ((), s)
-
-instance Show DummyTx where
-    show (DummyTx x) = show x
-
-instance Arbitrary DummyTx where
-    arbitrary = DummyTx <$> arbitrary
 
 newtype DummyNodeId = DummyNodeId Word8
     deriving (Eq, Ord, Num, Hashable.Hashable, Binary)

--- a/test/Test/Oscoin/DummyLedger.hs
+++ b/test/Test/Oscoin/DummyLedger.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE UndecidableInstances #-}
+
+module Test.Oscoin.DummyLedger
+    ( DummyTx(..)
+    , DummyState
+    , DummyOutput
+    , dummyEval
+    ) where
+
+
+import           Oscoin.Prelude
+
+import           Oscoin.Crypto.Blockchain.Eval (Evaluator)
+import           Oscoin.Crypto.Hash (HasHashing, Hashable(..))
+import qualified Oscoin.Crypto.Hash as Crypto
+import           Oscoin.Storage.Block.SQLite
+
+import           Codec.Serialise (Serialise)
+import qualified Data.ByteString as BS
+
+import           Test.QuickCheck
+
+newtype DummyTx = DummyTx ByteString
+    deriving (Eq, Ord, Show, Serialise)
+
+instance Arbitrary DummyTx where
+    arbitrary = DummyTx . BS.pack <$> vectorOf 32 arbitrary
+
+instance (HasHashing c) => Hashable c DummyTx where
+    hash (DummyTx payload) = Crypto.toHashed $ Crypto.hashByteArray payload
+
+instance IsTxRow DummyTx where
+    toTxRow (DummyTx msg) = TxRow
+        { txRowContext = mempty
+        , txRowMessage = msg
+        , txRowAuthor  = mempty
+        , txRowChainId = 0
+        , txRowNonce   = 0
+        }
+
+    fromTxRow TxRow{txRowMessage} = Right $ DummyTx txRowMessage
+
+type DummyState = ()
+
+type DummyOutput = ()
+
+dummyEval :: Evaluator DummyState DummyTx DummyOutput
+dummyEval _ s = Right ((), s)


### PR DESCRIPTION
We replace the use of `RadTx` with `DummyTx` in the block store tests. This is one step towards getting rid of Radicle. The change also improves the run time of the block store tests by roughly 40%.

To achieve the transition we start by extracting `DummyTx` into the `Test.Oscoin.DummyLedger` module.

The interface for the SQLite storage had a `SQLite.ToRow tx` constraint for all transactions that was implemeted for `Tx c Radicle.Value`. A naive implementation of `SQLite.ToRow DummyTx` would lead to incompatibilities with the database schema. For this reason I introduced the `StoreTransaction` class. This constraint needs to be satisfied in order to store transactions in the database.