### PR TITLE
Introduce 'Ledger' for Node, Miner, and tests

### DIFF
--- a/src/Oscoin/API/HTTP/Handlers.hs
+++ b/src/Oscoin/API/HTTP/Handlers.hs
@@ -120,12 +120,12 @@ getBlock h = do
         Nothing ->
             respond notFound404 $ errBody "Block not found"
 
-getStatePath :: Text -> ApiAction c s i ()
+getStatePath :: (Crypto.HasHashing c, Serialise (BlockHash c), Serialise (Crypto.PublicKey c), Serialise (Crypto.Signature c)) => Text -> ApiAction c s i ()
 getStatePath _chain = do
     path <- listParam "q"
     result' <- node $ Node.getPathLatest path
     case result' of
-        Just (_sh, val) ->
+        Just val ->
             respond ok200 (Ok val)
         Nothing ->
             respond notFound404 $ errBody "Value not found"

--- a/src/Oscoin/Crypto/Blockchain/Eval.hs
+++ b/src/Oscoin/Crypto/Blockchain/Eval.hs
@@ -9,6 +9,7 @@ module Oscoin.Crypto.Blockchain.Eval
     , buildBlockStrict
     , buildGenesis
     , evalBlock
+    , evalTraverse
     ) where
 
 import           Oscoin.Prelude

