### PR TITLE
Move mempool, orphanage, API tests to new structure

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,16 +42,16 @@ Test organization
 All tests are contained in the ``test`` directory. The tests contained
 in a module are exported through the ``tests`` value. The ``tests``
 export defines a is a ``tasty`` test group with with the same name as
-the module name minus the ``Test`` prefix. Tests from test modules are
-imported and collected in the ``Main`` module.
+the module name. Tests from test modules are imported and collected in
+the ``Main`` module.
 
 For unit tests there is a one-to-one correspondence between the tested
-module and the test module. . For example the tests for the code in
+module and the test module. For example the tests for the code in
 module ``A.B.C`` are contained in ``Test.A.B.C`` which exports
 
 .. code-block:: haskell
 
-   tests = testGroup "A.B.C" [ someTest ]
+   tests = testGroup "Test.A.B.C" [ someTest ]
 
 Profiling
 ---------

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -15,6 +15,7 @@ import qualified Oscoin.Tests as Oscoin
 import qualified Test.Control.Concurrent.RateLimit
 import qualified Test.Data.Conduit.Serialise
 import qualified Test.Data.Sequence.Circular
+import qualified Test.Oscoin.API
 import qualified Test.Oscoin.Configuration
 import qualified Test.Oscoin.Crypto.Hash
 import qualified Test.Oscoin.Crypto.PubKey
@@ -32,9 +33,10 @@ main = do
         , Multihash.tests
         , Integration.tests
         , Test.Control.Concurrent.RateLimit.tests
-        , Test.Data.Sequence.Circular.tests
         , Test.Data.Conduit.Serialise.tests
         , Test.Oscoin.Configuration.tests
+        , Test.Data.Sequence.Circular.tests
+        , Test.Oscoin.API.tests crypto
         , Test.Oscoin.Crypto.Hash.tests crypto
         , Test.Oscoin.Crypto.PubKey.tests crypto
         ]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -19,6 +19,7 @@ import qualified Test.Oscoin.API
 import qualified Test.Oscoin.Configuration
 import qualified Test.Oscoin.Crypto.Hash
 import qualified Test.Oscoin.Crypto.PubKey
+import qualified Test.Oscoin.Storage.Block.Orphanage
 import           Test.Tasty
 import           Test.Tasty.Ingredients.FailFast
 
@@ -39,4 +40,5 @@ main = do
         , Test.Oscoin.API.tests crypto
         , Test.Oscoin.Crypto.Hash.tests crypto
         , Test.Oscoin.Crypto.PubKey.tests crypto
+        , Test.Oscoin.Storage.Block.Orphanage.tests crypto
         ]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -19,6 +19,7 @@ import qualified Test.Oscoin.API
 import qualified Test.Oscoin.Configuration
 import qualified Test.Oscoin.Crypto.Hash
 import qualified Test.Oscoin.Crypto.PubKey
+import qualified Test.Oscoin.Node.Mempool
 import qualified Test.Oscoin.Storage.Block.Orphanage
 import           Test.Tasty
 import           Test.Tasty.Ingredients.FailFast
@@ -40,5 +41,6 @@ main = do
         , Test.Oscoin.API.tests crypto
         , Test.Oscoin.Crypto.Hash.tests crypto
         , Test.Oscoin.Crypto.PubKey.tests crypto
+        , Test.Oscoin.Node.Mempool.tests crypto
         , Test.Oscoin.Storage.Block.Orphanage.tests crypto
         ]

--- a/test/Oscoin/Tests.hs
+++ b/test/Oscoin/Tests.hs
@@ -9,7 +9,6 @@ import qualified Oscoin.Consensus.Config as Consensus
 import qualified Oscoin.Node.Mempool as Mempool
 import qualified Oscoin.Node.Mempool.Event as Mempool
 
-import qualified Oscoin.Test.API as API
 import qualified Oscoin.Test.API.HTTP as HTTP
 import qualified Oscoin.Test.CLI as CLI
 import qualified Oscoin.Test.Consensus as Consensus
