### PR TITLE
Allow instrumentation of pure code (Trace & Probes)

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -30,6 +30,7 @@ library:
     - binary
     - bytestring
     - cacophony >= 0.10.1
+    - comonad
     - cborg
     - clock
     - conduit

--- a/src/Oscoin/CLI/Command.hs
+++ b/src/Oscoin/CLI/Command.hs
@@ -17,6 +17,7 @@ import qualified Oscoin.Crypto.Hash as Crypto
 import qualified Oscoin.Crypto.PubKey as Crypto
 import qualified Oscoin.Data.OscoinTx as OscoinTx
 import           Oscoin.Data.Tx
+import qualified Oscoin.Telemetry as Telemetry
 import           Oscoin.Time (Timestamp)
 
 import           Codec.Serialise (Serialise)
@@ -108,7 +109,7 @@ printGenesisYaml txs diffi = do
             pure $ ResultError (fromEvalError err)
         Right blk -> do
             result <- mineGenesis
-                (mineNakamoto (const diffi)) blk
+                (mineNakamoto (Telemetry.probed Telemetry.noProbe) (const (pure diffi))) blk
 
             case result of
                 Left err  ->

--- a/src/Oscoin/Consensus/Nakamoto.hs
+++ b/src/Oscoin/Consensus/Nakamoto.hs
@@ -67,7 +67,7 @@ nakamotoConsensus
        , Monad m
        , Serialise tx
        )
-    => (forall a. Telemetry.Traced a -> m a)
+    => Telemetry.Tracer m
     -> Consensus c tx PoW m
 nakamotoConsensus probed = Consensus
     { cScore = comparing chainScore
@@ -132,7 +132,7 @@ mineNakamoto
        , Hashable c (BlockHeader c (Sealed c PoW))
        , Hashable c (BlockHeader c Unsealed)
        )
-    => (forall a. Telemetry.Traced a -> m a)
+    => Telemetry.Tracer m
     -> (forall tx. [Block c tx (Sealed c PoW)] -> Telemetry.Traced Difficulty)
     -> Miner c PoW m
 mineNakamoto probed difiFn getBlocks unsealedBlock = do

--- a/src/Oscoin/Consensus/Nakamoto.hs
+++ b/src/Oscoin/Consensus/Nakamoto.hs
@@ -23,8 +23,8 @@ import           Oscoin.Consensus.Validation
 import           Oscoin.Crypto.Blockchain
 import           Oscoin.Crypto.Blockchain.Block (Difficulty(..))
 import           Oscoin.Crypto.Hash (Hash, Hashable)
+import           Oscoin.Telemetry (NotableEvent(..), extract)
 import qualified Oscoin.Telemetry as Telemetry
-import           Oscoin.Telemetry.Events
 import           Oscoin.Time
 
 import           Codec.Serialise (Serialise)
@@ -88,7 +88,7 @@ validateFull [] blk =
 validateFull prefix@(parent:_) blk = runExcept $ do
     validateHeight     parent blk
     validateParentHash parent blk
-    validateDifficulty (Telemetry.tracing_ . chainDifficulty) prefix blk
+    validateDifficulty (extract . chainDifficulty) prefix blk
     validateTimestamp  parent blk
     validateBlockAge
     liftEither (validateBasic blk)

--- a/src/Oscoin/Consensus/Nakamoto/Lenient.hs
+++ b/src/Oscoin/Consensus/Nakamoto/Lenient.hs
@@ -28,6 +28,7 @@ import           Oscoin.Crypto.Blockchain
 import           Oscoin.Crypto.Hash (Hash, Hashable)
 import           Oscoin.Node.Mempool.Class
 import qualified Oscoin.Node.Mempool.Class as Mempool
+import           Oscoin.Telemetry (extract)
 import qualified Oscoin.Telemetry as Telemetry
 import           Oscoin.Time (Duration)
 
@@ -71,7 +72,7 @@ validateLenient [] blk =
 validateLenient prefix@(parent:_) blk = runExcept $ do
     validateHeight     parent blk
     validateParentHash parent blk
-    validateDifficulty (Telemetry.tracing_ . chainDifficulty) prefix blk
+    validateDifficulty (extract . chainDifficulty) prefix blk
     validateTimestamp  parent blk
     liftEither (validateBasic blk)
 