--- a/src/Oscoin/Storage/Ledger.hs
+++ b/src/Oscoin/Storage/Ledger.hs
@@ -1,0 +1,257 @@
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | A 'Ledger' provides access the states and receipts associated with
+-- blocks in a 'BlockStoreReader'.
+--
+-- This module should be imported qualified.
+module Oscoin.Storage.Ledger
+    ( Ledger
+    , hoist
+    , mkLedger
+    , newFromBlockStoreIO
+
+    , blockStoreReader
+    , getBlocksByDepth
+    , getTipWithState
+    , getTip
+    , lookupState
+    , lookupReceipt
+
+    , buildNextBlock
+    ) where
+
+import           Oscoin.Prelude
+
+import           Oscoin.Crypto.Blockchain
+import           Oscoin.Crypto.Blockchain.Eval
+import qualified Oscoin.Crypto.Hash as Crypto
+import           Oscoin.Storage.Block.Abstract (BlockStoreReader)
+import qualified Oscoin.Storage.Block.Abstract as BlockStore
+import           Oscoin.Storage.HashStore
+import qualified Oscoin.Storage.Receipt as ReceiptStore
+import qualified Oscoin.Time.Chrono as Chrono
+
+import           Codec.Serialise (Serialise)
+import           Control.Monad.Trans.Maybe
+import qualified Crypto.Data.Auth.Tree.Class as AuthTree
+
+-- | Errors that may be raised from the ledger's methods
+data LedgerError c
+    = StateNotInCache (BlockHash c)
+    -- ^ State for the given block is not materialized in the state
+    -- cache.
+    | BlockNotFound (BlockHash c)
+    -- ^ A block with the given hash was not found in the block store
+
+deriving instance (Crypto.HasHashing c) => Eq (LedgerError c)
+deriving instance (Show (Crypto.Hash c)) => Show (LedgerError c)
+
+data Ledger crypto seal tx output state (m :: * -> *) = Ledger
+    { ledgerBlockStoreReader :: BlockStoreReader crypto tx seal m
+    , ledgerStateStore       :: HashStore crypto state m
+    , ledgerReceiptStore     :: ReceiptStore.ReceiptStore crypto tx output m
+    , ledgerEvaluator        :: Evaluator state tx output
+    }
+
+hoist
+    :: (forall a. m a -> n a)
+    -> Ledger crypto seal tx output state m
+    -> Ledger crypto seal tx output state n
+hoist f l =
+    Ledger
+        { ledgerBlockStoreReader = BlockStore.hoistBlockStoreReader f $ ledgerBlockStoreReader l
+        , ledgerStateStore = hoistHashStore f $ ledgerStateStore l
+        , ledgerReceiptStore = ReceiptStore.hoistReceiptStore f $ ledgerReceiptStore l
+        , ledgerEvaluator = ledgerEvaluator l
+        }
+
+
+-- | Create a ledger backed by the given block store and in-memory
+-- storage of state and receipts.
+--
+-- @initialState@ is the state that the transactions of the
+-- genesisblock are applied to.
+newFromBlockStoreIO
+    :: ( MonadIO m
+       , Crypto.Hashable crypto state
+       , Crypto.Hashable crypto tx
+       )
+    => Evaluator state tx output
+    -> BlockStoreReader crypto tx seal IO
+    -> state
+    -> IO (Ledger crypto seal tx output state m)
+newFromBlockStoreIO ledgerEvaluator ledgerBlockStoreReader initialState = do
+    ledgerReceiptStore <- ReceiptStore.newReceiptStoreIO
+    ledgerStateStore <- newHashStoreIO
+    storeHashContent ledgerStateStore initialState
+
+    let ledger = Ledger{ledgerBlockStoreReader, ledgerStateStore, ledgerReceiptStore, ledgerEvaluator}
+    materialize ledger initialState
+    pure $ hoist liftIO ledger
+
+
+mkLedger
+    :: BlockStoreReader crypto tx seal m
+    -> HashStore crypto state m
+    -- ^ State store
+    -> Evaluator state tx output
+    -> ReceiptStore.ReceiptStore crypto tx output m
+    -> Ledger crypto seal tx output state m
+mkLedger ledgerBlockStoreReader ledgerStateStore ledgerEvaluator ledgerReceiptStore =
+    Ledger
+        { ledgerBlockStoreReader
+        , ledgerEvaluator
+        , ledgerStateStore
+        , ledgerReceiptStore
+        }
+
+
+-----------------------------------------------------------
+-- * Getters
+-----------------------------------------------------------
+
+blockStoreReader :: Ledger crypto seal tx output state m -> BlockStore.BlockStoreReader crypto tx seal m
+blockStoreReader = ledgerBlockStoreReader
+
+-- | Get the @depth@ most recent blocks.
+getBlocksByDepth
+    :: Ledger crypto seal tx output state m
+    -> Depth
+    -> m (Chrono.NewestFirst [] (Block crypto tx (Sealed crypto seal)))
+getBlocksByDepth ledger depth = BlockStore.getBlocksByDepth (blockStoreReader ledger) depth
+
+getTip :: Ledger crypto seal tx output state m -> m (Block crypto tx (Sealed crypto seal))
+getTip ledger = BlockStore.getTip (ledgerBlockStoreReader ledger)
+
+
+-- | Get the receipt for a given transaction contained in the
+-- blockchain.
+--
+-- Returns 'Nothing' if the transaction is not contained in the
+-- blockchain.
+--
+-- Also returns 'Nothing' if the receipt is in the blockchain but not
+-- in the receipt cache. In ther future we will generate the receipt
+-- if it is not in the cache.
+lookupReceipt
+    :: (Monad m, Crypto.Hashable crypto tx)
+    => Ledger crypto seal tx output state m
+    -> Crypto.Hashed crypto tx
+    -> m (Maybe (ReceiptStore.Receipt crypto tx output))
+lookupReceipt ledger txHash = runMaybeT $ do
+    -- Ensure that the transaction is in the block chain. Just calling
+    -- 'ReceiptStore.lookupReceipt' is not sufficient since
+    -- 'buildNextBlock' adds receipts without the block being part of
+    -- the blockchain.
+    txLookup <- MaybeT $ BlockStore.lookupTx (blockStoreReader ledger) txHash
+    block <- MaybeT $ BlockStore.lookupBlock (blockStoreReader ledger) (txBlockHash txLookup)
+    _ <- lift $ materializeBlock ledger block
+    MaybeT $ ReceiptStore.lookupReceipt (ledgerReceiptStore ledger) txHash
+
+
+-- | Get the most recent block and the associated state.
+getTipWithState
+    :: (Monad m, Crypto.Hashable crypto tx, HasCallStack)
+    => Ledger crypto seal tx output state m
+    -> m (Either (LedgerError crypto) (Block crypto tx (Sealed crypto seal), state))
+getTipWithState ledger = runExceptT $ do
+    block <- lift $ getTip ledger
+    st <- ExceptT $ materializeBlock ledger block
+    pure (block, st)
+
+
+lookupState
+    :: Ledger crypto seal tx output state m
+    -> Crypto.Hashed crypto state
+    -> m (Maybe state)
+lookupState Ledger{ledgerStateStore} stateHash = lookupHashContent ledgerStateStore stateHash
+
+
+-----------------------------------------------------------
+-- * Materialization
+-----------------------------------------------------------
+
+-- | Builds an unsealed block from a list of transactions applied to
+-- the state of the tip.
+--
+-- This uses 'Oscoin.Crypto.Blockchain.Eval' internally which means
+-- that invalid transactions are disregarded.
+--
+-- Used by 'Oscoin.Consensus.Mining.mineBlock'.
+buildNextBlock
+    :: ( Monad m
+       , Serialise tx
+       , Crypto.Hashable crypto tx
+       , Crypto.Hashable crypto state
+       , Crypto.Hashable crypto (BlockHeader crypto Unsealed)
+       , AuthTree.MerkleHash (Crypto.Hash crypto)
+       )
+    => Ledger crypto seal tx output state m
+    -> Timestamp
+    -> [tx]
+    -> m (Either (LedgerError crypto) (Block crypto tx Unsealed))
+buildNextBlock ledger time txs = runExceptT $ do
+    (currentTip, tipState) <- ExceptT $ getTipWithState ledger
+    let (newBlock, newState, receipts) = buildBlock (ledgerEvaluator ledger) time tipState txs (blockHash currentTip)
+    lift $ do
+        storeHashContent (ledgerStateStore ledger) newState
+        forM_ receipts $ ReceiptStore.storeReceipt (ledgerReceiptStore ledger)
+    pure newBlock
+
+
+-- | Computes the state and receipts associated with the given block
+-- and adds them to the storage.
+--
+-- The given state must be the state associated with the parent block
+-- of the given block.
+materializeBlockFromState
+    :: (Monad m, Crypto.Hashable crypto tx)
+    => Ledger crypto seal tx output state m
+    -> state
+    -> Block crypto tx (Sealed crypto seal)
+    -> m state
+materializeBlockFromState ledger prevState blk = do
+    let (newState, receipts) = evalBlock (ledgerEvaluator ledger) prevState blk
+    storeHashContent (ledgerStateStore ledger) newState
+    forM_ receipts (ReceiptStore.storeReceipt (ledgerReceiptStore ledger))
+    pure newState
+
+
+-- | Computes the state and receipts associated with the given block
+-- and adds them to the storage.
+--
+-- This is similar to 'materializeBlockFromState' but it looks up the
+-- parent state in the cache and materializes it recursivley if not
+-- present.
+materializeBlock
+    :: (Monad m, Crypto.Hashable crypto tx, HasCallStack)
+    => Ledger crypto seal tx output state m
+    -> Block crypto tx (Sealed crypto seal)
+    -> m (Either (LedgerError crypto) state)
+materializeBlock ledger blk = runExceptT $ do
+    maybeBlockState <- lift $ lookupHashContent (ledgerStateStore ledger) (Crypto.toHashed $ blockStateHash $ blockHeader blk)
+    case maybeBlockState of
+        Just blockState -> pure blockState
+        Nothing          -> do
+            maybeParentBlock <- lift $ BlockStore.lookupBlock (ledgerBlockStoreReader ledger) (parentHash blk)
+            parentBlock <- case maybeParentBlock of
+                Just parentBlock -> pure $ parentBlock
+                Nothing          -> throwError $ BlockNotFound $ parentHash blk
+            parentState <- ExceptT $ materializeBlock ledger parentBlock
+            lift $ materializeBlockFromState ledger parentState blk
+
+
+-- | Computes all states and receipts from the blocks in the
+-- blockchain and adds them to the storage.
+--
+-- The genesis block is applied to the given initial state
+materialize
+    :: (Monad m, Crypto.Hashable crypto tx)
+    => Ledger crypto seal tx output state m
+    -> state
+    -> m ()
+materialize ledger initialState = do
+    genesisBlock <- BlockStore.getGenesisBlock (blockStoreReader ledger)
+    allFollowingBlocks <- BlockStore.getBlocksByParentHash (blockStoreReader ledger) (blockHash genesisBlock)
+    _ <- foldlM (materializeBlockFromState ledger) initialState (genesisBlock : Chrono.toOldestFirst (Chrono.reverse allFollowingBlocks))
+    pure ()

