### PR TITLE
Consolidate and document block generators

### DIFF
--- a/test/Oscoin/Test/Crypto/Blockchain.hs
+++ b/test/Oscoin/Test/Crypto/Blockchain.hs
@@ -15,6 +15,7 @@ import           Oscoin.Crypto.Hash
 import           Oscoin.Time
 
 import           Oscoin.Test.Crypto
+import           Oscoin.Test.Crypto.Blockchain.Block.Generators
 import           Oscoin.Test.Crypto.Blockchain.Generators
 
 import           Codec.Serialise (Serialise)
@@ -47,10 +48,10 @@ testBlockchain d@Dict config = testGroup "Blockchain"
         \(blk :: Block c String String) ->
             (Aeson.decode . Aeson.encode) blk == Just blk
     , testProperty "Difficulty: decode . encode == id (JSON)" $
-        \(diffi :: Difficulty) ->
+        forAll genDifficulty $ \(diffi :: Difficulty) ->
             (Aeson.decode . Aeson.encode) diffi == Just diffi
     , testProperty "Difficulty: parseDifficulty . prettyDifficulty == id" $
-        \(diffi :: Difficulty) ->
+        forAll genDifficulty $ \(diffi :: Difficulty) ->
             (parseDifficulty. prettyDifficulty) diffi == Just diffi
     , testProperty "Difficulty (compact): decode . encode == id" $
         \(diffi :: Integer) -> -- TODO(alexis): Should only create 256-bit integers.
@@ -81,7 +82,7 @@ testValidateBlock Dict config = testGroup "Nakamoto: validateBlockchain"
             \blks -> let result = validateBlockchain Nakamoto.validateFull blks
                      in counterexample (show result) (result == Right ())
     , testProperty "Blocks bigger than the maximum size won't validate" $
-        forAll (arbitrary @(Block c Text Nakamoto.PoW)) $
+        forAll (arbitrary @(Block c Text ())) $
           \block -> let result = validateBlockSize config { Consensus.maxBlockSize = 1 } block
                     in counterexample (show result) (hasExceededMaxSize result)
     ]

--- a/test/Oscoin/Test/Crypto/Blockchain/Block/Arbitrary.hs
+++ b/test/Oscoin/Test/Crypto/Blockchain/Block/Arbitrary.hs
@@ -1,28 +1,20 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE UndecidableInstances #-}
 module Oscoin.Test.Crypto.Blockchain.Block.Arbitrary
-    ( arbitraryBlock
-    , arbitraryBlockWith
-    ) where
-
-import           Oscoin.Prelude
+    () where
 
 import           Codec.Serialise (Serialise)
 
-import qualified Oscoin.Consensus.Nakamoto as Nakamoto
 import           Oscoin.Crypto.Blockchain
-import           Oscoin.Crypto.Hash (Hash)
 
 import           Oscoin.Test.Crypto
+import           Oscoin.Test.Crypto.Blockchain.Block.Generators
 import           Oscoin.Test.Crypto.Hash.Arbitrary ()
 import           Oscoin.Test.Time ()
 import           Test.QuickCheck
 
 instance Arbitrary s => Arbitrary (Sealed c s) where
