### PR TITLE
Extract crypto tests from 'Oscoin.Tests'

### DIFF
--- a/test/Main.hs
+++ b/test/Main.hs
@@ -15,6 +15,8 @@ import qualified Oscoin.Tests as Oscoin
 import qualified Test.Control.Concurrent.RateLimit
 import qualified Test.Data.Conduit.Serialise
 import qualified Test.Data.Sequence.Circular
+import qualified Test.Oscoin.Crypto.Hash
+import qualified Test.Oscoin.Crypto.PubKey
 import           Test.Tasty
 import           Test.Tasty.Ingredients.FailFast
 
@@ -23,11 +25,14 @@ type CryptoUnderTest = IsCrypto MockCrypto
 main :: IO ()
 main = do
     let config = Consensus.getConfig Testing
+    let crypto = Dict @CryptoUnderTest
     defaultMainWithIngredients (map failFast defaultIngredients) $ testGroup "All"
-        [ Oscoin.tests (Dict @CryptoUnderTest) config
+        [ Oscoin.tests crypto config
         , Multihash.tests
         , Integration.tests
         , Test.Control.Concurrent.RateLimit.tests
         , Test.Data.Sequence.Circular.tests
         , Test.Data.Conduit.Serialise.tests
+        , Test.Oscoin.Crypto.Hash.tests crypto
+        , Test.Oscoin.Crypto.PubKey.tests crypto
         ]

--- a/test/Oscoin/Tests.hs
+++ b/test/Oscoin/Tests.hs
@@ -6,8 +6,6 @@ import           Oscoin.Prelude
 
 import qualified Oscoin.API.Types as API
 import qualified Oscoin.Consensus.Config as Consensus
-import qualified Oscoin.Crypto.Hash as Crypto
-import qualified Oscoin.Crypto.PubKey as Crypto
 import qualified Oscoin.Node.Mempool as Mempool
 import qualified Oscoin.Node.Mempool.Event as Mempool
 
@@ -17,8 +15,6 @@ import qualified Oscoin.Test.CLI as CLI
 import qualified Oscoin.Test.Consensus as Consensus
 import           Oscoin.Test.Crypto
 import           Oscoin.Test.Crypto.Blockchain (testBlockchain)
-import           Oscoin.Test.Crypto.PubKey.Arbitrary
-                 (arbitraryKeyPair, arbitrarySigned)
 import           Oscoin.Test.Data.Rad.Arbitrary ()
 import           Oscoin.Test.Data.Tx.Arbitrary ()
 import qualified Oscoin.Test.Environment as Environment
@@ -29,19 +25,14 @@ import qualified Oscoin.Test.Storage.Block.Orphanage as Orphanage
 import qualified Oscoin.Test.Storage.Block.SQLite.Blackbox as SQLite.Blackbox
 import qualified Oscoin.Test.Storage.Block.SQLite.Whitebox as SQLite.Whitebox
 import qualified Oscoin.Test.Telemetry as Telemetry
-import           Oscoin.Test.Util (condensed)
 
-import           Test.QuickCheck.Extended
 import           Test.QuickCheck.Instances ()
 import           Test.QuickCheck.Monadic
 import           Test.Tasty
 import           Test.Tasty.HUnit.Extended
 import           Test.Tasty.QuickCheck hiding ((===))
 
-import qualified Codec.Serialise as CBOR
-import qualified Data.Aeson as Aeson
 import           Data.ByteArray.Orphans ()
-import qualified Data.ByteString as BS
 
 tests :: forall c. Dict (IsCrypto c) -> Consensus.Config -> TestTree
 tests d@Dict config = testGroup "Oscoin"
@@ -50,10 +41,7 @@ tests d@Dict config = testGroup "Oscoin"
     , testGroup      "API"                            (API.tests d)
     -- ^ Testing API and Node using a 'MonadClient' instance
     , testGroup      "CLI"                            CLI.tests
-    , testGroup      "Crypto"                         (testOscoinCrypto d)
     , testProperty   "Mempool"                        (testOscoinMempool d)
-    , testProperty   "JSON instance of Hashed"        (propHashedJSON d)
-    , testProperty   "JSON instance of Signed"        (propSignedJSON d)
     , testGroup      "Consensus"                      (Consensus.tests d config)
     , testGroup      "P2P"                            (P2P.tests d)
     , testGroup      "Storage Cache"                  (BlockCache.tests d)
@@ -65,48 +53,6 @@ tests d@Dict config = testGroup "Oscoin"
     , testGroup      "Telemetry"                      (Telemetry.tests d)
     , testGroup      "Environment"                    Environment.tests
     ]