--- a/src/Oscoin/Storage/Receipt.hs
+++ b/src/Oscoin/Storage/Receipt.hs
@@ -6,6 +6,7 @@
 -- class to obtain a receipt store.
 module Oscoin.Storage.Receipt
     ( ReceiptStore
+    , Receipt
     , storeReceipt
     , lookupReceipt
     , hoistReceiptStore

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -24,6 +24,7 @@ import qualified Test.Oscoin.Crypto.PubKey
 import qualified Test.Oscoin.Node.Mempool
 import qualified Test.Oscoin.Protocol
 import qualified Test.Oscoin.Storage.Block.Orphanage
+import qualified Test.Oscoin.Storage.Ledger
 import           Test.Tasty
 import           Test.Tasty.Ingredients.FailFast
 
@@ -49,4 +50,5 @@ main = do
         , Test.Oscoin.Node.Mempool.tests crypto
         , Test.Oscoin.Protocol.tests crypto
         , Test.Oscoin.Storage.Block.Orphanage.tests crypto
+        , Test.Oscoin.Storage.Ledger.tests crypto
         ]

--- a/test/Test/Oscoin/API.hs
+++ b/test/Test/Oscoin/API.hs
@@ -63,7 +63,7 @@ tests Dict = testGroup "Test.Oscoin.API"
                 response <- Client.run (Client.getTransaction txHash)
                 response @?= API.Err "Transaction not found"
 
