### PR TITLE
Modify SQLite.Internal queries to use the height

### DIFF
--- a/src/Oscoin/Storage/Block/SQLite/Internal.hs
+++ b/src/Oscoin/Storage/Block/SQLite/Internal.hs
@@ -171,7 +171,7 @@ storeBlock Handle{..} blk = runTransaction hConn $ do
   where
     extendsTip :: Block c tx (Sealed c s) -> Bool
     extendsTip currentTip =
-        (blockHash currentTip            == parentHash blk) &&
+        (blockHash currentTip              == parentHash blk) &&
         ((blockHeight . blockHeader $ blk) == (succ . blockHeight . blockHeader $ currentTip))
 
 

--- a/test/Oscoin/Test/Storage/Block/SQLite/Whitebox.hs
+++ b/test/Oscoin/Test/Storage/Block/SQLite/Whitebox.hs
@@ -66,5 +66,7 @@ testIsConflicting (blk, blk') h@Handle{..} = do
     result <- runTransaction hConn $ isConflicting blk'
     result @?= True
 
+    -- Linking parents doesn't affect the height, so the block is still
+    -- considered as conflicting with a previously-stored one.
     result' <- runTransaction hConn $ isConflicting (linkParent blk blk')
-    result' @?= False
+    result' @?= True


### PR DESCRIPTION
This PR builds on top of #514 . It replaces most if not all the usages of `timestamp` in our SQLite queries with `height`. When not strictly necessary, I suspect it might help making things consistent on the long run (plus, there is an index on the `height`, which might speed up some queries in some circumstances).