### PR TITLE
Add option to create keypair if missing

### DIFF
--- a/src/Oscoin/Node/Options.hs
+++ b/src/Oscoin/Node/Options.hs
@@ -21,17 +21,18 @@ import           Network.Socket (HostName, PortNumber)
 import           Options.Applicative
 
 data Options = Options
-    { optHost           :: IP
-    , optGossipPort     :: PortNumber
-    , optApiPort        :: PortNumber
-    , optDiscovery      :: P2P.Disco.Options P2P.Disco.OptNetwork
-    , optBlockTimeLower :: Duration
-    , optPaths          :: Paths
-    , optEnvironment    :: Environment
-    , optMetricsHost    :: Maybe HostName
-    , optMetricsPort    :: Maybe PortNumber
-    , optEkgHost        :: Maybe HostName
-    , optEkgPort        :: Maybe PortNumber
+    { optHost               :: IP
+    , optGossipPort         :: PortNumber
+    , optApiPort            :: PortNumber
+    , optDiscovery          :: P2P.Disco.Options P2P.Disco.OptNetwork
+    , optBlockTimeLower     :: Duration
+    , optPaths              :: Paths
+    , optEnvironment        :: Environment
+    , optMetricsHost        :: Maybe HostName
+    , optMetricsPort        :: Maybe PortNumber
+    , optEkgHost            :: Maybe HostName
+    , optEkgPort            :: Maybe PortNumber
+    , optAllowEphemeralKeys :: Bool
     }
 
 nodeOptionsParser :: ConfigPaths -> Parser Options
@@ -90,4 +91,8 @@ nodeOptionsParser cps = Options
           ( long "ekg-port"
          <> help "Port number to bind to for the EKG server"
           )
+        )
+    <*> switch
+        ( long "allow-ephemeral-keys"
+       <> help "Create a fresh keypair if none could be found"
         )


### PR DESCRIPTION
This is useful for "ephemeral" deployments (i.e. locally or on the "devnet"). Otherwise, a proper KMS has to be set up, managed, and the application needs to know how to retrieve key material from there.

It _might_ be sufficient to not write these keys to disk, which would mean that if an instance gets rescheduled or rebooted, it appears as new.