### PR TITLE
Sized blockchain generators with reduced length

### DIFF
--- a/test/Oscoin/Test/Storage/Block/Equivalence.hs
+++ b/test/Oscoin/Test/Storage/Block/Equivalence.hs
@@ -56,7 +56,7 @@ classifyChain chain =
 -- and get the tip, and that both stores agree on the result.
 propInsertGetTipEquivalence :: forall c.  Dict (IsCrypto c) -> Property
 propInsertGetTipEquivalence Dict =
-    forAllShrink (resize 25 $ genBlockchainFrom (defaultGenesis @c)) genericShrink $ \chain ->
+    forAllShrink (genBlockchainFrom (defaultGenesis @c)) genericShrink $ \chain ->
         classifyChain chain $
             ioProperty $ withStores $ \stores -> do
                 p1 <- privateApiCheck stores (`Abstract.insertBlocksNaive` (Chrono.reverse . blocks) chain)
@@ -74,7 +74,7 @@ propForksInsertGetTipEquivalence Dict = do
     let forkParams = ForkParams 0 10 3  -- 3 forks of max 10 blocks.
         orphanage  = emptyOrphanage blockScore
         generator = do
-            chain <- resize 15 $ genBlockchainFrom (defaultGenesis @c)
+            chain <- genBlockchainFrom (defaultGenesis @c)
             orph  <- genOrphanChainsFrom forkParams chain
             pure (chain, orph)
     forAll generator $ \(chain, orphansWithLink) ->

--- a/test/Test/Oscoin/Storage/Block/Orphanage.hs
+++ b/test/Test/Oscoin/Storage/Block/Orphanage.hs
@@ -17,7 +17,6 @@ import           Oscoin.Time.Chrono (reverse, toNewestFirst)
 
 import           Oscoin.Test.Crypto
 import           Oscoin.Test.Crypto.Blockchain.Generators
-                 (ForkParams(..), genBlockchainFrom, genOrphanChainsFrom)
 import           Oscoin.Test.Util (Condensed(..))
 
 import           Data.ByteArray.Orphans ()
@@ -107,7 +106,7 @@ propSelectBestCandidateMultipleChoice Dict = property $ do
 
 propSelectBestCandidateComplex :: forall c. Dict (IsCrypto c) -> Property
 propSelectBestCandidateComplex Dict = property $ do
-    initialChain <- resize 15 $ genBlockchainFrom (defaultGenesis @c)
+    initialChain <- genBlockchainFrom (defaultGenesis @c)
     let forkParams = ForkParams 0 10 10  -- 10 fork of max 10 blocks.
     chains <- genOrphanChainsFrom forkParams initialChain
     orphanage <-


### PR DESCRIPTION
We change the blockchain generator so that
* the length of the blockchain is arbitrary instead of fixed by the size
* the length of the generated blockchain is limited to 15.

Since generating blockchains is expensive limiting the size speeds up the tests by about 15%.