### PR TITLE
Update 'evalBlock' to make it more powerful

### DIFF
--- a/exe/node/Main.hs
+++ b/exe/node/Main.hs
@@ -10,7 +10,7 @@ import qualified Oscoin.Consensus.Config as Consensus
 import qualified Oscoin.Consensus.Nakamoto as Nakamoto
 import           Oscoin.Crypto (Crypto)
 import           Oscoin.Crypto.Blockchain.Block (Block, Sealed)
-import           Oscoin.Crypto.Blockchain.Eval (evalBlock, fromEvalError)
+import           Oscoin.Crypto.Blockchain.Eval (evalBlock)
 import           Oscoin.Data.RadicleTx (RadTx)
 import qualified Oscoin.Data.RadicleTx as Rad (pureEnv, txEval)
 import           Oscoin.Node (runNodeT, withNode)
@@ -57,8 +57,7 @@ main = do
     nid          <- pure (mkNodeId $ fst keys)
     mem          <- Mempool.newIO
     gen          <- Yaml.decodeFileThrow (genesisPath optPaths) :: IO GenesisBlock
-    genState     <- either (die . fromEvalError) pure $
-                        evalBlock Rad.txEval Rad.pureEnv gen
+    let (genState, _receipts) = evalBlock Rad.txEval Rad.pureEnv gen
     stStore      <- newHashStoreIO
     storeHashContent stStore genState
     metricsStore <-

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -17,6 +17,7 @@ import qualified Test.Data.Conduit.Serialise
 import qualified Test.Data.Sequence.Circular
 import qualified Test.Oscoin.API
 import qualified Test.Oscoin.Configuration
+import qualified Test.Oscoin.Crypto.Blockchain.Eval
 import qualified Test.Oscoin.Crypto.Blockchain.GeneratorsTest
 import qualified Test.Oscoin.Crypto.Hash
 import qualified Test.Oscoin.Crypto.PubKey
@@ -40,6 +41,7 @@ main = do
         , Test.Data.Sequence.Circular.tests
         , Test.Oscoin.API.tests crypto
         , Test.Oscoin.Configuration.tests
+        , Test.Oscoin.Crypto.Blockchain.Eval.tests crypto
         , Test.Oscoin.Crypto.Blockchain.GeneratorsTest.tests crypto
         , Test.Oscoin.Crypto.Hash.tests crypto
         , Test.Oscoin.Crypto.PubKey.tests crypto

--- a/test/Oscoin/Test/Crypto/Blockchain.hs
+++ b/test/Oscoin/Test/Crypto/Blockchain.hs
@@ -9,15 +9,11 @@ import qualified Oscoin.Consensus.Config as Consensus
 import qualified Oscoin.Consensus.Nakamoto as Nakamoto
 import           Oscoin.Crypto.Blockchain (showChainDigest)
 import           Oscoin.Crypto.Blockchain.Block
-import           Oscoin.Crypto.Blockchain.Eval
-import           Oscoin.Crypto.Hash (Hashable(..), hashSerial)
-import           Oscoin.Time
 
 import           Oscoin.Test.Crypto
 import           Oscoin.Test.Crypto.Blockchain.Block.Generators
 import           Oscoin.Test.Crypto.Blockchain.Generators
 
-import           Codec.Serialise (Serialise)
 import qualified Codec.Serialise as Serialise
 import           Data.Binary.Put (putWord32le, runPut)
 import qualified Data.ByteString.Lazy as LBS
@@ -34,8 +30,7 @@ testBlockchain
     -> Consensus.Config
     -> TestTree
 testBlockchain d@Dict config = testGroup "Blockchain"
