### PR TITLE
Remove a bunch of 'ToJSON' and 'FromJSON' instances

### DIFF
--- a/src/Oscoin/Crypto/Blockchain/Eval.hs
+++ b/src/Oscoin/Crypto/Blockchain/Eval.hs
@@ -23,8 +23,6 @@ import           Oscoin.Time.Chrono (toNewestFirst)
 
 import           Codec.Serialise (Serialise)
 import qualified Crypto.Data.Auth.Tree.Class as AuthTree
-import           Data.Aeson
-                 (FromJSON(..), ToJSON(..), object, withObject, (.:), (.=))
 import qualified Generics.SOP as SOP
 
 
@@ -42,13 +40,6 @@ instance SOP.Generic EvalError
 instance SOP.HasDatatypeInfo EvalError
 
 instance Serialise EvalError
-
-instance ToJSON EvalError where
-    toJSON (EvalError e) = toJSON e
-
-instance FromJSON EvalError where
-    parseJSON v = EvalError <$> parseJSON v
-
 
 -- | A 'Receipt' is generated whenever a transaction is evaluated as
 -- part of a block.
@@ -71,20 +62,6 @@ mkReceipt
 mkReceipt block tx result = Receipt (Crypto.hash tx) result (blockHash block)
 
 instance (Serialise tx, Serialise (Hash c), Serialise o) => Serialise (Receipt c tx o)
-
-instance (ToJSON (Hash c), ToJSON tx, ToJSON o) => ToJSON (Receipt c tx o) where
-    toJSON Receipt{..} = object
-        [ "txHash"      .= receiptTx
-        , "txOutput"    .= receiptTxOutput
-        , "txBlockHash" .= receiptTxBlock
-        ]
-
-instance (FromJSON tx, FromJSON (Hash c), FromJSON o) => FromJSON (Receipt c tx o) where
-    parseJSON = withObject "Receipt" $ \o -> do
-        receiptTx        <- o .: "txHash"
-        receiptTxOutput  <- o .: "txOutput"
-        receiptTxBlock   <- o .: "txBlockHash"
-        pure Receipt{..}
 
 
 -- | Build a block by evaluating all the transactions and generating

--- a/src/Oscoin/Node/Mempool/Internal.hs
+++ b/src/Oscoin/Node/Mempool/Internal.hs
@@ -19,7 +19,6 @@ import           Oscoin.Crypto.Hash (Hash)
 import qualified Oscoin.Crypto.Hash as Crypto
 
 import           Codec.Serialise (Serialise(..))
-import qualified Data.Aeson as Aeson
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 
@@ -37,9 +36,6 @@ deriving instance Ord (Hash c) => Monoid (Mempool c tx)
 instance (Ord (Hash c), Serialise tx, Serialise (Hash c)) => Serialise (Mempool c tx) where
     encode (Mempool txs) = encode (Map.elems txs)
     decode               = Mempool <$> decode
-
-instance Aeson.ToJSON tx => Aeson.ToJSON (Mempool c tx) where
-    toJSON (Mempool txs) = Aeson.toJSON $ Map.elems txs
 
 -- | Lookup a transaction in a mempool.
 lookup :: Ord (Hash c) => Crypto.Hashed c tx -> Mempool c tx -> Maybe tx

--- a/src/Oscoin/P2P/Types.hs
+++ b/src/Oscoin/P2P/Types.hs
@@ -60,7 +60,6 @@ import qualified Codec.Serialise.Decoding as CBOR
 import qualified Codec.Serialise.Encoding as CBOR
 import           Control.Monad.Fail (fail)
 import           Control.Monad.Trans.Writer (execWriterT, tell)
-import           Data.Aeson (FromJSON, ToJSON)
 import           Data.Char (isAlphaNum)
 import           Data.Hashable (Hashable(..))
 import           Data.IP (IP(..))
@@ -166,10 +165,7 @@ fromPhysicalNetwork = \case
 newtype NodeId c = NodeId { fromNodeId :: PublicKey c }
     deriving (Generic)
 
-deriving instance Show (PublicKey c)     => Show (NodeId c)
-deriving instance FromJSON (PublicKey c) => FromJSON (NodeId c)
-deriving instance ToJSON (PublicKey c)   => ToJSON (NodeId c)
-
+deriving instance Show (PublicKey c) => Show (NodeId c)
 deriving instance Eq (PublicKey c)  => Eq (NodeId c)
 deriving instance Ord (PublicKey c) => Ord (NodeId c)
 

--- a/test/Oscoin/Test/API/HTTP.hs
+++ b/test/Oscoin/Test/API/HTTP.hs
@@ -10,14 +10,13 @@ import           Oscoin.Crypto.Blockchain.Block
 import           Oscoin.Crypto.Hash (Hashed)
 import qualified Oscoin.Crypto.Hash as Crypto
 import qualified Oscoin.Crypto.PubKey as Crypto
-import           Oscoin.Data.Tx (txPubKey, verifyTx)
+import           Oscoin.Data.Tx (txPubKey)
 import           Oscoin.Test.Crypto.Blockchain.Generators
 import           Oscoin.Test.Data.Rad.Arbitrary ()
 import           Oscoin.Test.Data.Tx.Arbitrary ()
 import           Oscoin.Test.HTTP.Helpers
 import           Oscoin.Time.Chrono (toNewestFirst)
 
-import qualified Data.Aeson as Aeson
 import           Data.Default (def)
 
 import           Network.HTTP.Types.Status
@@ -31,7 +30,6 @@ import           Test.Tasty.QuickCheck
 tests :: forall c. Dict (IsCrypto c) -> [TestTree]
 tests Dict =
     [ test "Smoke test" (smokeTestOscoinAPI @c)
-    , testProperty "JSON encoding of Tx" (encodeDecodeTx @c)
     , testGroup "POST /transactions"
         [ testGroup "400 Bad Request"
             [ test "Invalid signature" (postTransactionWithInvalidSignature @c)]
@@ -147,7 +145,3 @@ getBestChain = do
         get "/blockchain/best" >>=
             assertStatus ok200 <>
             assertResultOK (take 3 . toNewestFirst $ blocks chain)
-
-encodeDecodeTx :: IsCrypto c => API.RadTx c -> Property
-encodeDecodeTx tx =
-    (Aeson.eitherDecode . Aeson.encode) tx === Right tx .&&. verifyTx tx


### PR DESCRIPTION
Remove a bunch of 'ToJSON' and 'FromJSON' that are not needed anymore due to #481. This does not remove all the instances quite yet.