--- a/src/Oscoin/Consensus/Nakamoto/Lenient.hs
+++ b/src/Oscoin/Consensus/Nakamoto/Lenient.hs
@@ -49,7 +49,7 @@ nakamotoConsensusLenient
        , Hashable c (BlockHeader c (Sealed c PoW))
        , Hashable c (BlockHeader c Unsealed)
        )
-    => (forall a. Telemetry.Traced a -> m a)
+    => Telemetry.Tracer m
     -> Duration -- ^ Block time lower bound (see 'mineLenient')
     -> Consensus c tx PoW m
 nakamotoConsensusLenient probed blkTimeLower =

--- a/src/Oscoin/Telemetry/Events.hs
+++ b/src/Oscoin/Telemetry/Events.hs
@@ -5,6 +5,7 @@ module Oscoin.Telemetry.Events
 import           Oscoin.Prelude
 
 import qualified Oscoin.Consensus.Types as Consensus
+import           Oscoin.Crypto.Blockchain.Block.Difficulty (Difficulty)
 import qualified Oscoin.Crypto.Blockchain.Eval as Eval
 import           Oscoin.Crypto.Hash (HasHashing, Hash, Hashable, Hashed)
 import           Oscoin.Crypto.PubKey (PublicKey)
@@ -61,6 +62,11 @@ data NotableEvent where
                                => Hash c
                                -> Eval.EvalError
                                -> NotableEvent
+    -- | Triggered when the 'Difficulty' is adjusted. The first argument is
+    -- the new difficulty, the second the (now) previous one.
+    DifficultyAdjustedEvent :: Difficulty
+                            -> Difficulty
+                            -> NotableEvent
     -- | Triggered every time a transaction is successfully sent.
     TxSentEvent :: forall c tx. Buildable (Hash c)
                 => Hashed c tx

