### PR TITLE
Simplify orphanage tests

### DIFF
--- a/test/Oscoin/Test/Storage/Block/SQLite.hs
+++ b/test/Oscoin/Test/Storage/Block/SQLite.hs
@@ -3,30 +3,19 @@ module Oscoin.Test.Storage.Block.SQLite
     , DummySeal
     , withSqliteDB
     , withMemStore
-    , insertOrphans
-    , bestChainOracle
-    , shuffledOrphanChains
-    , Shuffled(..)
     ) where
 
 import           Oscoin.Prelude
-import qualified Prelude
 
-import           Codec.Serialise
-import qualified Data.Sequence as Seq
 
-import           Oscoin.Consensus.Nakamoto (blockScore)
 import           Oscoin.Crypto.Blockchain hiding (genesisBlock)
 import           Oscoin.Data.RadicleTx
 import qualified Oscoin.Storage.Block.Abstract as Abstract
-import           Oscoin.Storage.Block.Orphanage
 import           Oscoin.Storage.Block.SQLite as Sqlite
 import           Oscoin.Storage.Block.SQLite.Internal as Sqlite
 import qualified Oscoin.Time as Time
-import           Oscoin.Time.Chrono (toNewestFirst)
 
 import           Oscoin.Test.Crypto
-import           Oscoin.Test.Crypto.Blockchain.Generators
 import           Oscoin.Test.Data.Rad.Arbitrary ()
 import           Oscoin.Test.Data.Tx.Arbitrary ()
 
@@ -70,51 +59,3 @@ withMemStore genTestData action = monadicIO $ do
     testData <- pick (genTestData defaultGenesis)
     liftIO $
         Sqlite.withBlockStore ":memory:" defaultGenesis $ action testData
-
--- | Inserts all the given blocks in the 'Orphanage'.
-insertOrphans
-    :: IsCrypto c
-    => [Block c tx (Sealed c s)]
-    -> Orphanage c tx s
-    -> Orphanage c tx s
-insertOrphans xs o =
-    foldl' (flip insertOrphan) o xs
-
--- | Iterate over all the input chains and select the one with the best score.
-bestChainOracle
-    :: IsCrypto c
-    => BlockHash c
-    -- ^ The hash of the adopted block this chain originates from.
-    -> [(Shuffled (Blockchain c tx s), Blockchain c tx s, Block c tx (Sealed c s))]
-    -> Maybe (ChainCandidate c s)
-bestChainOracle _ [] = Nothing
-bestChainOracle root xs =
-    let (_shuffledChain, chain, lnk) =
-            maximumBy (\(_,chain1,lnk1) (_,chain2, lnk2) ->
-                sum (map blockScore (lnk1 : (toNewestFirst . blocks) chain1)) `compare`
-                sum (map blockScore (lnk2 : (toNewestFirst . blocks) chain2))
-            ) (filter (\(_,_,ls) -> parentHash ls == root) xs)
-        winningChain = reverse ((toNewestFirst . blocks) chain <> [lnk])
-    in Just $ ChainCandidate
-        { candidateChain     = Seq.fromList (map blockHash winningChain)
-        , candidateTipHeader = blockHeader (Prelude.last winningChain)
-        , candidateScore     = sum (map blockScore winningChain)
-        }
-
-newtype Shuffled a = Shuffled { fromShuffled :: a }
-
--- | Returns a list of /shuffled/ orphans chains and, for conveniency, also
--- the original, ordered one.
-shuffledOrphanChains
-    :: ( IsCrypto c
-       , Arbitrary tx
-       , Arbitrary s
-       , Serialise tx
-       , Serialise s
-       )
-    => ForkParams
-    -> Blockchain c tx s
-    -> Gen [(Shuffled (Blockchain c tx s), Blockchain c tx s, Block c tx (Sealed c s))]
-shuffledOrphanChains params initialChain = do
-    xs <- genOrphanChainsFrom params initialChain
-    forM xs (\(c,b) -> (,c,b) . Shuffled . unsafeToBlockchain <$> shuffle (toNewestFirst $ blocks c))

--- a/test/Oscoin/Test/Util.hs
+++ b/test/Oscoin/Test/Util.hs
@@ -3,7 +3,6 @@ module Oscoin.Test.Util where
 
 import           Oscoin.Prelude
 
-import           Oscoin.API.Types (RadTx)
 import           Oscoin.Crypto
 import           Oscoin.Crypto.Blockchain
 import qualified Oscoin.Crypto.Hash as Crypto
@@ -24,6 +23,9 @@ class Condensed a where
 
 instance Condensed () where
     condensed () = "()"
+
+instance Condensed Bool where
+    condensed = show
 
 instance Condensed Integer where
     condensed = show
@@ -86,20 +88,6 @@ instance Condensed (PrivateKey MockCrypto) where
 
 instance Show (Signature c) => Condensed (Signed c Text) where
     condensed = show
-
-showOrphans
-    :: Crypto.HasHashing c
-    => ( Blockchain c (RadTx c) s
-       , [(Blockchain c (RadTx c) s, Block c (RadTx c) (Sealed c s))]
-       )
-    -> String
-showOrphans (initialChain, orphansWithLinks) =
-    "chain: "      <> T.unpack (showChainDigest initialChain) <> "\n" <>
-    "orphans:\n- " <> T.unpack showOrphanAndLinks
-  where
-      showOrphanAndLinks =
-          T.intercalate "- " . map (\(c,l) -> showChainDigest c <> " link: " <> showBlockDigest l <> "\n")
-                             $ orphansWithLinks
 
 -- The Ed's Kmett one weird trick.
 


### PR DESCRIPTION
* We eliminate the use of monadic properties
* We simplify `propInsertOrphans` replacing `genOrphanChainsFrom` with `arbitraryBlockChain`.