-
-testOscoinCrypto :: Dict (IsCrypto c) -> [TestTree]
-testOscoinCrypto d = [
-      testCase     "fnord roundtrip" (testSignRoundtrip d)
-    , testProperty "CBOR.decode Hash . CBOR.encode Hash  == id" (testSerialiseHashRoundtrip d)
-    , testProperty "CBOR.decode Signed . CBOR.encode Signed  == id" (testSerialiseSignedRoundtrip d)
-    , testProperty "CBOR.decode PublicKey . CBOR.encode PublicKey  == id" (testSerialisePkRoundtrip d)
-    , testProperty "JSON.fromJSON  PublicKey . JSON.toJSON PublicKey  == id" (testJsonPkRoundtrip d)
-    ]
-
-testSerialiseHashRoundtrip :: forall c. Dict (IsCrypto c) -> Property
-testSerialiseHashRoundtrip Dict =
-    forAll (arbitrary @ByteString) $ \bytes ->
-        (BS.length bytes > 0) ==>
-            let h = Crypto.hash @c bytes
-            in (CBOR.deserialise . CBOR.serialise $ h) === h
-
-testSerialiseSignedRoundtrip :: forall c. Dict (IsCrypto c) -> Property
-testSerialiseSignedRoundtrip Dict =
-    forAll (arbitrarySigned (Proxy @c) :: Gen (Crypto.Signed c Text)) $ \msg ->
-        (CBOR.deserialise . CBOR.serialise $ msg) === msg
-
-testSerialisePkRoundtrip :: forall c. Dict (IsCrypto c) -> Property
-testSerialisePkRoundtrip Dict =
-    forAllShow (arbitraryKeyPair @c) (show . bimap identity condensed) $ \(pk, _) ->
-        (CBOR.deserialise . CBOR.serialise $ pk) === pk
-
-testJsonPkRoundtrip :: forall c. Dict (IsCrypto c) -> Property
-testJsonPkRoundtrip Dict =
-    forAllShow (arbitraryKeyPair @c) (show . bimap identity condensed) $ \(pk, _) ->
-        (Aeson.eitherDecode . Aeson.encode $ pk) === Right pk
-
-testSignRoundtrip :: forall c. Dict (IsCrypto c) -> Assertion
-testSignRoundtrip Dict = do
-    let val :: Text = "fnord"
-    (_, priKey) <- Crypto.generateKeyPair @c
-    signed <- Crypto.sign priKey val
-
-    -- Verify that hashing a signed message is the same thing as hashing an
-    -- unsigned one.
-    Crypto.fromHashed (Crypto.hash @c signed) @?=
-        Crypto.fromHashed (Crypto.hash val)
 
 testOscoinMempool :: forall c. Dict (IsCrypto c) -> Property
 testOscoinMempool Dict = monadicIO $ do
@@ -142,13 +88,3 @@ testOscoinMempool Dict = monadicIO $ do
     fromEvent :: Mempool.Event tx -> Maybe [tx]
     fromEvent (Mempool.Insert txs) = Just txs
     fromEvent _                    = Nothing
-
-propHashedJSON :: forall c. Dict (IsCrypto c) -> ByteString -> Bool
-propHashedJSON Dict bs =
-    let x = Crypto.hash @c bs
-     in (Aeson.decode . Aeson.encode) x == Just x
-
-propSignedJSON :: forall c. Dict (IsCrypto c) -> Property
-propSignedJSON Dict =
-    forAll (arbitrarySigned (Proxy @c) :: Gen (Crypto.Signed c Text)) $ \msg ->
-          (Aeson.eitherDecode . Aeson.encode) msg === Right msg