@@ -38,8 +37,6 @@ tests :: forall c. Dict (IsCrypto c) -> Consensus.Config -> TestTree
 tests d@Dict config = testGroup "Oscoin"
     [ testGroup      "API.HTTP"                       (HTTP.tests d)
     -- ^ Testing HTTP API constructing HTTP requests manually
-    , testGroup      "API"                            (API.tests d)
-    -- ^ Testing API and Node using a 'MonadClient' instance
     , testGroup      "CLI"                            CLI.tests
     , testProperty   "Mempool"                        (testOscoinMempool d)
     , Consensus.tests d config

--- a/test/Oscoin/Tests.hs
+++ b/test/Oscoin/Tests.hs
@@ -2,12 +2,7 @@ module Oscoin.Tests
     ( tests
     ) where
 
-import           Oscoin.Prelude
-
-import qualified Oscoin.API.Types as API
 import qualified Oscoin.Consensus.Config as Consensus
-import qualified Oscoin.Node.Mempool as Mempool
-import qualified Oscoin.Node.Mempool.Event as Mempool
 
 import qualified Oscoin.Test.API.HTTP as HTTP
 import qualified Oscoin.Test.CLI as CLI
@@ -25,10 +20,7 @@ import qualified Test.Oscoin.Crypto.Address as Address
 import qualified Test.Oscoin.P2P as P2P
 
 import           Test.QuickCheck.Instances ()
-import           Test.QuickCheck.Monadic
 import           Test.Tasty
-import           Test.Tasty.HUnit.Extended
-import           Test.Tasty.QuickCheck hiding ((===))
 
 import           Data.ByteArray.Orphans ()
 
@@ -37,7 +29,6 @@ tests d@Dict config = testGroup "Oscoin"
     [ testGroup      "API.HTTP"                       (HTTP.tests d)
     -- ^ Testing HTTP API constructing HTTP requests manually
     , testGroup      "CLI"                            CLI.tests
-    , testProperty   "Mempool"                        (testOscoinMempool d)
     , Consensus.tests d config
     , testGroup      "Address"                        (Address.tests d)
     , testGroup      "P2P"                            (P2P.tests d)
@@ -48,38 +39,3 @@ tests d@Dict config = testGroup "Oscoin"
     , testBlockchain d config
     , testGroup      "Telemetry"                      (Telemetry.tests d)
     ]
-
-testOscoinMempool :: forall c. Dict (IsCrypto c) -> Property
-testOscoinMempool Dict = monadicIO $ do
-    -- Create a new mempool of account transactions.
-    mp <- lift (Mempool.newIO @c)
-
-    -- Create some arbitrary transactions.
-    txs <- pick (arbitrary @[API.RadTx c])
-
-    -- Subscribe to the mempool with the subscription tokens.
-    (chan1, chan2, evs1, evs2) <- lift $ atomically $ do
-        chan1 <- Mempool.subscribe mp
-        chan2 <- Mempool.subscribe mp
-
-        -- Add the transactions.
-        Mempool.insertMany mp txs
-
-        -- Retrieve all events from the channels.
-        evs1 <- Mempool.drainChannel chan1
-        evs2 <- Mempool.drainChannel chan2
-
-        pure (chan1, chan2, evs1, evs2)
-
-    liftIO $ do
-        -- Verify that they contain the transactions we generated.
-        assertEqual "Chan 1 has all Txs" txs $ concat . mapMaybe fromEvent $ evs1
-        assertEqual "Chan 2 has all Txs" txs $ concat . mapMaybe fromEvent $ evs2
-
-        -- If we try to read again, the channel is empty.
-        atomically (Mempool.drainChannel chan1) >>= assertEqual "Chan 1 is empty" []
-        atomically (Mempool.drainChannel chan2) >>= assertEqual "Chan 2 is empty" []
-  where
-    fromEvent :: Mempool.Event tx -> Maybe [tx]
-    fromEvent (Mempool.Insert txs) = Just txs
-    fromEvent _                    = Nothing

--- a/test/Oscoin/Tests.hs
+++ b/test/Oscoin/Tests.hs
@@ -18,7 +18,6 @@ import           Oscoin.Test.Data.Rad.Arbitrary ()
 import           Oscoin.Test.Data.Tx.Arbitrary ()
 import qualified Oscoin.Test.Storage.Block.Cache as BlockCache
 import qualified Oscoin.Test.Storage.Block.Equivalence as StorageEquivalence
-import qualified Oscoin.Test.Storage.Block.Orphanage as Orphanage
 import qualified Oscoin.Test.Storage.Block.SQLite.Blackbox as SQLite.Blackbox
 import qualified Oscoin.Test.Storage.Block.SQLite.Whitebox as SQLite.Whitebox
 import qualified Oscoin.Test.Telemetry as Telemetry
@@ -43,7 +42,6 @@ tests d@Dict config = testGroup "Oscoin"
     , testGroup      "Address"                        (Address.tests d)
     , testGroup      "P2P"                            (P2P.tests d)
     , testGroup      "Storage Cache"                  (BlockCache.tests d)
-    , testGroup      "Storage Orphanage"              (Orphanage.tests d)
     , testGroup      "Storage equivalence checking"   (StorageEquivalence.tests d)
     , testGroup      "SQLite Storage blackbox"        (SQLite.Blackbox.tests d)
     , testGroup      "SQLite Storage whitebox"        (SQLite.Whitebox.tests d)

--- a/test/Test/Oscoin/API.hs
+++ b/test/Test/Oscoin/API.hs
@@ -1,6 +1,6 @@
 -- | Tests behavior of the Node through its API using a test
 -- implementation of 'MonadClient'.
-module Oscoin.Test.API
+module Test.Oscoin.API
     ( tests
     ) where
 
@@ -24,8 +24,8 @@ import           Test.Tasty.HUnit.Extended
 import           Test.Tasty.QuickCheck
 
 
-tests :: forall c. Dict (IsCrypto c) -> [TestTree]
-tests Dict =
+tests :: forall c. Dict (IsCrypto c) -> TestTree
+tests Dict = testGroup "Test.Oscoin.API"
     [ testGroup "getState"
         [ testProperty "existing value" $ monadicIO $ do
             -- #341: We need 'listOf1' here as generating an

--- a/test/Test/Oscoin/Node/Mempool.hs
+++ b/test/Test/Oscoin/Node/Mempool.hs
@@ -1,0 +1,57 @@
+module Test.Oscoin.Node.Mempool
+    ( tests
+    ) where
+
+import           Oscoin.Prelude
+
+import qualified Oscoin.API.Types as API
+import qualified Oscoin.Node.Mempool as Mempool
+import qualified Oscoin.Node.Mempool.Event as Mempool
+
+import           Oscoin.Test.Crypto
+import           Oscoin.Test.Data.Rad.Arbitrary ()
+import           Oscoin.Test.Data.Tx.Arbitrary ()
+
+import           Test.QuickCheck.Monadic
+import           Test.Tasty
+import           Test.Tasty.HUnit.Extended
+import           Test.Tasty.QuickCheck
+
+tests :: forall c. Dict (IsCrypto c) -> TestTree
+tests d = testGroup "Test.Oscoin.Node.Mempool"
+    [ testProperty "prop_mempool" (prop_mempool d) ]
+
+prop_mempool :: forall c. Dict (IsCrypto c) -> Property
+prop_mempool Dict = monadicIO $ do
+    -- Create a new mempool of account transactions.
+    mp <- lift (Mempool.newIO @c)
+
+    -- Create some arbitrary transactions.
+    txs <- pick (arbitrary @[API.RadTx c])
+
+    -- Subscribe to the mempool with the subscription tokens.
+    (chan1, chan2, evs1, evs2) <- lift $ atomically $ do
+        chan1 <- Mempool.subscribe mp
+        chan2 <- Mempool.subscribe mp
+
+        -- Add the transactions.
+        Mempool.insertMany mp txs
+
+        -- Retrieve all events from the channels.
+        evs1 <- Mempool.drainChannel chan1
+        evs2 <- Mempool.drainChannel chan2
+
+        pure (chan1, chan2, evs1, evs2)
+
+    liftIO $ do
+        -- Verify that they contain the transactions we generated.
+        assertEqual "Chan 1 has all Txs" txs $ concat . mapMaybe fromEvent $ evs1
+        assertEqual "Chan 2 has all Txs" txs $ concat . mapMaybe fromEvent $ evs2
+
+        -- If we try to read again, the channel is empty.
+        atomically (Mempool.drainChannel chan1) >>= assertEqual "Chan 1 is empty" []
+        atomically (Mempool.drainChannel chan2) >>= assertEqual "Chan 2 is empty" []
+  where
+    fromEvent :: Mempool.Event tx -> Maybe [tx]
+    fromEvent (Mempool.Insert txs) = Just txs
+    fromEvent _                    = Nothing

--- a/test/Test/Oscoin/Storage/Block/Orphanage.hs
+++ b/test/Test/Oscoin/Storage/Block/Orphanage.hs
@@ -1,6 +1,6 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE UndecidableInstances #-}
-module Oscoin.Test.Storage.Block.Orphanage
+module Test.Oscoin.Storage.Block.Orphanage
     ( tests
     ) where
 
@@ -32,12 +32,12 @@ import           Test.QuickCheck.Monadic
 import           Test.Tasty
 import           Test.Tasty.QuickCheck hiding ((===))
 
-tests :: Dict (IsCrypto c) -> [TestTree]
-tests d =
-    [ testProperty "insert orphans"                                     (propInsertOrphans d)
-    , testProperty "selectBestCandidate (single choice)"                (propSelectBestCandidateSingleChoice d)
-    , testProperty "selectBestCandidate (multiple choices)"             (propSelectBestCandidateMultipleChoice d)
-    , testProperty "selectBestCandidate (long chain, multiple choices)" (propSelectBestCandidateComplex d)
+tests :: Dict (IsCrypto c) -> TestTree
+tests d = testGroup "Test.Oscoin.Storage.Block.Orphanage"
+    [ testProperty "propInsertOrphans" (propInsertOrphans d)
+    , testProperty "propSelectBestCandidateSingleChoice" (propSelectBestCandidateSingleChoice d)
+    , testProperty "propSelectBestCandidateMultipleChoice" (propSelectBestCandidateMultipleChoice d)
+    , testProperty "propSelectBestCandidateComplex" (propSelectBestCandidateComplex d)
     ]
 
 {------------------------------------------------------------------------------


### PR DESCRIPTION
In three separate commits we
* move `Oscoin.Test.API` to `Test.Oscoin.API`
* move `Oscoin.Test.Storage.Block.Orphanage` to `Test.Oscoin.Storage.Block.Orphanage`
* extract `Test.Oscoin.Node.Mempool` from `Oscoin.Tests`