### PR TITLE
Cleanup 'Oscoin.Crypto.Blockchain.Block'

### DIFF
--- a/test/Oscoin/Test/HTTP/Helpers.hs
+++ b/test/Oscoin/Test/HTTP/Helpers.hs
@@ -40,8 +40,7 @@ import           Oscoin.Configuration (Environment(Development))
 import qualified Oscoin.Consensus.Config as Consensus
 import           Oscoin.Consensus.Trivial (blockScore, trivialConsensus)
 import           Oscoin.Crypto.Blockchain
-import           Oscoin.Crypto.Blockchain.Block
-                 (emptyGenesisBlock, genesisBlock, sealBlock)
+import           Oscoin.Crypto.Blockchain.Block (emptyGenesisBlock, sealBlock)
 import           Oscoin.Crypto.Hash (Hashed)
 import qualified Oscoin.Crypto.Hash as Crypto
 import qualified Oscoin.Crypto.PubKey as Crypto
@@ -240,7 +239,7 @@ runSession nst (Session sess) =
 -- Radicle environment
 runSessionEnv :: IsCrypto c => Rad.Env c -> Session c () -> Assertion
 runSessionEnv env (Session sess) = do
-    let nst = nodeState [] (fromGenesis $ genesisBlock [] env "" epoch) env
+    let nst = nodeState [] (fromGenesis $ sealBlock "" $ emptyGenesisFromState epoch env) env
     withNode nst $ \nh -> do
         app <- API.app nh
         Wai.runSession (runReaderT sess nh) app

--- a/test/Oscoin/Test/Storage/Block/Cache.hs
+++ b/test/Oscoin/Test/Storage/Block/Cache.hs
@@ -4,7 +4,7 @@ module Oscoin.Test.Storage.Block.Cache
 
 import           Oscoin.Prelude
 
-import           Oscoin.Crypto.Blockchain.Block hiding (genesisBlock)
+import           Oscoin.Crypto.Blockchain.Block
 import           Oscoin.Time.Chrono (NewestFirst(..))
 
 import           Oscoin.Storage.Block.Cache

--- a/test/Oscoin/Test/Storage/Block/SQLite.hs
+++ b/test/Oscoin/Test/Storage/Block/SQLite.hs
@@ -8,7 +8,7 @@ module Oscoin.Test.Storage.Block.SQLite
 import           Oscoin.Prelude
 
 
-import           Oscoin.Crypto.Blockchain hiding (genesisBlock)
+import           Oscoin.Crypto.Blockchain
 import           Oscoin.Data.RadicleTx
 import qualified Oscoin.Storage.Block.Abstract as Abstract
 import           Oscoin.Storage.Block.SQLite as Sqlite

--- a/test/Oscoin/Test/Storage/Block/SQLite/Blackbox.hs
+++ b/test/Oscoin/Test/Storage/Block/SQLite/Blackbox.hs
@@ -7,7 +7,7 @@ import           Oscoin.Prelude
 
 import           Oscoin.Crypto.Blockchain
                  (Blockchain(..), blocks, chainLength, txPayload)
-import           Oscoin.Crypto.Blockchain.Block hiding (genesisBlock)
+import           Oscoin.Crypto.Blockchain.Block
 import qualified Oscoin.Crypto.Hash as Crypto
 import           Oscoin.Data.RadicleTx
 import qualified Oscoin.Storage.Block.Abstract as Abstract

--- a/test/Oscoin/Test/Storage/Block/SQLite/Whitebox.hs
+++ b/test/Oscoin/Test/Storage/Block/SQLite/Whitebox.hs
@@ -9,7 +9,7 @@ import           Oscoin.Prelude
 
 import           Data.ByteArray.Orphans ()
 
-import           Oscoin.Crypto.Blockchain.Block hiding (genesisBlock)
+import           Oscoin.Crypto.Blockchain.Block
 import qualified Oscoin.Crypto.Hash as Crypto
 import           Oscoin.Data.RadicleTx
 import           Oscoin.Storage.Block.SQLite.Internal as Sqlite


### PR DESCRIPTION
This commit includes changes that improve the code in the `Oscoin.Crypto.Blockchain.Block` module.

We eliminate `genesisBlock`. This function was only used in one place where it was easily replaced by `emptyGenesisFromState`.

We eliminate the unused `withHeader` function.

We rewrite `linkParent` and `sealBlock` using lenses. This simplifies the code an reduces duplication. But more importantly we now guarantee the correctness of the `blockHash` field by using `blockHeaderL` instead of relying on us setting the field manually.