--- a/test/Test/Oscoin/Crypto/Hash.hs
+++ b/test/Test/Oscoin/Crypto/Hash.hs
@@ -1,0 +1,37 @@
+module Test.Oscoin.Crypto.Hash
+    ( tests
+    ) where
+
+import           Oscoin.Prelude
+
+import qualified Oscoin.Crypto.Hash as Crypto
+
+import           Oscoin.Test.Crypto
+
+import           Test.QuickCheck.Extended
+import           Test.QuickCheck.Instances ()
+import           Test.Tasty
+import           Test.Tasty.QuickCheck hiding ((===))
+
+import qualified Codec.Serialise as CBOR
+import qualified Data.Aeson as Aeson
+import           Data.ByteArray.Orphans ()
+import qualified Data.ByteString as BS
+
+tests :: forall c. Dict (IsCrypto c) -> TestTree
+tests d = testGroup "Oscoin.Crypto.Hash"
+    [ testProperty "JSON serialization of 'Hashed'" (propJsonHashRoundtrip d)
+    , testProperty "CBOR serialization of 'Hashed'" (propSerialiseHashRoundtrip d)
+    ]
+
+propJsonHashRoundtrip :: forall c. Dict (IsCrypto c) -> ByteString -> Bool
+propJsonHashRoundtrip Dict bs =
+    let x = Crypto.hash @c bs
+     in (Aeson.decode . Aeson.encode) x == Just x
+
+propSerialiseHashRoundtrip :: forall c. Dict (IsCrypto c) -> Property
+propSerialiseHashRoundtrip Dict =
+    forAll (arbitrary @ByteString) $ \bytes ->
+        (BS.length bytes > 0) ==>
+            let h = Crypto.hash @c bytes
+            in (CBOR.deserialise . CBOR.serialise $ h) === h

--- a/test/Test/Oscoin/Crypto/Hash.hs
+++ b/test/Test/Oscoin/Crypto/Hash.hs
@@ -15,23 +15,19 @@ import           Test.Tasty.QuickCheck hiding ((===))
 
 import qualified Codec.Serialise as CBOR
 import qualified Data.Aeson as Aeson
-import           Data.ByteArray.Orphans ()
-import qualified Data.ByteString as BS
 
 tests :: forall c. Dict (IsCrypto c) -> TestTree
 tests d = testGroup "Oscoin.Crypto.Hash"
