### PR TITLE
Remove JSON support for HTTP API

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -57,7 +57,6 @@ library:
     - hostname
     - http-api-data
     - http-client
-    - http-media
     - http-types
     - iproute
     - memory
@@ -158,7 +157,6 @@ tests:
       - hedgehog-quickcheck
       - http-api-data
       - http-client
-      - http-media
       - http-types
       - iproute
       - memory

--- a/src/Oscoin/API/HTTP.hs
+++ b/src/Oscoin/API/HTTP.hs
@@ -7,7 +7,7 @@ import           Oscoin.Prelude hiding (get)
 
 import           Oscoin.API.Types (RadTx)
 import           Oscoin.Crypto (Crypto)
-import           Oscoin.Crypto.Blockchain.Block (BlockHash, Sealed)
+import           Oscoin.Crypto.Blockchain.Block (BlockHash)
 import           Oscoin.Crypto.Hash (toHashed)
 import qualified Oscoin.Crypto.Hash as Crypto
 import           Oscoin.Crypto.Hash.RealWorld ()
@@ -30,7 +30,6 @@ import           Web.HttpApiData (FromHttpApiData(..))
 import           Web.Spock
 
 import           Codec.Serialise (Serialise)
-import           Data.Aeson (FromJSON, ToJSON)
 import           Formatting.Buildable (Buildable)
 
 withTelemetryMiddleware :: Node.Handle c tx e s i
@@ -43,9 +42,7 @@ withTelemetryMiddleware hdl action = do
 -- | Runner specialised over the production 'Crypto', as we use a separate
 -- node handle for tests.
 run
-    :: ( Serialise s
-       , ToJSON s
-       )
+    :: (Serialise s)
     => Int
     -> Node.Handle Crypto (RadTx Crypto) (Rad.Env Crypto) s i
     -> IO ()
@@ -53,9 +50,7 @@ run port hdl =
     withTelemetryMiddleware hdl $ \mdlware -> runApi (api mdlware) port hdl
 
 app
-    :: ( ToJSON (Sealed c s)
-       , ToJSON (Crypto.PublicKey c)
-       , Typeable c
+    :: ( Typeable c
        , FromHttpApiData (BlockHash c)
        , Serialise s
        , Serialise (BlockHash c)
@@ -63,12 +58,7 @@ app
        , Serialise (Crypto.Signature c)
        , Crypto.HasDigitalSignature c
        , Crypto.HasHashing c
-       , FromJSON (BlockHash c)
-       , FromJSON (Crypto.PublicKey c)
-       , FromJSON (Crypto.Signature c)
        , Buildable (Crypto.Hash c)
-       , ToJSON (Crypto.Hash c)
-       , ToJSON (Crypto.Signature c)
        )
     => Node.Handle c (RadTx c) (Rad.Env c) s i
     -> IO Wai.Application
@@ -85,9 +75,7 @@ staticFilePolicy =
 
 -- | Entry point for API.
 api
-    :: ( ToJSON (Sealed c s)
-       , ToJSON (Crypto.PublicKey c)
-       , Typeable c
+    :: ( Typeable c
        , FromHttpApiData (BlockHash c)
        , Serialise s
        , Serialise (BlockHash c)
@@ -95,12 +83,7 @@ api
        , Serialise (Crypto.Signature c)
        , Crypto.HasDigitalSignature c
        , Crypto.HasHashing c
-       , FromJSON (BlockHash c)
-       , FromJSON (Crypto.PublicKey c)
-       , FromJSON (Crypto.Signature c)
        , Buildable (Crypto.Hash c)
-       , ToJSON (Crypto.Hash c)
-       , ToJSON (Crypto.Signature c)
        )
     => Wai.Middleware
     -> Api c s i ()

--- a/test/Oscoin/Test/API/HTTP.hs
+++ b/test/Oscoin/Test/API/HTTP.hs
@@ -20,9 +20,7 @@ import           Oscoin.Time.Chrono (toNewestFirst)
 
 import qualified Data.Aeson as Aeson
 import           Data.Default (def)
-import qualified Data.Text as T
 
-import           Network.HTTP.Media ((//))
 import           Network.HTTP.Types.Status
 import           Web.HttpApiData (toUrlPiece)
 
@@ -48,14 +46,10 @@ tests Dict =
         ]
     ]
   where
-    test name mkTest = testGroup name $ do
-        let ctypes  = fromMediaType <$> [ JSON, CBOR ]
-        let accepts = ("*" // "*") : ctypes
-        codec <- [ newCodec accept content | content <- ctypes, accept <- accepts ]
-        [ testProperty (T.unpack $ prettyCodec codec) (
-            monadicIO $ do
-                HTTPTest{..} <- mkTest codec
-                liftIO $ runSession testState testSession )]
+    test name mkTest =
+        testProperty name $ monadicIO $ do
+            HTTPTest{..} <- mkTest $ newCodec (fromMediaType CBOR) (fromMediaType CBOR)
+            liftIO $ runSession testState testSession
 
 data HTTPTest c = HTTPTest
     { testState   :: NodeState c

--- a/test/Oscoin/Test/HTTP/Helpers.hs
+++ b/test/Oscoin/Test/HTTP/Helpers.hs
@@ -3,7 +3,6 @@
 module Oscoin.Test.HTTP.Helpers
     ( Codec
     , newCodec
-    , prettyCodec
 
     , NodeState(..)
     , nodeState
@@ -321,11 +320,6 @@ data Codec = Codec
     { codecAccept      :: HTTP.MediaType
     , codecContentType :: HTTP.MediaType
     } deriving (Show)
-
-prettyCodec :: Codec -> Text
-prettyCodec Codec{..} =
-    "(Accept: " <> show codecAccept <>
-    ", Content-Type: " <> show codecContentType <> ")"
 
 newCodec :: HTTP.MediaType -> HTTP.MediaType -> Codec
 newCodec accept ctype = Codec

--- a/test/Oscoin/Test/Telemetry.hs
+++ b/test/Oscoin/Test/Telemetry.hs
@@ -61,7 +61,7 @@ newExampleHistogram = do
 
 smokeTestMiddleware :: forall c. Dict (IsCrypto c) -> Assertion
 smokeTestMiddleware Dict = HTTP.runSession @c HTTP.emptyNodeState $
-    HTTP.get (HTTP.newCodec "text/plain" "text/plain") "/metrics"
+    HTTP.get "/metrics"
         >>= HTTP.assertStatus ok200
 
 testRenderCounter :: Assertion


### PR DESCRIPTION
This removes all support for content type negotiation and JSON encoding from the HTTP API. The HTTP API only supports the CBOR content type now

 We stop maintaining the JSON because of the following reasons:
 * There is no strong use case to provide multiple encodings.
 * Support for the JSON encoding was incomplete. Some endpoints were only available as CBOR.
 * The JSON encoding requires us to write `ToJSON`/`FromJSON` instances in addition to `Serialise` instances.

 As a consequence of removing content type negotiation support we get rid of 200 lines of code and cut the test time in half.
Supersedes #433 