-        , testCase "confirmed transaction" $ runEmptySession $ do
+        , testCase "unconfirmed transaction" $ runEmptySession $ do
             (txHash, tx) <- createValidTx @c (Rad.String "jo")
             liftNode $ Mempool.addTxs [tx]
             response <- Client.run (Client.getTransaction txHash)

--- a/test/Test/Oscoin/Storage/Ledger.hs
+++ b/test/Test/Oscoin/Storage/Ledger.hs
@@ -1,0 +1,127 @@
+module Test.Oscoin.Storage.Ledger
+    ( tests
+    ) where
+
+import           Oscoin.Prelude
+
+import           Oscoin.Crypto.Blockchain.Block
+import           Oscoin.Crypto.Blockchain.Eval
+import qualified Oscoin.Crypto.Hash as Crypto
+import qualified Oscoin.Storage.Block.Abstract as BlockStore
+import           Oscoin.Storage.Block.Memory (newBlockStoreFromGenesisIO)
+import qualified Oscoin.Storage.Ledger as Ledger
+import qualified Oscoin.Time as Time
+
+import           Codec.Serialise
+
+import           Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Gen.QuickCheck as Gen
+import qualified Hedgehog.Range as Range
+
+import           Oscoin.Test.Crypto
+import           Oscoin.Test.Crypto.Blockchain.Block.Arbitrary ()
+import           Oscoin.Test.Crypto.Blockchain.Block.Generators
+import           Test.Oscoin.DummyLedger
+import           Test.QuickCheck (Arbitrary)
+import           Test.Tasty
+import           Test.Tasty.Hedgehog
+
+type DummySeal = ()
+
+tests :: Dict (IsCrypto c) -> TestTree
+tests c = testGroup "Test.Oscoin.Storage.Ledger"
+    [ testProperty "prop_getTipWithState" $ prop_getTipWithState c
+    , testProperty "prop_lookupReceipt" $ prop_lookupReceipt c
+    , testProperty "prop_buildNextBlock" $ prop_buildNextBlock c
+    ]
+
+-- | After adding a block to the block store 'Ledger.getTipWithState'
+-- returns the added block and the evaluated state.
+prop_getTipWithState :: forall c. Dict (IsCrypto c) -> Property
+prop_getTipWithState Dict = property $ do
+    (ledger, blockStoreWriter) <- newDummyLedger @c
+    (parentBlock, parentState) <- evalEither =<< Ledger.getTipWithState ledger
+    (blk, st) <- forAll $ genEvaledBlock parentBlock parentState dummyEval
+    BlockStore.insertBlock blockStoreWriter blk
+    result <- Ledger.getTipWithState ledger
+    result === Right (blk, st)
+
+
+-- | After adding a block to the block store 'Ledger.lookupReceipt' returns the
+-- receipts for transactions in the block
+prop_lookupReceipt :: forall c. Dict (IsCrypto c) -> Property
+prop_lookupReceipt Dict = property $ do
+    (ledger, blockStoreWriter) <- newDummyLedger @c
+    (parentBlock, parentState) <- evalEither =<< Ledger.getTipWithState ledger
+    (blk, _) <- forAll $ genEvaledBlock parentBlock parentState dummyEval
+    BlockStore.insertBlock blockStoreWriter blk
+    tx <- forAll $ Gen.element (toList $ blockData blk)
+    maybeReceipt <- Ledger.lookupReceipt ledger (Crypto.hash tx)
+    receipt <- case maybeReceipt of
+        Nothing      -> failure
+        Just receipt -> pure receipt
+
+    receiptTx receipt === Crypto.hash tx
+    receiptTxBlock receipt === blockHash blk
+    receiptTxOutput receipt === Right tx
+
+
+-- Checks that a block created with 'Ledger.buildNextBlock' satisfies
+-- the following properties:
+--
+-- * The block includes the proposed transactions
+-- * The state hash is correctly computed
+-- * The 'parentHash' of the block points to the tip of the blockchain.
+--
+prop_buildNextBlock :: forall c. Dict (IsCrypto c) -> Property
+prop_buildNextBlock Dict = property $ do
+    (ledger, _) <- newDummyLedger @c
+    (parentBlock, parentState) <- evalEither =<< Ledger.getTipWithState ledger
+    txs <- forAll $ Gen.list (Range.linear 1 6) Gen.arbitrary
+    timestamp <- forAll $ Gen.arbitrary
+    nextBlock <- evalEither =<< Ledger.buildNextBlock ledger timestamp txs
+
+    let (_, expectedState) = evalTraverse dummyEval txs parentState
+    toList (blockData nextBlock) === txs
+    blockStateHash (blockHeader nextBlock) === Crypto.fromHashed (Crypto.hash expectedState)
+    parentHash nextBlock === blockHash parentBlock
+
+
+-- | Creates a new 'Ledger' and 'BlockStoreWriter' pair with a single
+-- genesis block already in the block store.
+newDummyLedger
+    :: (IsCrypto crypto, MonadIO m)
+    => m
+        ( Ledger.Ledger crypto DummySeal DummyTx DummyOutput DummyState m
+        , BlockStore.BlockStoreWriter crypto DummyTx DummySeal m
+        )
+newDummyLedger = do
+    (blockStoreReader, blockStoreWriter) <- liftIO $ newBlockStoreFromGenesisIO genesisBlk
+    ledger <- liftIO $ Ledger.newFromBlockStoreIO dummyEval blockStoreReader genesisState
+    pure (ledger, BlockStore.hoistBlockStoreWriter liftIO blockStoreWriter)
+  where
+    genesisState = [] :: [DummyTx]
+    genesisBlk = sealBlock () $ emptyGenesisFromState Time.epoch genesisState
+
+
+-- | Generate an arbitrary child block with arbitrary transactions and
+-- with a correct state hash.
+genEvaledBlock
+    :: ( IsCrypto c
+       , Crypto.Hashable c state
+       , MonadGen m
+       , Serialise s
+       , Serialise tx
+       , Arbitrary s
+       , Arbitrary tx
+       )
+    => Block c tx s
+    -> state
+    -> Evaluator state tx output
+    -> m (Block c tx s, state)
+genEvaledBlock parentBlock parentState evl = do
+    txs <- Gen.list (Range.linear 1 6) Gen.arbitrary
+    let (_, newState) = evalTraverse evl txs parentState
+    newBlock <- Gen.quickcheck $ genBlockWith parentBlock txs newState
+    pure (newBlock, newState)


### PR DESCRIPTION
We introduce the `Ledger` abstraction which wraps the block store, state store, and receipt store. The purpose of the `Ledger` is to provide consistent access to block artifacts (states and receipts). This commit only integrates the ledger with `Oscoin.Node`, `Oscoin.Consensus.Mining`, and the `Oscoin.Test.Consensus.Nakamoto`. It remains to integrate the ledger with `Protocol` where it will replace the `BlockStore`.

 Todo

 - [x] ~~Test and document `Ledger` constructors~~ Will do in a follow-up PR