### PR TITLE
GCE discovery

### DIFF
--- a/exe/node/Main.hs
+++ b/exe/node/Main.hs
@@ -116,10 +116,11 @@ main = do
                     instr :: HasCallStack => P2P.Disco.DiscoEvent -> IO ()
                     instr = Telemetry.emit telemetry . Telemetry.DiscoEvent
                  in
-                    P2P.Disco.withDisco instr optDiscovery' $ Set.fromList
-                        [ MDns.Service "gossip" MDns.TCP optHost optGossipPort
-                        , MDns.Service "http"   MDns.TCP optHost optApiPort
-                        ]
+                    P2P.Disco.withDisco instr optDiscovery' optGossipPort $
+                        Set.fromList
+                            [ MDns.Service "gossip" MDns.TCP optHost optGossipPort
+                            , MDns.Service "http"   MDns.TCP optHost optApiPort
+                            ]
 
             seeds  <- liftIO disco
             gossip <- managed $

--- a/package.yaml
+++ b/package.yaml
@@ -48,6 +48,8 @@ library:
     - filepath
     - formatting
     - generics-sop
+    - gogol
+    - gogol-compute
     - gossip
     - hashable
     - hostname
@@ -79,6 +81,8 @@ library:
     - stm >=2.4.5.0
     - text
     - transformers
+    - unliftio-core
+    - unordered-containers
     - vector
     - wai
     - wai-middleware-static

--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -3,6 +3,9 @@ resolver: lts-13.16
 
 packages:
 - github-0.20
+- gogol-0.4.0@sha256:c2065fa419553781b7f972e3ec9f14e74df2c8ff2f1edf1151c7297f2c8a0729
+- gogol-compute-0.4.0@sha256:ffab3f609a8f8e71d079f6a625d37dd95a79a2de0ec7189f819e4f256ba9143f
+- gogol-core-0.4.0@sha256:764a6648535bf2e248c220fe85d4d63fa4c21f896e7f0e23322b2bb8cc3e81c6
 - hedgehog-quickcheck-0.1@sha256:03bb3c3cb1301d6ad0a6dae13b7bac3d547e82c555bb43b11bf83098d4a4ef22
 - tasty-fail-fast-0.0.3@sha256:0a5a850d7fb5aecb9058d847fa1e634357c2b83bad4b31e41ed1ba6c2d2f1828
 - tasty-hedgehog-0.2.0.0@sha256:83a8b777fa472040979e44dba43c32441f55d5ddb9641a4d53deee4b0e09fa34

--- a/src/Oscoin/P2P/Disco/GCE.hs
+++ b/src/Oscoin/P2P/Disco/GCE.hs
@@ -1,0 +1,123 @@
+{-# LANGUAGE DataKinds #-}
+
+module Oscoin.P2P.Disco.GCE where
+
+import           Oscoin.Prelude
+
+import           Oscoin.P2P.Types (Network, renderNetwork)
+
+import           Control.Monad.IO.Unlift (MonadUnliftIO)
+import           Data.HashMap.Strict (HashMap)
+import qualified Data.HashMap.Strict as Map
+import           Data.IP (IP)
+import qualified Data.Set as Set
+import qualified Data.Text as T
+import           Data.Text.Read as T
+import           Lens.Micro
+                 ( Getting
+                 , each
+                 , filtered
+                 , set
+                 , to
+                 , toListOf
+                 , traversed
+                 , (^?)
+                 , _Just
+                 )
+import           Lens.Micro.Extras (view)
+import           Network.Google
+                 (AllowScopes, Env, HasScope, runGoogle, runResourceT, send)
+import           Network.Google.Compute
+                 ( Instance
+                 , InstanceAggregatedList
+                 , InstancesAggregatedList
+                 , NetworkInterface
+                 , i1Labels
+                 , i1NetworkInterfaces
+                 , ialItems
+                 , ialaFilter
+                 , ialiAddtional
+                 , ilAddtional
+                 , instancesAggregatedList
+                 , islInstances
+                 , niNetwork
+                 , niNetworkIP
+                 )
+import           Network.Socket (PortNumber)
+
+-- | Look up GCE instances as gossip peers.
+--
+-- The instances are filtered by the given labels. Each instance must be on the
+-- VPC denoted by 'Network', which is determined by:
+--
+-- * filtering by a "network" label with a value of 'Network'
+-- * considering only the NIC(s) of instances with a matching 'niNetwork'
+--
+-- Instances may advertise their bound ports via labels.
+--
+lookup
+    :: ( MonadUnliftIO m
+       , AllowScopes s
+       , HasScope    s InstancesAggregatedList
+       )
+    => Text              -- ^ Project ID
+    -> HashMap Text Text -- ^ Labels
+    -> Text              -- ^ Label to consider for obtaining 'PortNumber'
+    -> Network
+    -> Env s
+    -> m (Set (IP, Maybe PortNumber))
+lookup proj labels portLabel (renderNetwork -> net) r =
+    runResourceT . runGoogle r $ do
+        instances <- toListOf inst <$> send (mkRq proj)
+        pure . Set.fromList . flip concatMap instances $ \i ->
+            let
+                iport = firstOf  (port . traversed) i
+                addrs = toListOf addr               i
+             in
+                zip addrs (repeat iport)
+  where
+    -- morally. microlens is just .. too micro
+    firstOf = flip (^?)
+
+    filters :: Text
+    filters =
+          mconcat
+        . intersperse " AND "
+        . map (\(k, v) -> "(labels." <> k <> " = " <> v <> ")")
+        . Map.toList
+        . Map.insert "network" net
+        $ labels
+
+    mkRq :: Text -> InstancesAggregatedList
+    mkRq = set ialaFilter (Just filters) . instancesAggregatedList
+
+    inst :: Monoid r => Getting r InstanceAggregatedList Instance
+    inst =
+          ialItems . _Just
+        . ialiAddtional
+        . traversed . islInstances . traversed
+
+    addr :: Monoid r => Getting r Instance IP
+    addr =
+          i1NetworkInterfaces
+        . each . filtered inVPC
+        . niNetworkIP . _Just
+        . to (readMaybe . T.unpack) . _Just
+
+    port :: Monoid r => Getting r Instance (Maybe PortNumber)
+    port =
+          i1Labels . _Just
+        . ilAddtional
+        . to portFromLabels
+
+    inVPC :: NetworkInterface -> Bool
+    inVPC nic =
+        case view niNetwork nic of
+            Nothing -> False
+            Just  n -> net `T.isSuffixOf` n
+
+    portFromLabels :: HashMap Text Text -> Maybe PortNumber
+    portFromLabels =
+          map (fromIntegral @Word16 . fst)
+        . (>>= hush . T.decimal)
+        . Map.lookup portLabel

--- a/src/Oscoin/P2P/Disco/Options.hs
+++ b/src/Oscoin/P2P/Disco/Options.hs
@@ -36,6 +36,7 @@ data Options network = Options
     , optSeeds      :: [SeedAddr Crypto]
     , optSDDomains  :: [HostName]
     , optEnableMDns :: Bool
+    , optEnableGCE  :: Bool
     , optNameserver :: Maybe (HostName, PortNumber) -- only for testing currently
     }
 
