### PR TITLE
Reject a peer presenting one's own public key in the handshake.

### DIFF
--- a/test/Oscoin/Test/P2P/Handshake.hs
+++ b/test/Oscoin/Test/P2P/Handshake.hs
@@ -1,4 +1,4 @@
-module Oscoin.Test.P2P.Handshake (tests, props) where
+module Oscoin.Test.P2P.Handshake  where
 
 import           Oscoin.Prelude
 
@@ -8,32 +8,37 @@ import           Oscoin.P2P.Handshake as Handshake
 import           Oscoin.P2P.Types (NodeId, fromNodeId, mkNodeId)
 
 import           Oscoin.Test.Crypto
+import           Oscoin.Test.Crypto.PubKey.Arbitrary (arbitraryKeyPairs)
 import           Oscoin.Test.P2P.Helpers (framedPair)
+import           Oscoin.Test.Util (Condensed, condensed)
 
 import qualified Crypto.Noise.Exception as Noise
 
 import           Hedgehog
+import           Hedgehog.Gen.QuickCheck (quickcheck)
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testProperty)
 
-{-# ANN module ("HLint: ignore Reduce duplication" :: String ) #-}
-
 tests :: Dict (IsCrypto c) -> TestTree
 tests d = testGroup "Oscoin.Test.P2P.Handshake"
-    [ testProperty "prop_simple" (prop_simpleHandshake d)
-    , testProperty "prop_secure" (prop_secureHandshake d)
+    [ testProperty "prop_simple"            (prop_simple d)
+    , testProperty "prop_simpleRejectsSelf" (prop_simpleRejectsSelf d)
+    , testProperty "prop_secure"            (prop_secure d)
+    , testProperty "prop_secureRejectsSelf" (prop_secureRejectsSelf d)
     ]
 
 -- | For GHCi use.
 props :: Dict (IsCrypto c) -> IO Bool
 props d = checkParallel $ Group "Oscoin.Test.P2P.Handshake"
-    [ ("prop_simple", prop_simpleHandshake d)
-    , ("test_secure", prop_secureHandshake d)
+    [ ("prop_simple",            prop_simple d)
+    , ("prop_simpleRejectsSelf", prop_simpleRejectsSelf d)
+    , ("prop_secure",            prop_secure d)
+    , ("prop_secureRejectsSelf", prop_secureRejectsSelf d)
     ]
 
-prop_simpleHandshake :: forall c. Dict (IsCrypto c) -> Property
-prop_simpleHandshake Dict = withTests 1 . property $ do
-    ((pkAlice :: PublicKey c, skAlice), (pkBob, skBob)) <- keyPairs
+prop_simple :: forall c. Dict (IsCrypto c) -> Property
+prop_simple Dict = withTests 1 . property $ do
+    ((pkAlice, skAlice), (pkBob, skBob)) <- genKeyPairPair @c
     ((ttAlice, close1), (ttBob, close2)) <- liftIO framedPair
 
     let nidAlice = mkNodeId pkAlice
@@ -49,8 +54,8 @@ prop_simpleHandshake Dict = withTests 1 . property $ do
                 (hBob Handshake.Connector (Just nidAlice)) `finally` close2)
 
     case hrs of
-        (Left _, _) -> failure
-        (_, Left _) -> failure
+        (Left e, _) -> annotateShow e *> failure
+        (_, Left e) -> annotateShow e *> failure
         (Right hrAlice, Right hrBob) -> do
             -- Alice and Bob know the other's key, respectively
             nidHash (Handshake.hrPeerId hrAlice) === nidHash nidBob
@@ -77,9 +82,29 @@ prop_simpleHandshake Dict = withTests 1 . property $ do
     assertInvalidSignature x f =
         (=== Left Handshake.InvalidSignature) =<< evalIO (try (f x))
 
-prop_secureHandshake :: forall c. Dict (IsCrypto c) -> Property
-prop_secureHandshake Dict = withTests 1 . property $ do
-    ((pkAlice :: PublicKey c, skAlice), (pkBob, skBob)) <- keyPairs
+prop_simpleRejectsSelf :: forall c. Dict (IsCrypto c) -> Property
+prop_simpleRejectsSelf Dict = withTests 1 . property $ do
+    (pk, sk)                             <- genKeyPair @c
+    ((ttAlice, close1), (ttBob, close2)) <- liftIO framedPair
+
+    let hsAlice = Handshake.simpleHandshake @ByteString (pk, sk)
+    let hBob    = Handshake.simpleHandshake @ByteString (pk, sk)
+
+    hrs <-
+        evalIO $ concurrently
+            (Handshake.runHandshakeT ttAlice
+                (hsAlice Handshake.Acceptor Nothing) `finally` close1)
+            (Handshake.runHandshakeT ttBob
+                (hBob Handshake.Connector (Just (mkNodeId pk))) `finally` close2)
+
+    case hrs of
+        (Left Handshake.DuplicateId, _) -> success
+        (_, Left Handshake.DuplicateId) -> success
+        _                               -> failure
+
+prop_secure :: forall c. Dict (IsCrypto c) -> Property
+prop_secure Dict = withTests 1 . property $ do
+    ((pkAlice, skAlice), (pkBob, skBob)) <- genKeyPairPair @c
     ((ttAlice, close1), (ttBob, close2)) <- liftIO framedPair
 
     let nidAlice = mkNodeId pkAlice
@@ -95,8 +120,8 @@ prop_secureHandshake Dict = withTests 1 . property $ do
                 (hBob Handshake.Connector (Just nidAlice)) `finally` close2)
 
     case hrs of
-        (Left _, _) -> failure
-        (_, Left _) -> failure
+        (Left e, _) -> annotateShow e *> failure
+        (_, Left e) -> annotateShow e *> failure
         (Right hrAlice, Right hrBob) -> do
             -- Alice and Bob know the other's key, respectively
             nidHash (Handshake.hrPeerId hrAlice) === nidHash nidBob
@@ -125,6 +150,27 @@ prop_secureHandshake Dict = withTests 1 . property $ do
             Left Noise.DecryptionError -> success
             _                          -> failure
 
+prop_secureRejectsSelf :: forall c. Dict (IsCrypto c) -> Property
+prop_secureRejectsSelf Dict = withTests 1 . property $ do
+    (pk, sk) <- genKeyPair @c
+
+    ((ttAlice, close1), (ttBob, close2)) <- liftIO framedPair
+
+    let hsAlice = Handshake.secureHandshake @ByteString (pk, sk)
+    let hBob    = Handshake.secureHandshake @ByteString (pk, sk)
+
+    hrs <-
+        evalIO $ concurrently
+            (Handshake.runHandshakeT ttAlice
+                (hsAlice Handshake.Acceptor Nothing) `finally` close1)
+            (Handshake.runHandshakeT ttBob
+                (hBob Handshake.Connector (Just (mkNodeId pk))) `finally` close2)
+
+    case hrs of
+        (Left (Handshake.SimpleHandshakeError Handshake.DuplicateId), _) -> success
+        (_, Left (Handshake.SimpleHandshakeError Handshake.DuplicateId)) -> success
+        _                                                                -> failure
+
 --------------------------------------------------------------------------------
 
 tripping' :: (MonadTest m, Eq a, Show a) => a -> (a -> m b) -> (b -> m a) -> m ()
@@ -133,13 +179,37 @@ tripping' x f g = do
     gf <- g fx
     gf === x
 
-keyPairs :: IsCrypto c => PropertyT IO (Crypto.KeyPair c, Crypto.KeyPair c)
-keyPairs = liftA2 (,) gen gen
-  where
-    gen = evalIO Crypto.generateKeyPair
-
 nidHash
     :: Crypto.Hashable c (PublicKey c)
     => NodeId c
     -> Crypto.Hashed c (PublicKey c)
 nidHash = Crypto.hash . fromNodeId
+
+condensedS :: Condensed a => a -> String
+condensedS = toS . condensed
+
+genKeyPair
+    :: forall c.
+    ( HasHashing            c
+    , HasDigitalSignature   c
+    , Condensed (PublicKey  c)
+    , Condensed (PrivateKey c)
+    )
+    => PropertyT IO (KeyPair c)
+genKeyPair =
+    forAllWith condensedS (quickcheck (arbitraryKeyPairs @c 1)) >>= \case
+        [a] -> pure a
+        x   -> annotate (condensedS x) *> failure
+
+genKeyPairPair
+    :: forall c.
+    ( HasHashing            c
+    , HasDigitalSignature   c
+    , Condensed (PublicKey  c)
+    , Condensed (PrivateKey c)
+    )
+    => PropertyT IO (KeyPair c, KeyPair c)
+genKeyPairPair =
+    forAllWith condensedS (quickcheck (arbitraryKeyPairs @c 2)) >>= \case
+        [a, b] -> pure (a, b)
+        x      -> annotate (condensedS x) *> failure


### PR DESCRIPTION
Note that this doesn't prevent duplicate keys in the network.