-    [ testProperty "JSON serialization of 'Hashed'" (propJsonHashRoundtrip d)
-    , testProperty "CBOR serialization of 'Hashed'" (propSerialiseHashRoundtrip d)
+    [ testProperty "prop_jsonRoundtripHash" (prop_jsonRoundtripHash d)
+    , testProperty "prop_serialiseRoundtripHash" (prop_serialiseRoundtripHash d)
     ]
 
-propJsonHashRoundtrip :: forall c. Dict (IsCrypto c) -> ByteString -> Bool
-propJsonHashRoundtrip Dict bs =
-    let x = Crypto.hash @c bs
-     in (Aeson.decode . Aeson.encode) x == Just x
+prop_jsonRoundtripHash :: forall c. Dict (IsCrypto c) -> ByteString -> Property
+prop_jsonRoundtripHash Dict bytes =
+    let h = Crypto.hash @c bytes
+    in (Aeson.decode . Aeson.encode) h === Just h
 
-propSerialiseHashRoundtrip :: forall c. Dict (IsCrypto c) -> Property
-propSerialiseHashRoundtrip Dict =
-    forAll (arbitrary @ByteString) $ \bytes ->
-        (BS.length bytes > 0) ==>
-            let h = Crypto.hash @c bytes
-            in (CBOR.deserialise . CBOR.serialise $ h) === h
+prop_serialiseRoundtripHash :: forall c. Dict (IsCrypto c) -> ByteString -> Property
+prop_serialiseRoundtripHash Dict bytes =
+    let h = Crypto.hash @c bytes
+    in (CBOR.deserialise . CBOR.serialise $ h) === h

--- a/test/Test/Oscoin/Crypto/PubKey.hs
+++ b/test/Test/Oscoin/Crypto/PubKey.hs
@@ -15,7 +15,6 @@ import           Oscoin.Test.Util (condensed)
 import           Test.QuickCheck.Extended
 import           Test.QuickCheck.Instances ()
 import           Test.Tasty
-import           Test.Tasty.HUnit.Extended
 import           Test.Tasty.QuickCheck hiding ((===))
 
 import qualified Codec.Serialise as CBOR
@@ -24,40 +23,37 @@ import           Data.ByteArray.Orphans ()
 
 tests :: forall c. Dict (IsCrypto c) -> TestTree
 tests d = testGroup "Oscoin.Crypto.PubKey"
-    [ testProperty "JSON serialization of 'Signed'" (propSignedJSON d)
-    , testProperty "CBOR serialization of 'Signed'" (testSerialiseSignedRoundtrip d)
-    , testProperty "JSON serialization of key pair" (testJsonPkRoundtrip d)
-    , testProperty "CBOR serialization of key pair" (testSerialisePkRoundtrip d)
-    , testCase "Hash of signed message is hash of message" (testHashSigned d)
+    [ testProperty "prop_jsonRoundtripSigned" (prop_jsonRoundtripSigned d)
+    , testProperty "prop_serialiseRoundtripSigned" (prop_serialiseRoundtripSigned d)
+    , testProperty "prop_jsonRoundtripPublicKey" (prop_jsonRoundtripPublicKey d)
+    , testProperty "prop_serialiseRoundtripPublicKey" (prop_serialiseRoundtripPublicKey d)
+    , testProperty "prop_hashSigned" (prop_hashSigned d)
     ]
 
-propSignedJSON :: forall c. Dict (IsCrypto c) -> Property
-propSignedJSON Dict =
-    forAll (arbitrarySigned (Proxy @c) :: Gen (Crypto.Signed c Text)) $ \msg ->
+prop_jsonRoundtripSigned :: forall c. Dict (IsCrypto c) -> Property
+prop_jsonRoundtripSigned Dict =
+    forAll (arbitrarySigned Proxy :: Gen (Crypto.Signed c Text)) $ \msg ->
           (Aeson.eitherDecode . Aeson.encode) msg === Right msg
 
-testJsonPkRoundtrip :: forall c. Dict (IsCrypto c) -> Property
-testJsonPkRoundtrip Dict =
+prop_serialiseRoundtripSigned :: forall c. Dict (IsCrypto c) -> Property
+prop_serialiseRoundtripSigned Dict =
+    forAll (arbitrarySigned Proxy :: Gen (Crypto.Signed c Text)) $ \msg ->
+        (CBOR.deserialise . CBOR.serialise $ msg) === msg
+
+prop_jsonRoundtripPublicKey :: forall c. Dict (IsCrypto c) -> Property
+prop_jsonRoundtripPublicKey Dict =
     forAllShow (arbitraryKeyPair @c) (show . bimap identity condensed) $ \(pk, _) ->
         (Aeson.eitherDecode . Aeson.encode $ pk) === Right pk
 
-testSerialisePkRoundtrip :: forall c. Dict (IsCrypto c) -> Property
-testSerialisePkRoundtrip Dict =
+prop_serialiseRoundtripPublicKey :: forall c. Dict (IsCrypto c) -> Property
+prop_serialiseRoundtripPublicKey Dict =
     forAllShow (arbitraryKeyPair @c) (show . bimap identity condensed) $ \(pk, _) ->
         (CBOR.deserialise . CBOR.serialise $ pk) === pk
 
-testSerialiseSignedRoundtrip :: forall c. Dict (IsCrypto c) -> Property
-testSerialiseSignedRoundtrip Dict =
-    forAll (arbitrarySigned (Proxy @c) :: Gen (Crypto.Signed c Text)) $ \msg ->
-        (CBOR.deserialise . CBOR.serialise $ msg) === msg
-
 -- Verify that hashing a signed message is the same thing as hashing an
 -- unsigned one.
-testHashSigned :: forall c. Dict (IsCrypto c) -> Assertion
-testHashSigned Dict = do
-    let val :: Text = "fnord"
-    (_, priKey) <- Crypto.generateKeyPair @c
-    signed <- Crypto.sign priKey val
-
-    Crypto.fromHashed (Crypto.hash @c signed) @?=
-        Crypto.fromHashed (Crypto.hash val)
+prop_hashSigned :: forall c. Dict (IsCrypto c) -> Property
+prop_hashSigned Dict =
+    forAll (arbitrarySigned Proxy) $ \(signed :: Crypto.Signed c ByteString) ->
+        let msg = Crypto.sigMessage signed
+        in Crypto.fromHashed (Crypto.hash @c signed) === Crypto.fromHashed (Crypto.hash msg)

--- a/test/Test/Oscoin/Crypto/PubKey.hs
+++ b/test/Test/Oscoin/Crypto/PubKey.hs
@@ -1,0 +1,63 @@
+module Test.Oscoin.Crypto.PubKey
+    ( tests
+    ) where
+
+import           Oscoin.Prelude
+
+import qualified Oscoin.Crypto.Hash as Crypto
+import qualified Oscoin.Crypto.PubKey as Crypto
+
+import           Oscoin.Test.Crypto
+import           Oscoin.Test.Crypto.PubKey.Arbitrary
+                 (arbitraryKeyPair, arbitrarySigned)
+import           Oscoin.Test.Util (condensed)
+
+import           Test.QuickCheck.Extended
+import           Test.QuickCheck.Instances ()
+import           Test.Tasty
+import           Test.Tasty.HUnit.Extended
+import           Test.Tasty.QuickCheck hiding ((===))
+
+import qualified Codec.Serialise as CBOR
+import qualified Data.Aeson as Aeson
+import           Data.ByteArray.Orphans ()
+
+tests :: forall c. Dict (IsCrypto c) -> TestTree
+tests d = testGroup "Oscoin.Crypto.PubKey"
+    [ testProperty "JSON serialization of 'Signed'" (propSignedJSON d)
+    , testProperty "CBOR serialization of 'Signed'" (testSerialiseSignedRoundtrip d)
+    , testProperty "JSON serialization of key pair" (testJsonPkRoundtrip d)
+    , testProperty "CBOR serialization of key pair" (testSerialisePkRoundtrip d)
+    , testCase "Hash of signed message is hash of message" (testHashSigned d)
+    ]
+
+propSignedJSON :: forall c. Dict (IsCrypto c) -> Property
+propSignedJSON Dict =
+    forAll (arbitrarySigned (Proxy @c) :: Gen (Crypto.Signed c Text)) $ \msg ->
+          (Aeson.eitherDecode . Aeson.encode) msg === Right msg
+
+testJsonPkRoundtrip :: forall c. Dict (IsCrypto c) -> Property
+testJsonPkRoundtrip Dict =
+    forAllShow (arbitraryKeyPair @c) (show . bimap identity condensed) $ \(pk, _) ->
+        (Aeson.eitherDecode . Aeson.encode $ pk) === Right pk
+
+testSerialisePkRoundtrip :: forall c. Dict (IsCrypto c) -> Property
+testSerialisePkRoundtrip Dict =
+    forAllShow (arbitraryKeyPair @c) (show . bimap identity condensed) $ \(pk, _) ->
+        (CBOR.deserialise . CBOR.serialise $ pk) === pk
+
+testSerialiseSignedRoundtrip :: forall c. Dict (IsCrypto c) -> Property
+testSerialiseSignedRoundtrip Dict =
+    forAll (arbitrarySigned (Proxy @c) :: Gen (Crypto.Signed c Text)) $ \msg ->
+        (CBOR.deserialise . CBOR.serialise $ msg) === msg
+
+-- Verify that hashing a signed message is the same thing as hashing an
+-- unsigned one.
+testHashSigned :: forall c. Dict (IsCrypto c) -> Assertion
+testHashSigned Dict = do
+    let val :: Text = "fnord"
+    (_, priKey) <- Crypto.generateKeyPair @c
+    signed <- Crypto.sign priKey val
+
+    Crypto.fromHashed (Crypto.hash @c signed) @?=
+        Crypto.fromHashed (Crypto.hash val)


### PR DESCRIPTION
Move crypto tests from `Oscoin.Tests` to new `Test.Oscoin.Crypto.Hash` and `Test.Oscoin.Crypto.PubKey`.