### PR TITLE
Add the height to the block header (Part I)

### DIFF
--- a/data/blockstore.sql
+++ b/data/blockstore.sql
@@ -4,6 +4,7 @@
 
 CREATE TABLE IF NOT EXISTS "blocks" (
   "hash"          char(64)      UNIQUE NOT NULL PRIMARY KEY,
+  "height"        integer       UNIQUE NOT NULL,
   "parenthash"    char(64)      UNIQUE,
   "datahash"      char(64)      NOT NULL,
   "statehash"     char(64)      NOT NULL,
@@ -18,6 +19,8 @@ CREATE TABLE IF NOT EXISTS "blocks" (
   FOREIGN KEY ("parenthash")
     REFERENCES blocks ("hash")
 );
+
+CREATE UNIQUE INDEX IF NOT EXISTS block_height_ix ON blocks(height);
 
 CREATE TABLE IF NOT EXISTS "transactions" (
   "hash"       char(64)      NOT NULL PRIMARY KEY,

--- a/data/genesis.yaml
+++ b/data/genesis.yaml
@@ -1,10 +1,11 @@
-hash: 2Drjgb71K6GBgwozNFndEAoFjE3nZEJiTyngPxrdK449dhDoGY
+hash: 2DrjgbCd1rxCgmw24kS8YxJeR9esBPCQdDZ3i29gWRwUt7Vkbw
 data: []
 header:
+  height: 0
   dataHash: 2Drjgb4FtifQz3pNjpYitXQVQXvVG3WBeub54JJnq438GFasNF
   targetDifficulty: ffff0021
   stateHash: 2DrjgbJVAd2Q9WQVZT1Vtam2hCNGZSefi5DwPJNbSaxWmuUypo
   seal: 0
-  timestamp: 1555593388744402434
+  timestamp: 1556090695611683221
   parentHash: 2Drjgb4FtifQz3pNjpYitXQVQXvVG3WBeub54JJnq438GFasNF
 

--- a/src/Database/SQLite/Simple/Orphans.hs
+++ b/src/Database/SQLite/Simple/Orphans.hs
@@ -31,7 +31,8 @@ instance ( Crypto.HasHashing c
          , FromField s
          ) => FromRow (BlockHeader c s) where
     fromRow = BlockHeader
-        <$> fieldWith fromPrevHashField
+        <$> field
+        <*> fieldWith fromPrevHashField
         <*> field
         <*> field
         <*> field

--- a/src/Oscoin/Storage/Block/SQLite.hs
+++ b/src/Oscoin/Storage/Block/SQLite.hs
@@ -80,7 +80,7 @@ lookupBlock
 lookupBlock Handle{hConn} h = runTransaction hConn $ do
     conn <- ask
     result :: Maybe (BlockHeader c (Sealed c s)) <- listToMaybe <$> liftIO (Sql.query conn
-        [sql| SELECT parenthash, datahash, statehash, timestamp, difficulty, seal
+        [sql| SELECT height, parenthash, datahash, statehash, timestamp, difficulty, seal
                 FROM blocks
                WHERE hash = ? |] (Only h))
 

--- a/src/Oscoin/Storage/Ledger.hs
+++ b/src/Oscoin/Storage/Ledger.hs
@@ -192,7 +192,8 @@ buildNextBlock
     -> m (Either (LedgerError crypto) (Block crypto tx Unsealed))
 buildNextBlock ledger time txs = runExceptT $ do
     (currentTip, tipState) <- ExceptT $ getTipWithState ledger
-    let (newBlock, newState, receipts) = buildBlock (ledgerEvaluator ledger) time tipState txs (blockHash currentTip)
+    let (newBlock, newState, receipts) =
+            buildBlock (ledgerEvaluator ledger) time tipState txs currentTip
     lift $ do
         storeHashContent (ledgerStateStore ledger) newState
         forM_ receipts $ ReceiptStore.storeReceipt (ledgerReceiptStore ledger)

--- a/test/Oscoin/Test/Crypto/Blockchain/Block/Generators.hs
+++ b/test/Oscoin/Test/Crypto/Blockchain/Block/Generators.hs
@@ -116,7 +116,8 @@ genBlockWith parentBlock txs st = do
     blockSeal  <- arbitrary
     blockDiffi <- genDifficultyFrom (blockTargetDifficulty prevHeader)
     let header = (emptyHeader :: BlockHeader c Unsealed)
-               { blockPrevHash         = headerHash prevHeader
+               { blockHeight           = succ . blockHeight $ prevHeader
+               , blockPrevHash         = headerHash prevHeader
                , blockDataHash         = hashTxs txs
                , blockStateHash        = hashState st
                , blockSeal

--- a/test/Test/Oscoin/Crypto/Blockchain/Eval.hs
+++ b/test/Test/Oscoin/Crypto/Blockchain/Eval.hs
@@ -119,4 +119,4 @@ buildTestBlock
     -> [Tx]
     -> (Block c Tx Unsealed, St, [Receipt c Tx Output])
 buildTestBlock Dict st txs =
-    buildBlock evalTx epoch st txs (blockHash $ emptyGenesisBlock epoch)
+    buildBlock evalTx epoch st txs (emptyGenesisBlock epoch)


### PR DESCRIPTION
This is a stepping stone in fixing #497.

This has to be considered "Part I" as it adds the height to the `BlockHeader` but it doesn't reap the benefits out of it (i.e. we can simplify and speed some of our SQLite queries as we now have an index on the `height` field).

I have decided, for review purposes, to include that in a subsequent PR (branching off either from this or from `master` if this PR ends up being merged quickly).