### PR TITLE
Make (node) options invertible

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -44,3 +44,7 @@
 - ignore: {name: Avoid reverse}
 - ignore: {name: Use print}
 - ignore: {name: Use camelCase}
+
+- ignore:
+    name: Avoid restricted qualification
+    within: [System.Console.Option]

--- a/src/Oscoin/P2P/Disco.hs
+++ b/src/Oscoin/P2P/Disco.hs
@@ -92,7 +92,7 @@ data DiscoEvent =
 --
 withDisco
     :: (HasCallStack => DiscoEvent -> IO ())
-    -> Options Network
+    -> Options crypto Network
     -> PortNumber
     -> Set MDns.Service
     -> (IO (Set SockAddr) -> IO a)
@@ -137,7 +137,8 @@ withDisco tracer opt defaultGossipPort !advertise k = do
                     resolveA tracer rslv nodeHost nodePort)
         <*> (Concurrently $
                 map (fromMaybe mempty) . for mrslv $ \r ->
-                    Set.fromList <$> resolveMDns tracer rslv r (optNetwork opt))
+                    Set.fromList <$>
+                        resolveMDns tracer rslv r (optNetwork opt))
         <*> (Concurrently $
                 map (fromMaybe mempty) . for goog $ \g -> do
                     -- TODO(kim): we may want to allow passing in the project

--- a/src/Oscoin/P2P/Types.hs
+++ b/src/Oscoin/P2P/Types.hs
@@ -33,6 +33,7 @@ module Oscoin.P2P.Types
     , SeedAddr
     , NodeAddr(..)
     , readNodeAddr
+    , showNodeAddr
 
     , Msg(..)
     , MsgId(..)
@@ -292,6 +293,12 @@ readNodeAddr = \case
             <$> readHost host
             <*> note "Invalid port number" (readMaybe port)
 
+-- | Show the 'NodeAddr' suitable for consumption by 'readNodeAddr'.
+showNodeAddr :: NodeAddr Maybe c -> String
+showNodeAddr NodeAddr { nodeHost, nodePort } =
+    toS $ case nodeHost of
+        NumericHost IPv6{} -> "[" <> renderHost nodeHost <> "]:" <> show nodePort
+        _                  -> renderHost nodeHost <> ":" <> show nodePort
 
 data Msg c tx s =
       BlockMsg (Block c tx s)

--- a/src/System/Console/Option.hs
+++ b/src/System/Console/Option.hs
@@ -1,0 +1,245 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE TypeFamilies          #-}
+
+-- code-review: ignore
+-- Temporarily inlined from unreleased library
+
+-- Copyright   : 2019 Kim Altintop
+-- License     : BSD3
+-- Maintainer  : kim.altintop@gmail.com
+-- Stability   : experimental
+-- Portability : non-portable (GHC extensions)
+--
+module System.Console.Option
+    ( Cmd     (..)
+    , SomeCmd (..)
+    , Opt     (..)
+    , SomeOpt (..)
+    , Var
+    , Sh      (..)
+    , Op      (..)
+
+    , Eval
+    , EvalError
+    , runEval
+
+    , evalCmd
+    , evalOpt
+    , evalSomeOpt
+    , evalSh
+    , evalShInt
+    , evalArith
+    )
+where
+
+import           Control.Monad.Except
+import           Control.Monad.Reader
+import           Data.List (intersperse)
+import           Data.Proxy (Proxy(..))
+import           Data.String (IsString(..))
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Lazy.Builder as Build
+import qualified Data.Text.Lazy.Builder.Int as Build
+import qualified Data.Text.Read as Read
+import           Data.Typeable (TypeRep, Typeable, typeOf, typeRep)
+import           Formatting.Buildable (Buildable(..))
+import           Prelude
+
+
+data Cmd a = Cmd FilePath [Opt a]
+    deriving (Eq, Ord, Show, Read, Functor)
+
+instance Buildable a => Buildable (Cmd a) where
+    build (Cmd exe opts) =
+        mconcat . intersperse " " $ Build.fromString exe : map build opts
+
+data SomeCmd = SomeCmd FilePath [SomeOpt]
+    deriving Show
+
+instance Buildable SomeCmd where
+    build (SomeCmd exe opts) =
+        mconcat . intersperse " " $ Build.fromString exe : map build opts
+
+
+data Opt a where
+    Flag :: Text      -> Opt a
+    Arg  :: Text      -> Opt a
+    Opt  :: Text -> a -> Opt a
+
+deriving instance Eq   a => Eq   (Opt a)
+deriving instance Ord  a => Ord  (Opt a)
+deriving instance Show a => Show (Opt a)
+deriving instance Read a => Read (Opt a)
+
+deriving instance Functor Opt
+
+instance Buildable a => Buildable (Opt a) where
+    build = \case
+        Flag f   -> "--" <> Build.fromText f
+        Opt  n v -> "--" <> Build.fromText n <> "=" <> build v
+        Arg  a   -> Build.fromText a
+
+
+data SomeOpt where
+    ShOpt  :: (Buildable a, Show a) => Opt (Sh a) -> SomeOpt
+    LitOpt ::                          Opt Text   -> SomeOpt
+
+deriving instance Show SomeOpt
+
+instance Buildable SomeOpt where
+    build = \case
+        ShOpt  opt -> build opt
+        LitOpt opt -> build opt
+
+
+newtype Var = Var Text
+    deriving (Eq, Ord, Show, Read)
+
+instance IsString Var where
+    fromString = Var . fromString
+
+instance Buildable Var where
+    build (Var x) = Build.fromText x
+
+
+data Sh a where
+    ShNum  :: Int  -> Sh Int
+    ShStr  :: Text -> Sh Text
+    ShVar  :: Var  -> Sh Var
+    ShEval :: Sh a -> Sh (Sh a)
+
+    ShCmd  :: Typeable a => Cmd a -> Sh (Cmd a)
+
+    ShArith
+        :: ( Show      a
+           , Show      b
+           , Buildable a
+           , Buildable b
+           )
+        => Op
+        -> Sh a
+        -> Sh b
+        -> Sh Int
+
+deriving instance Show a => Show (Sh a)
+
+instance Buildable a => Buildable (Sh a) where
+    build = \case
+        ShNum   x      -> Build.decimal x
+        ShStr   x      -> Build.fromText x
+        ShVar   x      -> "${" <> build x <> "}"
+        ShCmd   cmd    -> build cmd
+        ShEval  sh     -> "$(" <> build sh <> ")"
+        ShArith op a b -> "$((" <> build a <> build op <> build b <> "))"
+
+
+data Op = Add | Sub | Mul | Div
+    deriving (Eq, Ord, Enum, Show, Read)
+
+instance IsString Op where
+    fromString = \case
+        "+" -> Add
+        "-" -> Sub
+        "*" -> Mul
+        "/" -> Div
+        x   -> error $ "Unkown arithmetic operator: " <> x
+
+instance Buildable Op where
+    build = \case
+        Add -> "+"
+        Sub -> "-"
+        Mul -> "*"
+        Div -> "/"
+
+
+data EvalEnv = EvalEnv
+    { eeVars :: Var -> Maybe Text
+    , eeCmds :: forall a. Cmd a -> Maybe Text
+    }
+
+data EvalError
+    = UnsetVariable  Var
+    | UnknownCommand TypeRep
+    | CastError      TypeRep TypeRep
+    deriving Show
+
+type Eval a = ExceptT EvalError (Reader EvalEnv) a
+
+runEval
+    :: (Var -> Maybe Text)
+    -> (forall x. Cmd x -> Maybe Text)
+    -> Eval a
+    -> Either EvalError a
+runEval vs cs = flip runReader (EvalEnv vs cs) . runExceptT
+
+evalCmd :: Cmd (Sh a) -> Eval (Cmd Text)
+evalCmd (Cmd exe opts) = Cmd exe <$> traverse evalOpt opts
+
+evalOpt :: Opt (Sh a) -> Eval (Opt Text)
+evalOpt = \case
+    Flag x   -> pure $ Flag x
+    Arg  x   -> pure $ Arg  x
+    Opt  k v -> evalSh v >>= \case
+        ShStr x -> pure $ Opt k x
+
+evalSomeOpt :: SomeOpt -> Eval (Opt Text)
+evalSomeOpt = \case
+    ShOpt  x -> evalOpt x
+    LitOpt x -> pure x
+
+evalSh :: Sh a -> Eval (Sh Text)
+evalSh = \case
+    ShVar   x      -> ShStr <$> lookupVar x
+    ShCmd   x      -> ShStr <$> runCmd    x
+    ShEval  x      -> evalSh x
+    ShArith op a b ->
+        evalSh . ShNum =<<
+            evalArith op <$> evalShInt a <*> evalShInt b
+    ShNum   x      -> pure . ShStr $ Text.pack (show x)
+    ShStr   x      -> pure $ ShStr x
+  where
+    lookupVar :: Var -> Eval Text
+    lookupVar x = do
+        vars <- asks eeVars
+        note (UnsetVariable x) $ vars x
+
+    runCmd :: Typeable x => Cmd x -> Eval Text
+    runCmd x = do
+        cmds <- asks eeCmds
+        note (UnknownCommand (typeOf x)) $ cmds x
+
+evalShInt :: Sh a -> Eval Int
+evalShInt sh = evalSh sh >>= cast >>= int
+  where
+    int :: Sh Int -> Eval Int
+    int = \case
+        ShNum   x      -> pure x
+        ShArith op a b -> evalArith op <$> evalShInt a <*> evalShInt b
+
+    cast :: Sh Text -> Eval (Sh Int)
+    cast (ShStr x) =
+        case Read.signed Read.decimal x of
+            Right (i, "") -> pure $ ShNum i
+            _             -> throwError $ CastError tyFrom tyTo
+      where
+        tyFrom = typeRep (Proxy @(Sh Text))
+        tyTo   = typeRep (Proxy @Int)
+
+evalArith :: Op -> Int -> Int -> Int
+evalArith Add = (+)
+evalArith Sub = (-)
+evalArith Mul = (*)
+evalArith Div = div
+
+--------------------------------------------------------------------------------
+
+note :: MonadError e m => e -> Maybe a -> m a
+note _ (Just a) = pure a
+note e Nothing  = throwError e

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -24,6 +24,7 @@ import qualified Test.Oscoin.Crypto.Hash
 import qualified Test.Oscoin.Crypto.PubKey
 import qualified Test.Oscoin.Data.OscoinTx
 import qualified Test.Oscoin.Node.Mempool
+import qualified Test.Oscoin.Node.Options
 import qualified Test.Oscoin.Protocol
 import qualified Test.Oscoin.Storage.Block.Orphanage
 import qualified Test.Oscoin.Storage.Ledger
@@ -80,6 +81,7 @@ main = do
                 , Test.Oscoin.Crypto.PubKey.tests crypto
                 , Test.Oscoin.Data.OscoinTx.tests crypto
                 , Test.Oscoin.Node.Mempool.tests crypto
+                , Test.Oscoin.Node.Options.tests crypto
                 , Test.Oscoin.Protocol.tests crypto
                 , Test.Oscoin.Storage.Block.Orphanage.tests crypto
                 , Test.Oscoin.Storage.Ledger.tests crypto

--- a/test/Test/Oscoin/Configuration.hs
+++ b/test/Test/Oscoin/Configuration.hs
@@ -4,10 +4,24 @@ import           Oscoin.Prelude
 
 import           Oscoin.Configuration
                  ( Network
+                 , getConfigPaths
+                 , pathsParser
                  , readEnvironmentText
                  , readNetworkText
                  , renderEnvironment
                  , renderNetwork
+                 , renderPathsOpts
+                 )
+
+
+import qualified Test.Oscoin.Configuration.Gen as Gen
+
+import           Options.Applicative
+                 ( ParserResult(..)
+                 , briefDesc
+                 , defaultPrefs
+                 , execParserPure
+                 , info
                  )
 
 import           Hedgehog
@@ -20,6 +34,7 @@ tests = testGroup "Test.Oscoin.Configuration"
     [ testProperty "prop_roundtripEnvironment"     prop_roundtripEnvironment
     , testProperty "prop_roundtripNetworkText"     prop_roundtripNetworkText
     , testProperty "prop_roundtripNetworkShowRead" prop_roundtripNetworkShowRead
+    , testProperty "prop_roundtripPathsCLI"        prop_roundtripPathsCLI
     ]
 
 props :: IO Bool
@@ -27,6 +42,7 @@ props = checkParallel $ Group "Test.Oscoin.Configuration"
     [ ("prop_roundtripEnvironment"    , prop_roundtripEnvironment)
     , ("prop_roundtripNetworkText"    , prop_roundtripNetworkText)
     , ("prop_roundtripNetworkShowRead", prop_roundtripNetworkShowRead)
+    , ("prop_roundtripPathsCLI"       , prop_roundtripPathsCLI)
     ]
 
 prop_roundtripEnvironment :: Property
@@ -43,3 +59,16 @@ prop_roundtripNetworkShowRead :: Property
 prop_roundtripNetworkShowRead = property $ do
     net <- forAll Gen.enumBounded
     tripping net (show @Network) readEither
+
+prop_roundtripPathsCLI :: Property
+prop_roundtripPathsCLI = property $ do
+    cps <- liftIO getConfigPaths
+    ps  <- forAll Gen.paths
+    let
+        opts  = map toS $ renderPathsOpts ps
+        pinfo = info (pathsParser cps) briefDesc
+     in
+        case execParserPure defaultPrefs pinfo opts of
+            Success ps'             -> annotateShow opts  >> ps' === ps
+            Failure e               -> annotateShow e     *> failure
+            CompletionInvoked compl -> annotateShow compl *> failure

--- a/test/Test/Oscoin/Configuration/Gen.hs
+++ b/test/Test/Oscoin/Configuration/Gen.hs
@@ -1,0 +1,33 @@
+module Test.Oscoin.Configuration.Gen
+    ( paths
+    , environment
+    , filePath
+    )
+where
+
+import           Oscoin.Prelude
+
+import           Oscoin.Configuration (Environment, Paths(..))
+
+import           System.FilePath ((</>))
+
+import           Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+paths :: MonadGen m => m Paths
+paths = Paths <$> filePath <*> filePath <*> filePath
+
+environment :: MonadGen m => m Environment
+environment = Gen.enumBounded
+
+-- nb. ranges are way below admissible values for performance reasons
+filePath :: MonadGen m => m FilePath
+filePath = do
+    root <- Gen.element ["", "/"]
+    dirs <- Gen.list (Range.constantFrom 1 1 23) dir
+    pure $ case dirs of
+        [] -> root
+        xs -> foldl' (</>) root xs
+  where
+    dir = Gen.string (Range.constantFrom 1 1 42) Gen.latin1

--- a/test/Test/Oscoin/Node/Options.hs
+++ b/test/Test/Oscoin/Node/Options.hs
@@ -1,0 +1,45 @@
+module Test.Oscoin.Node.Options (tests, props) where
+
+import           Oscoin.Prelude
+
+import           Oscoin.Configuration (getConfigPaths)
+import           Oscoin.Node.Options
+
+import           Options.Applicative
+                 ( ParserResult(..)
+                 , briefDesc
+                 , defaultPrefs
+                 , execParserPure
+                 , info
+                 )
+
+import           Oscoin.Test.Crypto (Dict(..), IsCrypto)
+import           Test.Oscoin.Node.Options.Gen (genNodeOptions)
+
+import           Hedgehog
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.Hedgehog (testProperty)
+
+tests :: Dict (IsCrypto c) -> TestTree
+tests d = testGroup "Test.Oscoin.Node.Options"
+    [ testProperty "prop_roundtripOptions" (prop_roundtripOptions d)
+    ]
+
+props :: Dict (IsCrypto c) -> IO Bool
+props d = checkParallel $ Group "Test.Oscoin.Node.Options"
+    [ ("prop_roundtripOptions", prop_roundtripOptions d)
+    ]
+
+prop_roundtripOptions :: forall c. Dict (IsCrypto c) -> Property
+prop_roundtripOptions Dict = property $ do
+    cps  <- liftIO getConfigPaths
+    nopt <- forAll genNodeOptions
+    let
+        opts  = map toS $ renderNodeOptionsOpts nopt
+        pinfo = info (nodeOptionsParser @c cps) briefDesc
+     in
+        case execParserPure defaultPrefs pinfo opts of
+            Success nopt'           -> annotateShow opts  >> nopt' === nopt
+            Failure e               -> annotateShow e     *> failure
+            CompletionInvoked compl -> annotateShow compl *> failure
+

--- a/test/Test/Oscoin/Node/Options/Gen.hs
+++ b/test/Test/Oscoin/Node/Options/Gen.hs
@@ -1,0 +1,33 @@
+module Test.Oscoin.Node.Options.Gen (genNodeOptions) where
+
+import           Oscoin.Prelude
+
+import qualified Oscoin.Consensus.Nakamoto as Nakamoto
+import           Oscoin.Node.Options
+import qualified Oscoin.P2P.Disco.Options as Disco
+import           Oscoin.P2P.Types (renderHostname)
+import           Oscoin.Time (seconds)
+
+import qualified Test.Oscoin.Configuration.Gen as Config.Gen
+import qualified Test.Oscoin.P2P.Disco.Options.Gen as Disco.Gen
+import qualified Test.Oscoin.P2P.Gen as P2P.Gen
+
+import           Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+genNodeOptions :: MonadGen m => m (Options c Disco.OptNetwork)
+genNodeOptions = Options
+    <$> P2P.Gen.genIP
+    <*> P2P.Gen.genPortNumber
+    <*> P2P.Gen.genPortNumber
+    <*> Disco.Gen.genOptions
+    <*> ((* seconds) . (`div` seconds)
+            <$> Gen.int64 (Range.constant (1 * seconds) Nakamoto.blockTime))
+    <*> Config.Gen.paths
+    <*> Config.Gen.environment
+    <*> Gen.maybe (toS . renderHostname <$> P2P.Gen.genHostname)
+    <*> Gen.maybe P2P.Gen.genPortNumber
+    <*> Gen.maybe (toS . renderHostname <$> P2P.Gen.genHostname)
+    <*> Gen.maybe P2P.Gen.genPortNumber
+    <*> Gen.bool

--- a/test/Test/Oscoin/P2P.hs
+++ b/test/Test/Oscoin/P2P.hs
@@ -5,6 +5,7 @@ import           Oscoin.Prelude
 import           Oscoin.Test.Crypto
 
 import qualified Test.Oscoin.P2P.Disco as Disco
+import qualified Test.Oscoin.P2P.Disco.Options as Disco.Options
 import qualified Test.Oscoin.P2P.Handshake as Handshake
 import qualified Test.Oscoin.P2P.IO as IO
 import qualified Test.Oscoin.P2P.Transport as Transport
@@ -15,6 +16,7 @@ import           Test.Tasty
 tests :: Dict (IsCrypto c) -> [TestTree]
 tests d =
     [ Disco.tests
+    , Disco.Options.tests d
     , Handshake.tests d
     , IO.tests
     , Transport.tests
@@ -24,6 +26,7 @@ tests d =
 props :: Dict (IsCrypto c) -> IO Bool
 props d = and <$> sequence
     [ Disco.props
+    , Disco.Options.props d
     , Handshake.props d
     , IO.props
     , Transport.props

--- a/test/Test/Oscoin/P2P/Disco.hs
+++ b/test/Test/Oscoin/P2P/Disco.hs
@@ -168,7 +168,7 @@ haveIPv6 = do
     hints = defaultHints { addrFlags = [AI_ADDRCONFIG, AI_ALL, AI_NUMERICHOST] }
 
 
-runDisco :: Options Network -> Set MDns.Service -> IO (Set SockAddr)
+runDisco :: Options c Network -> Set MDns.Service -> IO (Set SockAddr)
 runDisco opts srvs = withDisco (const $ pure ()) opts 6942 srvs identity
 
 runNameserver :: (PortNumber -> IO a) -> IO a

--- a/test/Test/Oscoin/P2P/Disco/Options.hs
+++ b/test/Test/Oscoin/P2P/Disco/Options.hs
@@ -1,0 +1,42 @@
+module Test.Oscoin.P2P.Disco.Options (tests, props) where
+
+import           Oscoin.Prelude
+
+import           Oscoin.P2P.Disco.Options
+
+import           Options.Applicative
+                 ( ParserResult(..)
+                 , briefDesc
+                 , defaultPrefs
+                 , execParserPure
+                 , info
+                 )
+
+import           Oscoin.Test.Crypto (Dict(..), IsCrypto)
+import qualified Test.Oscoin.P2P.Disco.Options.Gen as Gen
+
+import           Hedgehog
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.Hedgehog (testProperty)
+
+tests :: Dict (IsCrypto c) -> TestTree
+tests d = testGroup "Test.Oscoin.P2P.Disco.Options"
+    [ testProperty "prop_roundtripOptions" (prop_roundtripOptions d)
+    ]
+
+props :: Dict (IsCrypto c) -> IO Bool
+props d = checkParallel $ Group "Test.Oscoin.P2P.Disco.Options"
+    [ ("prop_roundtripOptions", prop_roundtripOptions d)
+    ]
+
+prop_roundtripOptions :: forall c. Dict (IsCrypto c) -> Property
+prop_roundtripOptions Dict = property $ do
+    dopt <- forAll Gen.genOptions
+    let
+        opts  = map toS $ renderDiscoOpts dopt
+        pinfo = info (discoParser @c) briefDesc
+     in
+        case execParserPure defaultPrefs pinfo opts of
+            Success dopt'           -> annotateShow opts  >> dopt' === dopt
+            Failure e               -> annotateShow e     *> failure
+            CompletionInvoked compl -> annotateShow compl *> failure

--- a/test/Test/Oscoin/P2P/Disco/Options/Gen.hs
+++ b/test/Test/Oscoin/P2P/Disco/Options/Gen.hs
@@ -1,0 +1,47 @@
+module Test.Oscoin.P2P.Disco.Options.Gen
+    ( genOptions
+    , genOptNetwork
+    , genSeed
+    )
+where
+
+import           Oscoin.Prelude
+
+import           Oscoin.P2P.Disco.Options
+                 (OptNetwork(..), Options(..), evalYesNo)
+import           Oscoin.P2P.Types
+                 ( Network(..)
+                 , NodeAddr(..)
+                 , SeedAddr
+                 , renderHostname
+                 , renderNetwork
+                 )
+
+import           Test.Oscoin.P2P.Gen
+
+import           Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+genOptions :: MonadGen m => m (Options c OptNetwork)
+genOptions = Options
+    <$> genOptNetwork
+    <*> Gen.list (Range.constant 0 5) genSeed
+    <*> Gen.list (Range.constant 0 1)
+            (toS . renderHostname <$> genHostname)
+    <*> Gen.bool
+    <*> Gen.bool
+    <*> pure Nothing
+
+genOptNetwork :: MonadGen m => m OptNetwork
+genOptNetwork = Gen.choice [confirm, noConfirm, pure Random]
+  where
+    confirm = do
+        net <- Gen.element [Mainnet, Testnet]
+        pure $ Confirm (renderNetwork net) (evalYesNo net)
+
+    noConfirm =
+        NoConfirm <$> Gen.choice [genSomeNetwork, pure Devnet]
+
+genSeed :: MonadGen m => m (SeedAddr c)
+genSeed = NodeAddr Nothing <$> genHost <*> genPortNumber


### PR DESCRIPTION
i.e. render CLI options from a Options value

It is desirable for certain deployment configurations to be able to safely override the configuration of the deployed executable. For this, we need to be able to render the set of CLI options which fully constitute the configuration from the configuration value itself.

Ideally, the (partial) isomorphisms would be built up field-wise  à la [invertible syntax](http://www.informatik.uni-marburg.de/~rendel/unparse/). I have, however, not yet found a satisfying formulation. Of course, we could just define suitable functions `a -> [Opt Text]`, yet this is quite error prone. Reading the latest in [~~hipster~~higher kinded data](https://chrispenner.ca/posts/hkd-options) experiments, it occured to me that would be quite nice syntactically and mnemonically to stick functorial "unparsers" in a record's fields, even though not actually "safe". Doing the same with the parsers is also quite cute, although not strictly required for this patch.

Unfortunately, the `barbies` (!!1) library chokes on Sandy's type-family-of-fame, which eliminates the boring `Identity` functor, and I can't at the moment be bothered to get this to work with `generics-sop` (because a boggling of the mind). Since options usually get scrutinised early, it seems bearable.