-    arbitrary = SealedWith <$> arbitrary
-
-instance Arbitrary Difficulty where
-    arbitrary = arbitraryDifficulty
+    arbitrary = genSeal
 
 instance ( Serialise tx
          , Serialise s
@@ -30,48 +22,4 @@ instance ( Serialise tx
          , Arbitrary s
          , IsCrypto c
          ) => Arbitrary (Block c tx s) where
-    arbitrary = arbitraryBlock
-
-instance Arbitrary Nakamoto.PoW where
-    arbitrary = Nakamoto.PoW <$> arbitrary
-
--- | Generates an arbitrary block where the parent hash is randomly generated.
--- Callers of this function needs to be aware that generating a block this way
--- doesn't give them any guarantee in terms of creating a well-constructed
--- blockchain. Use this function only when you know what you are doing. To
--- generate well-formed blocks and blockchains, take a look at 'genBlockFrom' and
--- 'genBlockchainFrom'.
-arbitraryBlock
-    :: (IsCrypto c, Serialise s, Serialise tx, Arbitrary tx, Arbitrary s)
-    => Gen (Block c tx s)
-arbitraryBlock =
-    arbitraryBlockWith =<< arbitrary
-
--- | Generates a random 'Difficulty' without considering the previous one.
-arbitraryDifficulty :: Gen Difficulty
-arbitraryDifficulty =
-    (unsafeDifficulty . getPositive <$> arbitrary) `suchThat` noOverflow
-  where noOverflow d = d <= maxDifficulty
-
--- | Generates a 'Block' from a given list of transactions. The same caveats
--- as 'arbitraryBlock' apply.
-arbitraryBlockWith
-    :: forall c tx s. (IsCrypto c, Serialise s, Serialise tx, Arbitrary s)
-    => [tx]
-    -> Gen (Block c tx s)
-arbitraryBlockWith txs = do
-    timestamp <- arbitrary
-    diffi <- arbitraryDifficulty
-    prevHash <- arbitrary :: Gen (Hash c)
-    stateHash <- arbitrary :: Gen (Hash c)
-    blockSeal <- arbitrary
-
-    let header = (emptyHeader :: BlockHeader c Unsealed)
-               { blockPrevHash   = prevHash
-               , blockDataHash   = hashTxs txs
-               , blockStateHash  = stateHash
-               , blockTimestamp  = timestamp
-               , blockSeal
-               , blockTargetDifficulty = diffi
-               }
-    pure $ mkBlock header txs
+    arbitrary = genStandaloneBlock

--- a/test/Oscoin/Test/Crypto/Blockchain/Block/Generators.hs
+++ b/test/Oscoin/Test/Crypto/Blockchain/Block/Generators.hs
@@ -1,6 +1,12 @@
 module Oscoin.Test.Crypto.Blockchain.Block.Generators
     ( -- * Generating genereric blocks
       genBlockFrom
+    , genBlockWith
+    , genStandaloneBlock
+
+    , genSeal
+    , genPoWSeal
+    , genDifficulty
 
     -- * Generating Nakamoto blocks
     , genNakamotoBlockFrom
@@ -12,12 +18,46 @@ import           Codec.Serialise (Serialise)
 
 import qualified Oscoin.Consensus.Nakamoto as Nakamoto
 import           Oscoin.Crypto.Blockchain
+import qualified Oscoin.Crypto.Hash as Crypto
 import           Oscoin.Time
 
 import           Oscoin.Test.Crypto
-import           Oscoin.Test.Crypto.Blockchain.Block.Arbitrary ()
+import           Oscoin.Test.Crypto.Hash.Arbitrary ()
 import           Oscoin.Test.Time ()
 import           Test.QuickCheck
+
+
+-- | Generates an arbitrary block where the parent hash is randomly generated.
+--
+-- To create properly linked blockchains use 'genBlockFrom' or
+-- 'genBlockchainFrom'.
+genStandaloneBlock
+    :: forall c tx s.
+       ( IsCrypto c
+       , Serialise s
+       , Serialise tx
+       , Arbitrary s
+       , Arbitrary tx
+       )
+    => Gen (Block c tx s)
+genStandaloneBlock = do
+    txs :: [tx] <- arbitrary
+    timestamp <- arbitrary
+    diffi <- genDifficulty
+    prevHash <- arbitrary
+    stateHash <- arbitrary
+    blockSeal <- arbitrary
+
+    let header = (emptyHeader :: BlockHeader c Unsealed)
+               { blockPrevHash   = prevHash
+               , blockDataHash   = hashTxs txs
+               , blockStateHash  = stateHash
+               , blockTimestamp  = timestamp
+               , blockSeal
+               , blockTargetDifficulty = diffi
+               }
+    pure $ mkBlock header txs
+
 
 -- | The difficulty is calculated with random swings with a factor of 4(**).
 -- (**) This is /almost/ true: in particular, we decrease the difficulty of a
@@ -41,35 +81,53 @@ genDifficultyFrom (fromDifficulty -> prevDifficulty) =
                  ]
   where noOverflow d = d <= maxDifficulty
 
--- | Generates an arbitrary but valid block, linked against the input one
--- and cointaining the txs specified as input.
+
+-- | Generates a random 'Difficulty' without considering the previous one.
+genDifficulty :: Gen Difficulty
+genDifficulty =
+    (unsafeDifficulty . getPositive <$> arbitrary) `suchThat` noOverflow
+  where noOverflow d = d <= maxDifficulty
+
+
+-- | Generates a block that satisfies the following properties
+--
+-- * The block contains the provided transactions and has a correct
+-- 'blockDataHash'.
+-- * 'blockStateHash' matches the hash of the provided state.
+-- * 'blockPrevHash' matches the hash of the provided parent block.
+-- * 'blockTargetDifficulty' follows 'genDifficultyFrom' using the
+--   parent block.
+-- * 'blockTimestamp' is larger than the parent block’s timestamp
 genBlockWith
-    :: forall c s tx.
+    :: forall c s tx state.
        ( Arbitrary s
        , Serialise s
        , Serialise tx
        , IsCrypto c
+       , Crypto.Hashable c state
        )
     => Block c tx s
     -> [tx]
+    -> state
     -> Gen (Block c tx s)
-genBlockWith parentBlock txs =  do
+genBlockWith parentBlock txs st = do
     let prevHeader = blockHeader parentBlock
     elapsed    <- choose (2750 * seconds, 3250 * seconds)
-    blockState <- arbitrary :: Gen Word8
     blockSeal  <- arbitrary
     blockDiffi <- genDifficultyFrom (blockTargetDifficulty prevHeader)
     let header = (emptyHeader :: BlockHeader c Unsealed)
                { blockPrevHash         = headerHash prevHeader
                , blockDataHash         = hashTxs txs
-               , blockStateHash        = hashState blockState
+               , blockStateHash        = hashState st
                , blockSeal
                , blockTimestamp        = blockTimestamp prevHeader `timeAdd` elapsed
                , blockTargetDifficulty = blockDiffi
                }
     pure $ mkBlock header txs
 
---- | Generates an arbitrary but valid block, linked against the input one.
+-- | Generates an arbitrary but valid block, linked against the input
+-- one. Uses 'genBlockWith' with an arbitrary set of transactions and
+-- an arbitrary state.
 genBlockFrom
     :: ( IsCrypto c
        , Arbitrary tx
@@ -81,7 +139,14 @@ genBlockFrom
     -> Gen (Block c tx s)
 genBlockFrom parentBlock = do
     txs <- arbitrary
-    genBlockWith parentBlock txs
+    st :: Word8 <- arbitrary
+    genBlockWith parentBlock txs st
+
+genSeal :: (Arbitrary s) => Gen (Sealed c s)
+genSeal = SealedWith <$> arbitrary
+
+genPoWSeal :: Gen (Sealed c Nakamoto.PoW)
+genPoWSeal = SealedWith . Nakamoto.PoW <$> arbitrary
 
 {------------------------------------------------------------------------------
   Generating Nakamoto's blocks
@@ -101,7 +166,7 @@ genNakamotoBlockWith prefix@(parent:|_) txs = do
     let prevHeader = blockHeader parent
     elapsed    <- choose (60 * seconds, 120 * seconds)
     blockState <- arbitrary :: Gen Word8
-    blockSeal  <- arbitrary
+    blockSeal  <- genPoWSeal
     blockDiffi <- pure $ Nakamoto.chainDifficulty (toList prefix)
     let header = (emptyHeader :: BlockHeader c Unsealed)
                { blockPrevHash         = headerHash prevHeader

--- a/test/Oscoin/Test/Crypto/Blockchain/Generators.hs
+++ b/test/Oscoin/Test/Crypto/Blockchain/Generators.hs
@@ -21,6 +21,7 @@ import           Oscoin.Crypto.Blockchain
 import qualified Oscoin.Time.Chrono as Chrono
 
 import           Oscoin.Test.Crypto
+import           Oscoin.Test.Crypto.Blockchain.Block.Arbitrary ()
 import           Oscoin.Test.Crypto.Blockchain.Block.Generators
 import           Test.QuickCheck
 
@@ -186,7 +187,7 @@ genNakamotoBlockchain
     => Gen (Blockchain c tx Nakamoto.PoW)
 genNakamotoBlockchain = do
     blockTimestamp <- arbitrary
-    genesisSeal <- arbitrary
+    genesisSeal <- genPoWSeal
     let genHeader = emptyHeader
             { blockSeal = genesisSeal
             , blockTimestamp

--- a/test/Oscoin/Test/Storage/Block/SQLite/Blackbox.hs
+++ b/test/Oscoin/Test/Storage/Block/SQLite/Blackbox.hs
@@ -14,7 +14,7 @@ import qualified Oscoin.Storage.Block.Abstract as Abstract
 import qualified Oscoin.Time.Chrono as Chrono
 
 import           Oscoin.Test.Crypto
-import           Oscoin.Test.Crypto.Blockchain.Block.Arbitrary (arbitraryBlock)
+import           Oscoin.Test.Crypto.Blockchain.Block.Arbitrary ()
 import           Oscoin.Test.Crypto.Blockchain.Block.Generators
 import           Oscoin.Test.Crypto.Blockchain.Generators (genBlockchainFrom)
 import           Oscoin.Test.Data.Rad.Arbitrary ()
@@ -55,7 +55,7 @@ genGetBlocks
     => Block c (RadTx c) (Sealed c DummySeal)
     -> Gen (Block c (RadTx c) (Sealed c DummySeal), Blockchain c (RadTx c) DummySeal)
 genGetBlocks genesisBlock =
-    (,) <$> arbitraryBlock
+    (,) <$> genStandaloneBlock
         <*> resize 1 (genBlockchainFrom genesisBlock)
 
 

--- a/test/Oscoin/Test/Storage/Block/SQLite/Whitebox.hs
+++ b/test/Oscoin/Test/Storage/Block/SQLite/Whitebox.hs
@@ -15,6 +15,7 @@ import           Oscoin.Data.RadicleTx
 import           Oscoin.Storage.Block.SQLite.Internal as Sqlite
 
 import           Oscoin.Test.Crypto
+import           Oscoin.Test.Crypto.Blockchain.Block.Arbitrary ()
 import           Oscoin.Test.Crypto.Blockchain.Block.Generators
 import           Oscoin.Test.Data.Rad.Arbitrary ()
 import           Oscoin.Test.Data.Tx.Arbitrary ()

--- a/test/Test/Oscoin/P2P/Gen.hs
+++ b/test/Test/Oscoin/P2P/Gen.hs
@@ -30,7 +30,8 @@ import qualified Data.Text as T
 import           System.Random.SplitMix (mkSMGen)
 
 import           Oscoin.Test.Crypto
-import           Oscoin.Test.Crypto.Blockchain.Block.Arbitrary (arbitraryBlock)
+import           Oscoin.Test.Crypto.Blockchain.Block.Arbitrary ()
+import           Oscoin.Test.Crypto.Blockchain.Block.Generators
 import           Oscoin.Test.Data.Rad.Arbitrary ()
 import           Oscoin.Test.Data.Tx.Arbitrary ()
 
@@ -84,11 +85,11 @@ genIP = Gen.choice [ ipv4, ipv6 ]
 genMsg :: IsCrypto c => Gen (Msg c Text (Sealed c Text))
 genMsg = Gen.choice [ blkMsg, txMsg ]
   where
-    blkMsg = BlockMsg <$> quickcheck arbitraryBlock
+    blkMsg = BlockMsg <$> quickcheck genStandaloneBlock
     txMsg  = TxMsg    <$> Gen.text (Range.constant 0 512) Gen.unicodeAll
 
 genMsgId :: forall c. IsCrypto c => Gen (MsgId c Text)
 genMsgId = Gen.choice [ blkMsgId, txMsgId ]
   where
-    blkMsgId = BlockId . blockHash <$> quickcheck (arbitraryBlock @c @Text @(Sealed c Text))
+    blkMsgId = BlockId . blockHash <$> quickcheck (genStandaloneBlock @c @Text @(Sealed c Text))
     txMsgId  = TxId    . hash      <$> Gen.text (Range.constant 0 512) Gen.unicodeAll


### PR DESCRIPTION
We move all block generators from `Oscoin.Test.Crypto.Blockchain.Block.Arbitrary` to the `Oscoin.Test.Crypto.Blockchain.Block.Generators` module that already contained the majority of block generators. The `Arbitrary` modules only provides the necessary orphan `Arbitrary` instances.