--- a/src/Oscoin/Telemetry/Trace.hs
+++ b/src/Oscoin/Telemetry/Trace.hs
@@ -1,0 +1,75 @@
+module Oscoin.Telemetry.Trace
+    ( Traced
+    , tracing
+    , traced
+    , Probe(..)
+    , hoistProbe
+    , probed
+    , noProbe
+
+    -- * Re-exports from 'Control.Comonad'
+    , extract
+    ) where
+
+import           Oscoin.Prelude
+
+import           Oscoin.Telemetry.Events
+import           Oscoin.Time.Chrono
+
+import           Control.Comonad
+import           Control.Monad.State.Strict (modify')
+
+
+{------------------------------------------------------------------------------
+  Tracing events within pure code.
+------------------------------------------------------------------------------}
+
+newtype Traced a =
+    Traced (StateT (OldestFirst [] NotableEvent) Identity a)
+    deriving (Functor, Applicative, Monad)
+
+tracing :: Traced a -> (a, OldestFirst [] NotableEvent)
+tracing (Traced t) = runIdentity . flip runStateT mempty $ t
+
+-- | Like 'tracing', but ignores the traced events.
+tracing_ :: Traced a -> a
+tracing_ (Traced t) = fst . runIdentity . flip runStateT mempty $ t
+
+traced :: NotableEvent -> a -> Traced a
+traced evt a = Traced $ do
+    modify' $ \nf -> nf `seq` nf <> OldestFirst [evt]
+    pure a
+
+instance Comonad Traced where
+  extract = tracing_
+  -- (Traced a -> b) -> Traced a -> Traced b
+  extend fn a = Traced $ do
+      let (_, evts) = tracing a
+      put $! evts
+      pure (fn a)
+
+{------------------------------------------------------------------------------
+  Probes to trace events
+------------------------------------------------------------------------------}
+
+-- | A 'Probe' over @m@.
+data Probe m where
+    Probe :: (NotableEvent -> m ()) -> Probe m
+
+
+-- | When given a 'Probe' and a 'Traced' @a@, it collects the traces, output
+-- them using the 'Probe' and returns the traced value @a@.
+probed :: Monad m => Probe m -> Traced a -> m a
+probed (Probe runProbe) t = do
+    let (a, evts) = tracing t
+    forM_ (toOldestFirst evts) runProbe
+    pure a
+
+-- | The \"identity\" probe.
+noProbe :: Monad m => Probe m
+noProbe = Probe (\_ -> pure ())
+
+-- | Given a natural transformation, transform a 'Probe' operating in a
+-- 'Monad' @m@ into a 'Probe' on @n@.
+hoistProbe :: (forall x. m x -> n x) -> Probe m -> Probe n
+hoistProbe natTrans (Probe fn) = Probe (natTrans . fn)

--- a/test/Oscoin/Test/Crypto/Blockchain/Block/Generators.hs
+++ b/test/Oscoin/Test/Crypto/Blockchain/Block/Generators.hs
@@ -19,6 +19,7 @@ import           Codec.Serialise (Serialise)
 import qualified Oscoin.Consensus.Nakamoto as Nakamoto
 import           Oscoin.Crypto.Blockchain
 import qualified Oscoin.Crypto.Hash as Crypto
+import           Oscoin.Telemetry (tracing_)
 import           Oscoin.Time
 
 import           Oscoin.Test.Crypto
@@ -168,7 +169,7 @@ genNakamotoBlockWith prefix@(parent:|_) txs = do
     elapsed    <- choose (60 * seconds, 120 * seconds)
     blockState <- arbitrary :: Gen Word8
     blockSeal  <- genPoWSeal
-    blockDiffi <- pure $ Nakamoto.chainDifficulty (toList prefix)
+    blockDiffi <- pure $ tracing_ (Nakamoto.chainDifficulty (toList prefix))
     let header = (emptyHeader :: BlockHeader c Unsealed)
                { blockHeight           = succ (blockHeight prevHeader)
                , blockPrevHash         = headerHash prevHeader

--- a/test/Oscoin/Test/Crypto/Blockchain/Block/Generators.hs
+++ b/test/Oscoin/Test/Crypto/Blockchain/Block/Generators.hs
@@ -19,7 +19,7 @@ import           Codec.Serialise (Serialise)
 import qualified Oscoin.Consensus.Nakamoto as Nakamoto
 import           Oscoin.Crypto.Blockchain
 import qualified Oscoin.Crypto.Hash as Crypto
-import           Oscoin.Telemetry (tracing_)
+import           Oscoin.Telemetry (extract)
 import           Oscoin.Time
 
 import           Oscoin.Test.Crypto
@@ -169,7 +169,7 @@ genNakamotoBlockWith prefix@(parent:|_) txs = do
     elapsed    <- choose (60 * seconds, 120 * seconds)
     blockState <- arbitrary :: Gen Word8
     blockSeal  <- genPoWSeal
-    blockDiffi <- pure $ tracing_ (Nakamoto.chainDifficulty (toList prefix))
+    blockDiffi <- pure $ extract (Nakamoto.chainDifficulty (toList prefix))
     let header = (emptyHeader :: BlockHeader c Unsealed)
                { blockHeight           = succ (blockHeight prevHeader)
                , blockPrevHash         = headerHash prevHeader


### PR DESCRIPTION
This PR delivers a simple instrumentation mechanism for pure code by introducing three types:

- A `Traced` (co)monad, suitable to annotate pure values with "tracing" (i.e. events);
- A `Probe`, which can be used to actually _emit_ the traced events;
- A `Traced` type alias which removes the need for the user to remember to pass `HasCallStack` everywhere.

## Problem description

While working on #432, we had this `chainDifficulty` function:

```haskell
-- | Calculate the difficulty of a blockchain.
chainDifficulty :: [Block c tx s] -> Difficulty
chainDifficulty [] =
    minDifficulty
chainDifficulty (NonEmpty.fromList -> blks)
    | NonEmpty.length blks `mod` fromIntegral difficultyBlocks == 0 =
        encodeDifficulty $ fst (decodeDifficulty currentDifficulty)
                         * fromIntegral targetElapsed
                         `div` toInteger actualElapsed
    | otherwise =
        prevDifficulty
```

This function is responsible to adjust the `Difficulty` of the network and, while it's nice and pure, it's not very telemetry-friendly. In practice, though, it would be extremely useful to be able to log & record "difficulty adjustments" as it would help us, before mainnet, to monitor the health of the consensus algorithm and to spot bugs. What can we do, then?

## Solution

We separate the concern of tracing events with the one of actually logging them, and this is what the `Traced` and `Probe` types do. The code now becomes:

```haskell
chainDifficulty :: [Block c tx s] -> Telemetry.Traced Difficulty
chainDifficulty [] =
    pure minDifficulty
chainDifficulty (NonEmpty.fromList -> blks)
    | NonEmpty.length blks `mod` fromIntegral difficultyBlocks == 0 = do
        let newDifficulty =
                encodeDifficulty $ fst (decodeDifficulty currentDifficulty)
                                 * fromIntegral targetElapsed
                                 `div` toInteger actualElapsed
        Telemetry.traced (DifficultyAdjustedEvent newDifficulty currentDifficulty) newDifficulty
    | otherwise =
        pure prevDifficulty
```

Apart from the monadic nature (which is unavoidable if we want to decorate our pure value), this is essentially unchanged, modulo the addition to this `Telemetry.traced` call, which reminds, in spirit, `Debug.Trace`. The difference though is that **we don't do evil IO** and, in fact, our `Traced` type is completely pure:

```haskell
newtype Traced a =
    Traced (StateT (OldestFirst [] NotableEvent) Identity a)
    deriving (Functor, Applicative, Monad)
```

What we gain now is that we can collect events in this monadic context, and we can later on use a `Probe` to emit the events. But how to do that without:

1. Changing the code everywhere;
2. Actually performing IO?

We can use a `Tracer` function, defined as:

```
type Tracer m = HasCallStack => forall a. Traced a -> m a
```

And simply pass this function to any function that want to probe something deep down the guts of the application. Note how this can live in any monad `m` and therefore we don't need to commit to any concrete one just yet. Finally, at the very top-level of our app, we can create a `Probe` and call `probed` to get a `Tracer` out of it:

```haskell
            let probe   = Telemetry.telemetryProbe telemetry
                        & Telemetry.hoistProbe liftIO
            let consensus =
                    case optEnvironment of
                        Production  ->
                            Consensus.nakamotoConsensus (Telemetry.probed probe)
                        Development ->
                            Consensus.nakamotoConsensusLenient (Telemetry.probed probe) optBlockTimeLower
```

When this code is run, it would produce something like:

```
monadic/oscoin (adinapoli/trace-and-probes) > stack exec oscoin -- --genesis data/genesis.yaml --blockstore blockstore.db
info  | node starting env=development logical_network=devnet physical_network=xysnx4b7s-zfocl-ky genesis=2DrjgbCd1rxCgmw24kS8YxJeR9esBPCQdDZ3i29gWRwUt7Vkbw loc="Oscoin.Node:81:13"
Spock is running on port 8477
info  | bootstrapping peer_addr=127.0.0.1:6942 peer_nodeid=2DrjgbLeNjsmAYKS4Lj96mqiRktsqgYnPpwGQyqxGmJqnBJMvU ns="gossip" loc="Oscoin.P2P:134:10"
info  | bootstrapped peer_addr=127.0.0.1:6942 peer_nodeid=2DrjgbLeNjsmAYKS4Lj96mqiRktsqgYnPpwGQyqxGmJqnBJMvU ns="gossip" loc="Oscoin.P2P:134:10"
info  | difficulty adjustment new=Difficulty {fromDifficulty = 539799905} old=Difficulty {fromDifficulty = 553713663} ns="consensus" loc="Oscoin.Consensus.Nakamoto:140:14"
```

## Limitations

Unfortunately we cannot get precise-to-the-events `SrcLoc`, but rather we would get the `SrcLoc` associated to the last `probed` call within the codebase. In practice this should be just fine, but if we want to do better, I feel like we would need to overhaul a bit our logging/telemetry system: the reason is that we can have multiple events we trace (cfr. `NotableEvent`) but at the end of the day we probably will have fewer `emit/probed` call within the code (for efficiency/composability reasons) and therefore the `CallStack` will be fixed by the location where `emit/probed` is called. To fix this properly we would probably need to decorate our `NotableEvent` GADT with a `HasCallStack` constraint for each type constructor, and then modify `emit/withLogger` accordingly. This is a lot of work, so that's not a priority for now.

## Other concerns

If we find ourself using `Traced` in anger, we should keep an eye on the memory efficiency -- i.e., making sure this doesn't leak memory. I have tried my best to use strict functions where it matters, but a sanity check down the line won't hurt.