-    [ testBuildBlock d
-    , testValidateBlock d config
+    [ testValidateBlock d config
     , testProperty "Block: deserialise . serialise == id" $
         \(blk :: Block c ByteString ByteString) ->
             (Serialise.deserialise . Serialise.serialise) blk == blk
@@ -79,79 +74,3 @@ testValidateBlock Dict config = testGroup "Nakamoto: validateBlockchain"
 hasExceededMaxSize :: Either (ValidationError c) a -> Bool
 hasExceededMaxSize (Left (InvalidBlockSize _)) = True
 hasExceededMaxSize _                           = False
-
-testBuildBlock
-    :: forall c. Dict (IsCrypto c)
-    -> TestTree
-testBuildBlock d@Dict = testGroup "buildBlock"
-    [ testProperty "creates receipt for all transactions" $
-        \txs -> let (_, _, receipts) = buildTestBlock d mempty txs
-                in map receiptTx receipts === map (hash @c) txs
-    , testProperty "receipts have block hash" $
-        \txs -> let (blk, _, receipts) = buildTestBlock d mempty txs
-                in conjoin [ receiptTxBlock receipt === blockHash blk | receipt <- receipts ]
-    , testProperty "valid transactions create new state" $
-        \txs -> let (_, s, _) = buildTestBlock d mempty txs
-                    validTxOutputs = [ output | TxOk output <- txs ]
-                in reverse validTxOutputs === s
-    , testProperty "only valid transactions are included in block" $
-        \txs -> let (blk, _, _) = buildTestBlock d mempty txs
-                    validTxs = filter txIsOk txs
-                in validTxs === toList (blockData blk)
-    , testProperty "transactions errors recorded in receipts" $
-        \txs err -> let (_, _, receipts) = buildTestBlock d mempty txsWithError
-                        txsWithError = TxErr err : txs
-                    in (receiptTxOutput <$> head receipts) === Just (Left (EvalError (show err)))
-    , testProperty "error transactions do not change block" $
-        \txs -> let validTxs = [ TxOk out | TxOk out <- txs ]
-                    (blkWithErrors, _, _) = buildTestBlock d mempty txs
-                    (blkWithoutErrors, _, _) = buildTestBlock d mempty validTxs
-                in  blockData blkWithErrors === blockData blkWithoutErrors
-    ]
-
-
---
--- * Test evaluator
---
--- We define a test evaluator where a transaction is either an output
--- or an error and the state is just the list of outputs.
---
-
-type Output = Word8
-
-type St = [Output]
-
-data Tx
-    = TxOk Output
-    | TxErr Int
-    deriving (Eq, Show, Generic)
-
-txIsOk :: Tx -> Bool
-txIsOk (TxOk _)  = True
-txIsOk (TxErr _) = False
-
-instance Arbitrary Tx where
-    arbitrary = txFromEither <$> arbitrary
-      where
-        txFromEither (Left err)     = TxErr err
-        txFromEither (Right output) = TxOk output
-
-instance Serialise Tx
-
-instance HasHashing c => Hashable c Tx where
-    hash = hashSerial
-
-eval :: Evaluator St Tx Output
-eval (TxOk output) st = Right (output, output : st)
-eval (TxErr err) _    = Left (EvalError (show err))
-
-
--- | Build block on an empty genesis block with 'eval' as defined
--- above.
-buildTestBlock
-    :: Dict (IsCrypto c)
-    -> St
-    -> [Tx]
-    -> (Block c Tx Unsealed, St, [Receipt c Tx Output])
-buildTestBlock Dict st txs =
-    buildBlock eval epoch st txs (blockHash $ emptyGenesisBlock epoch)

--- a/test/Test/Oscoin/Crypto/Blockchain/Eval.hs
+++ b/test/Test/Oscoin/Crypto/Blockchain/Eval.hs
@@ -1,0 +1,122 @@
+module Test.Oscoin.Crypto.Blockchain.Eval
+    ( tests
+    ) where
+
+import           Oscoin.Prelude
+
+import           Oscoin.Crypto.Blockchain.Block
+import           Oscoin.Crypto.Blockchain.Eval
+import qualified Oscoin.Crypto.Hash as Crypto
+import           Oscoin.Time
+
+import           Codec.Serialise
+
+import           Oscoin.Test.Crypto
+import           Oscoin.Test.Crypto.Blockchain.Block.Arbitrary ()
+import           Test.QuickCheck (Arbitrary)
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+tests :: forall c. Dict (IsCrypto c) -> TestTree
+tests d = testGroup "Test.Oscoin.Crypto.Blockchain.Eval"
+    [ test_buildBlock d
+    , test_evalBlock d
+    ]
+
+test_buildBlock :: forall c. Dict (IsCrypto c) -> TestTree
+test_buildBlock d@Dict = testGroup "buildBlock"
+    [ testProperty "creates receipt for all transactions" $
+        \txs -> let (_, _, receipts) = buildTestBlock d mempty txs
+                in map receiptTx receipts === map (Crypto.hash @c) txs
+    , testProperty "receipts have block hash" $
+        \txs -> let (blk, _, receipts) = buildTestBlock d mempty txs
+                in conjoin [ receiptTxBlock receipt === blockHash blk | receipt <- receipts ]
+    , testProperty "valid transactions create new state" $
+        \txs -> let (_, s, _) = buildTestBlock d mempty txs
+                    validTxOutputs = [ output | TxOk output <- txs ]
+                in reverse validTxOutputs === s
+    , testProperty "only valid transactions are included in block" $
+        \txs -> let (blk, _, _) = buildTestBlock d mempty txs
+                    validTxs = filter txIsOk txs
+                in validTxs === toList (blockData blk)
+    , testProperty "transactions errors recorded in receipts" $
+        \txs err -> let (_, _, receipts) = buildTestBlock d mempty txsWithError
+                        txsWithError = TxErr err : txs
+                    in (receiptTxOutput <$> head receipts) === Just (Left (EvalError (show err)))
+    , testProperty "error transactions do not change block" $
+        \txs -> let validTxs = [ TxOk out | TxOk out <- txs ]
+                    (blkWithErrors, _, _) = buildTestBlock d mempty txs
+                    (blkWithoutErrors, _, _) = buildTestBlock d mempty validTxs
+                in  blockData blkWithErrors === blockData blkWithoutErrors
+    ]
+
+
+test_evalBlock :: forall c. Dict (IsCrypto c) -> TestTree
+test_evalBlock Dict = testGroup "evalBlock"
+    [ testProperty "produces the correct state" $ property $ do
+        txs <- arbitrary
+        let blk = mkBlock emptyHeader txs :: Block c Tx Unsealed
+        let expectedState = reverse [ output | TxOk output <- txs ]
+        let (newSt, _) = evalBlock evalTx [] blk
+        pure $ newSt === expectedState
+    , testProperty "includes all receipts" $ property $ do
+        txs <- arbitrary
+        let blk = mkBlock emptyHeader txs :: Block c Tx Unsealed
+        let (_, receipts) = evalBlock evalTx [] blk
+        pure $ conjoin
+            [ map receiptTx receipts === map Crypto.hash txs
+            , map receiptTxOutput receipts === map txToResult txs
+            , map receiptTxBlock receipts === map (\_ -> blockHash blk) txs
+            ]
+    ]
+
+--
+-- * Test evaluator
+--
+-- We define a test evaluator where a transaction is either an output
+-- or an error and the state is just the list of outputs starting with
+-- the most recent output.
+--
+
+type Output = Word8
+
+type St = [Output]
+
+data Tx
+    = TxOk Output
+    | TxErr Int
+    deriving (Eq, Show, Generic)
+
+txIsOk :: Tx -> Bool
+txIsOk (TxOk _)  = True
+txIsOk (TxErr _) = False
+
+txToResult :: Tx -> Either EvalError Output
+txToResult (TxOk output) = Right output
+txToResult (TxErr err)   = Left (EvalError $ show err)
+
+instance Arbitrary Tx where
+    arbitrary = txFromEither <$> arbitrary
+      where
+        txFromEither (Left err)     = TxErr err
+        txFromEither (Right output) = TxOk output
+
+instance Serialise Tx
+
+instance Crypto.HasHashing c => Crypto.Hashable c Tx where
+    hash = Crypto.hashSerial
+
+evalTx :: Evaluator St Tx Output
+evalTx (TxOk output) st = Right (output, output : st)
+evalTx (TxErr err) _    = Left (EvalError (show err))
+
+
+-- | Build block on an empty genesis block with 'eval' as defined
+-- above.
+buildTestBlock
+    :: Dict (IsCrypto c)
+    -> St
+    -> [Tx]
+    -> (Block c Tx Unsealed, St, [Receipt c Tx Output])
+buildTestBlock Dict st txs =
+    buildBlock evalTx epoch st txs (blockHash $ emptyGenesisBlock epoch)


### PR DESCRIPTION
`evalBlock` is updated to produce the new state and the receipts from block transactions. This functionality will be used by the Ledger abstraction in the future.

We also add tests for `evalBlock` and move the tests for `buildBlock` into the same module.

Finally, we eliminate the unused `evalBlockchain` functions.