### PR TITLE
Reorganize non-oscoin tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,23 @@ Then run ``:main`` from the repl to run the tests, and reload with ``:r`` as
 necessary. You can run a subset of tests with ``:main -p "test
 pattern"``.
 
+Test organization
+~~~~~~~~~~~~~~~~~
+
+All tests are contained in the ``test`` directory. The tests contained
+in a module are exported through the ``tests`` value. The ``tests``
+export defines a is a ``tasty`` test group with with the same name as
+the module name minus the ``Test`` prefix. Tests from test modules are
+imported and collected in the ``Main`` module.
+
+For unit tests there is a one-to-one correspondence between the tested
+module and the test module. . For example the tests for the code in
+module ``A.B.C`` are contained in ``Test.A.B.C`` which exports
+
+.. code-block:: haskell
+
+   tests = testGroup "A.B.C" [ someTest ]
+
 Profiling
 ---------
 To profile the test-suite, run::

--- a/test/Control/Concurrent/Tests.hs
+++ b/test/Control/Concurrent/Tests.hs
@@ -1,8 +1,0 @@
-module Control.Concurrent.Tests (tests) where
-
-import qualified Control.Concurrent.Test.RateLimit as RateLimit
-
-import           Test.Tasty (TestTree, testGroup)
-
-tests :: TestTree
-tests = testGroup "Concurrent" [RateLimit.tests]

--- a/test/Data/Conduit/Tests.hs
+++ b/test/Data/Conduit/Tests.hs
@@ -1,7 +1,0 @@
-module Data.Conduit.Tests (tests) where
-
-import qualified Data.Conduit.Test.Serialise as Serialise
-import           Test.Tasty (TestTree, testGroup)
-
-tests :: TestTree
-tests = testGroup "Conduit" [Serialise.tests]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -8,13 +8,13 @@ import           Oscoin.Crypto.Hash.Mock ()
 import           Oscoin.Crypto.PubKey.Mock ()
 import           Oscoin.Environment (Environment(Testing))
 
-import qualified Control.Concurrent.Tests as Concurrent
 import qualified Crypto.Test.Hash.Multi as Multihash
-import qualified Data.Conduit.Tests as Conduit
-import qualified Data.Sequence.Circular.Tests as Circular
 import qualified Integration.Tests as Integration
 import           Oscoin.Test.Crypto
 import qualified Oscoin.Tests as Oscoin
+import qualified Test.Control.Concurrent.RateLimit
+import qualified Test.Data.Conduit.Serialise
+import qualified Test.Data.Sequence.Circular
 import           Test.Tasty
 import           Test.Tasty.Ingredients.FailFast
 
@@ -26,8 +26,8 @@ main = do
     defaultMainWithIngredients (map failFast defaultIngredients) $ testGroup "All"
         [ Oscoin.tests (Dict @CryptoUnderTest) config
         , Multihash.tests
-        , Concurrent.tests
-        , Conduit.tests
         , Integration.tests
-        , Circular.tests
+        , Test.Control.Concurrent.RateLimit.tests
+        , Test.Data.Sequence.Circular.tests
+        , Test.Data.Conduit.Serialise.tests
         ]

--- a/test/Test/Control/Concurrent/RateLimit.hs
+++ b/test/Test/Control/Concurrent/RateLimit.hs
@@ -1,4 +1,4 @@
-module Control.Concurrent.Test.RateLimit (tests) where
+module Test.Control.Concurrent.RateLimit (tests) where
 
 import           Prelude
 
@@ -12,7 +12,7 @@ import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit (Assertion, testCase, (@?=))
 
 tests :: TestTree
-tests = testGroup "Rate Limit"
+tests = testGroup "Control.Concurrent.RateLimit"
     [ testCase "actions/s" testActionsPerSecond
     , testCase "actions/s concurrent" testActionsPerSecondConcurrent
     ]

--- a/test/Test/Data/Conduit/Serialise.hs
+++ b/test/Test/Data/Conduit/Serialise.hs
@@ -1,4 +1,4 @@
-module Data.Conduit.Test.Serialise (tests) where
+module Test.Data.Conduit.Serialise (tests) where
 
 import           Prelude
 
@@ -20,7 +20,7 @@ import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testProperty)
 
 tests :: TestTree
-tests = testGroup "Serialise"
+tests = testGroup "Data.Conduit.Serialise"
     [ testProperty "conduitDecodeCBOR . conduitEncodeCBOR == id" . property $
         propSerdeIdentity =<< forAll nonEmptyWiggles
     ]

--- a/test/Test/Data/Sequence/Circular.hs
+++ b/test/Test/Data/Sequence/Circular.hs
@@ -1,4 +1,4 @@
-module Data.Sequence.Circular.Tests
+module Test.Data.Sequence.Circular
     ( tests
     ) where
 


### PR DESCRIPTION
We move to a unified test organization by renaming the following modules

    Control.Concurrent.Test.RateLimit -> Test.Control.Concurrent.RateLimit
    Data.Conduit.Test.Serialise -> Test.Data.Conduit.Serialise
    Data.Sequence.Circular.Tests -> Test.Data.Sequence.Circular

We also update the exports so that the exported group contains the fully
qualified module name.

Finally, we document this approach.