### PR TITLE
Always publish artifacts

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -84,19 +84,16 @@ steps:
     - |
       set -euo pipefail
 
-      if [ "$BRANCH_NAME" == "master" ]; then
-        stack build \
-          --test \
-          --flag=oscoin:static \
-          --no-terminal \
-          --pedantic \
-          --copy-bins \
-          --local-bin-path=/workspace/bin \
-          --haddock \
-          --exec="mv $(stack path --local-doc-root) api-docs"
-      else
-        stack build --test --no-terminal --pedantic
-      fi
+      stack build \
+        --test \
+        --flag=oscoin:static \
+        --no-terminal \
+        --pedantic \
+        --copy-bins \
+        --local-bin-path=/workspace/bin \
+        --haddock \
+        --no-haddock-deps \
+        --exec="mv $(stack path --local-doc-root) api-docs"
 
   - id: "Lint (weeder)"
     waitFor:
@@ -120,14 +117,12 @@ steps:
     - |
       set -euo pipefail
 
-      if [ "$BRANCH_NAME" == "master" ]; then
-        bins=(
-          /workspace/bin/oscoin
-          /workspace/bin/oscoin-cli
-        )
+      bins=(
+        /workspace/bin/oscoin
+        /workspace/bin/oscoin-cli
+      )
 
-        echo "$${bins[*]}" | xargs -P8 -n1 ./scripts/publish-image.sh
-      fi
+      echo "$${bins[*]}" | xargs -P8 -n1 ./scripts/publish-image.sh
 
   - id: "Publish Haddocks"
     waitFor:
@@ -142,6 +137,4 @@ steps:
     - |
       set -euxo pipefail
 
-      if [ "$BRANCH_NAME" == "master" ]; then
-        gsutil -m rsync -d -r api-docs gs://oscoin-apidocs/${COMMIT_SHA}
-      fi
+      gsutil -m rsync -d -r api-docs gs://oscoin-apidocs/${COMMIT_SHA}

--- a/scripts/ci-cache.sh
+++ b/scripts/ci-cache.sh
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 deps_hash=$(cat package.yaml snapshot.yaml | sha256sum | cut -d' ' -f1)
-bucket="gs://oscoin-build-cache/v5"
+bucket="gs://oscoin-build-cache/v6"
 local_cache_archive="stack-root.tar.gz"
 remote_cache_master="${bucket}/stack-root-master.tar.gz"
 remote_cache_hashed="${bucket}/stack-root-${deps_hash}.tar.gz"

--- a/src/Oscoin/Data/Ledger.hs
+++ b/src/Oscoin/Data/Ledger.hs
@@ -241,7 +241,7 @@ data Project c = Project
 
     , pCheckpoints     :: Set (Checkpoint c)
 
-    -- * Contract
+    -- | Contract
     , pSendTransfer    :: SendTransfer' c
     , pReceiveTransfer :: ReceiveTransfer' c
     , pReceiveReward   :: ReceiveReward' c


### PR DESCRIPTION
The same SHA1 doesn't get rebuilt, so fast-forward merges to master won't actually publish any artifacts. Our latest Doge image is from Apr 11.

It is anyways generally useful to be able to spin up a non-master container image, and _potentially_ to look at API docs (because Haddock markup is hard). I would, however, also be fine to not generate/publish Haddocks at all, as nobody is looking at them.

