### PR TITLE
Introduce getBlockStoreReader

### DIFF
--- a/src/Oscoin/Node/Trans.hs
+++ b/src/Oscoin/Node/Trans.hs
@@ -5,7 +5,7 @@ module Oscoin.Node.Trans
     , runNodeT
     , Config(..)
     , Handle(..)
-    , withBlockStore
+    , getBlockStoreReader
     ) where
 
 import           Oscoin.Prelude
@@ -92,13 +92,12 @@ instance ( Ord (Hash c)
     {-# INLINE numTxs    #-}
     {-# INLINE subscribe #-}
 
-withBlockStore
-    :: MonadIO m
-    => (Abstract.BlockStoreReader c tx s IO -> IO b)
-    -> NodeT c tx st s i m b
-withBlockStore f = do
+getBlockStoreReader
+    :: (MonadIO m, MonadIO n)
+    => NodeT c tx st s i n (Abstract.BlockStoreReader c tx s m)
+getBlockStoreReader = do
     bs <- asks hBlockStore
-    liftIO $ f bs
+    pure $ Abstract.hoistBlockStoreReader liftIO bs
 
 instance MonadClock m => MonadClock (NodeT c tx st s i m)
 


### PR DESCRIPTION
We replace `Oscoin.Node.Trans.withBlockStore` with `Oscoin.Node.Trans.getBlockStoreReader`. The new function can be used in more places and we do not need to get the BlockStore from the handle anymore.