@@ -140,5 +141,9 @@ discoParser = Options
     <*> switch
         ( long "enable-mdns"
        <> help "Enable mDNS discovery"
+        )
+    <*> switch
+        ( long "enable-gce-sd"
+       <> help "Enable instance discovery on Google Compute Engine"
         )
     <*> pure Nothing

--- a/test/Test/Oscoin/P2P/Disco.hs
+++ b/test/Test/Oscoin/P2P/Disco.hs
@@ -71,12 +71,13 @@ runPropMulticast net =
              , optSeeds      = []
              , optSDDomains  = []
              , optEnableMDns = True
+             , optEnableGCE  = False
              , optNameserver = Nothing
              }
      in
-        withDisco noTracing opts (srvs 6942) $ \resolve0 ->
-        withDisco noTracing opts (srvs 4269) $ \resolve1 ->
-        withDisco noTracing opts (srvs 6666) $ \resolve2 ->
+        withDisco noTracing opts 6942 (srvs 6942) $ \resolve0 ->
+        withDisco noTracing opts 4269 (srvs 4269) $ \resolve1 ->
+        withDisco noTracing opts 6666 (srvs 6666) $ \resolve2 ->
             (,,) <$> retry resolve0
                  <*> retry resolve1
                  <*> retry resolve2
@@ -100,6 +101,7 @@ prop_staticPeers = withTests 1 . property $ do
                      , optSeeds      = seeds
                      , optSDDomains  = []
                      , optEnableMDns = False
+                     , optEnableGCE  = False
                      , optNameserver = Just ("127.0.0.1", port)
                      }
              in
@@ -135,6 +137,7 @@ prop_dnsSD = withTests 1 . property $ do
                      , optSeeds      = []
                      , optSDDomains  = ["svc.cluster.local"]
                      , optEnableMDns = False
+                     , optEnableGCE  = False
                      , optNameserver = Just ("127.0.0.1", port)
                      }
              in
@@ -166,7 +169,7 @@ haveIPv6 = do
 
 
 runDisco :: Options Network -> Set MDns.Service -> IO (Set SockAddr)
-runDisco opts srvs = withDisco (const $ pure ()) opts srvs identity
+runDisco opts srvs = withDisco (const $ pure ()) opts 6942 srvs identity
 
 runNameserver :: (PortNumber -> IO a) -> IO a
 runNameserver k =


### PR DESCRIPTION
Discovery of peers when running on GCE, using `compute.instances.aggregatedList`.

This is part of the grander plan to go with plain (container) instances vs. some ~~security and configuration management nightmare~~ scheduling system. Note that the utility (and necessity) is limited to the "devnet" environment, which will feature a relatively small number of instances, and high churn (continuous deployment, developer ad-hoc deployments). "Testnet" and beyond is expected to have a (mostly) stable set of seed nodes deployed as a separate instance group, so DNS discovery is less of a configuration management concern.

Pro tip: if you install the `btc` GHC plugin, you may be able to earn a block reward for compiling `gogol-compute`.

**Alternatives considered**

* Make instances "register" themselves with DNS on boot

   Requires coordination

* Create DNS RRs post-deployment

    More complex deployment (wait until instances are assigned network addresses), prevents autoscaling deployments

* Run a service which maintains DNS RRs

    Hard to justify for devnet, more complex deployment

* Sidecar init container which performs the lookup using a combination of `bash` and `gcloud` and writes some config or environment file

    Please. 