### PR TITLE
Do not run protocol for simple block storage tests

### DIFF
--- a/src/Oscoin/Storage/Block/Abstract.hs
+++ b/src/Oscoin/Storage/Block/Abstract.hs
@@ -9,6 +9,7 @@
 module Oscoin.Storage.Block.Abstract
     ( BlockStoreReader(..)
     , BlockStore
+    , hoistBlockStore
 
     , hoistBlockStoreReader
     , insertBlocksNaive
@@ -91,6 +92,14 @@ hoistBlockStoreWriter natTrans bs = BlockStoreWriter
     { insertBlock  = natTrans . insertBlock bs
     , switchToFork = \d -> natTrans . switchToFork bs d
     }
+
+hoistBlockStore
+    :: forall c tx s n m. (forall a. n a -> m a)
+    -> BlockStore c tx s n
+    -> BlockStore c tx s m
+hoistBlockStore natTrans (public, private) =
+  (hoistBlockStoreReader natTrans public, hoistBlockStoreWriter natTrans private)
+
 
 -- | /O(n)/. A naive function to store blocks in linear time.
 -- Useful for testing but discouraged for any serious production use.


### PR DESCRIPTION
We do not run the protocol for the `getTip . insertBlock equivalance` test. The property under test is independent of running the protocol. This also reduces the time to run the test by a whopping 65%.