### PR TITLE
Build haskell-scratch base image to match build base

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,6 +14,28 @@ steps:
     entrypoint: "bash"
     args: ["./scripts/shellcheck.sh"]
 
+  - id: "Build haskell-scratch rootfs"
+    waitFor: ["-"]
+    name: "eu.gcr.io/opensourcecoin/docker-haskell:8.6.4"
+    args:
+    - make
+    - "-C"
+    - /workspace/scripts/docker/haskell-scratch
+    - "integer-gmp"
+
+  - id: "Build haskell-scratch image"
+    waitFor:
+    - "Build haskell-scratch rootfs"
+    name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    args:
+    - '-c'
+    - |
+      set -euox pipefail
+
+      tar -cC /workspace/scripts/docker/haskell-scratch/root . | \
+        docker import - eu.gcr.io/$PROJECT_ID/haskell-scratch:integer-gmp
+
   - id: "Load cache"
     name: gcr.io/cloud-builders/gsutil
     entrypoint: "bash"
@@ -103,7 +125,7 @@ steps:
     - STACK_ROOT=/workspace/.stack # weeder uses stack under the hood
     args: ["stack", "exec", "--", "weeder", "."]
 
-  - id: "Publish images"
+  - id: "Build images"
     waitFor:
     - Lint (weeder)
     name: gcr.io/cloud-builders/docker
@@ -122,7 +144,7 @@ steps:
         /workspace/bin/oscoin-cli
       )
 
-      echo "$${bins[*]}" | xargs -P8 -n1 ./scripts/publish-image.sh
+      echo "$${bins[*]}" | xargs -P8 -n1 ./scripts/docker/build-image.sh
 
   - id: "Publish Haddocks"
     waitFor:
@@ -138,3 +160,7 @@ steps:
       set -euxo pipefail
 
       gsutil -m rsync -d -r api-docs gs://oscoin-apidocs/${COMMIT_SHA}
+images:
+- "eu.gcr.io/$PROJECT_ID/oscoin"
+- "eu.gcr.io/$PROJECT_ID/oscoin-cli"
+- "eu.gcr.io/$PROJECT_ID/haskell-scratch:integer-gmp"

--- a/scripts/docker/build-image.sh
+++ b/scripts/docker/build-image.sh
@@ -9,7 +9,7 @@ cp "$1" "$dir"
 pushd "$dir"
 
 cat > Dockerfile << EOF
-FROM fpco/haskell-scratch:integer-gmp
+FROM eu.gcr.io/$PROJECT_ID/haskell-scratch:integer-gmp
 COPY $bin /bin/$bin
 ENTRYPOINT ["/bin/$bin"]
 EOF
@@ -23,7 +23,5 @@ docker build --label "version=$COMMIT_SHA" \
 if [[ $BRANCH_NAME == "master" ]]; then
   docker tag "$img:$BRANCH_NAME" "$img:latest"
 fi
-
-docker push "$img"
 
 popd

--- a/scripts/docker/haskell-scratch/Makefile
+++ b/scripts/docker/haskell-scratch/Makefile
@@ -1,0 +1,73 @@
+# Adapted from https://github.com/fpco/haskell-scratch/
+#
+# Builds a minimal rootfs for haskell applications, for use with 'docker import'
+#
+default: integer-gmp
+
+root:
+	@mkdir root
+root/bin: | root
+	@mkdir root/bin
+root/etc: | root
+	@mkdir root/etc
+root/bin/sh: | root/bin
+	@cp -L /bin/sh root/bin/
+root/lib: | root
+	@mkdir root/lib
+root/lib/x86_64-linux-gnu: | root/lib
+	@mkdir root/lib/x86_64-linux-gnu
+root/lib/x86_64-linux-gnu/libc.so.6: | root/lib/x86_64-linux-gnu
+	@cp -L /lib/x86_64-linux-gnu/libc.so.6 root/lib/x86_64-linux-gnu/
+root/lib/x86_64-linux-gnu/libdl.so.2: | root/lib/x86_64-linux-gnu
+	@cp -L /lib/x86_64-linux-gnu/libdl.so.2 root/lib/x86_64-linux-gnu/
+root/lib/x86_64-linux-gnu/libm.so.6: | root/lib/x86_64-linux-gnu
+	@cp -L /lib/x86_64-linux-gnu/libm.so.6 root/lib/x86_64-linux-gnu/
+root/lib/x86_64-linux-gnu/libpthread.so.0: | root/lib/x86_64-linux-gnu
+	@cp -L /lib/x86_64-linux-gnu/libpthread.so.0 root/lib/x86_64-linux-gnu/
+root/lib/x86_64-linux-gnu/libutil.so.1: | root/lib/x86_64-linux-gnu
+	@cp -L /lib/x86_64-linux-gnu/libutil.so.1 root/lib/x86_64-linux-gnu/
+root/lib/x86_64-linux-gnu/librt.so.1: | root/lib/x86_64-linux-gnu
+	@cp -L /lib/x86_64-linux-gnu/librt.so.1 root/lib/x86_64-linux-gnu/
+root/lib/x86_64-linux-gnu/libz.so.1: | root/lib/x86_64-linux-gnu
+	@cp -L /lib/x86_64-linux-gnu/libz.so.1 root/lib/x86_64-linux-gnu/
+root/lib/x86_64-linux-gnu/libnss_files.so.2: | root/lib/x86_64-linux-gnu
+	@cp -L /lib/x86_64-linux-gnu/libnss_files.so.2 root/lib/x86_64-linux-gnu/
+root/lib/x86_64-linux-gnu/libnss_dns.so.2: | root/lib/x86_64-linux-gnu
+	@cp -L /lib/x86_64-linux-gnu/libnss_dns.so.2 root/lib/x86_64-linux-gnu/
+root/lib/x86_64-linux-gnu/libresolv.so.2: | root/lib/x86_64-linux-gnu
+	@cp -L /lib/x86_64-linux-gnu/libresolv.so.2 root/lib/x86_64-linux-gnu/
+root/lib64: | root
+	@mkdir root/lib64
+root/lib64/ld-linux-x86-64.so.2: | root/lib64
+	@cp -L /lib64/ld-linux-x86-64.so.2 root/lib64/
+root/etc/protocols:  | root/etc
+	@cp -L /etc/protocols root/etc/
+root/etc/services:  | root/etc
+	@cp -L /etc/services root/etc/
+root/usr: | root
+	@mkdir root/usr
+root/usr/lib: | root/usr
+	@mkdir root/usr/lib
+root/usr/lib/x86_64-linux-gnu: | root/usr/lib
+	@mkdir root/usr/lib/x86_64-linux-gnu
+root/usr/lib/x86_64-linux-gnu/gconv: | root/usr/lib/x86_64-linux-gnu
+	@mkdir root/usr/lib/x86_64-linux-gnu/gconv
+root/usr/lib/x86_64-linux-gnu/gconv/UTF-16.so: | root/usr/lib/x86_64-linux-gnu/gconv
+	@cp -L /usr/lib/x86_64-linux-gnu/gconv/UTF-16.so root/usr/lib/x86_64-linux-gnu/gconv/
+root/usr/lib/x86_64-linux-gnu/gconv/UTF-32.so: | root/usr/lib/x86_64-linux-gnu/gconv
+	@cp -L /usr/lib/x86_64-linux-gnu/gconv/UTF-32.so root/usr/lib/x86_64-linux-gnu/gconv/
+root/usr/lib/x86_64-linux-gnu/gconv/UTF-7.so: | root/usr/lib/x86_64-linux-gnu/gconv
+	@cp -L /usr/lib/x86_64-linux-gnu/gconv/UTF-7.so root/usr/lib/x86_64-linux-gnu/gconv/
+root/usr/lib/x86_64-linux-gnu/gconv/gconv-modules: | root/usr/lib/x86_64-linux-gnu/gconv
+	@cp -L /usr/lib/x86_64-linux-gnu/gconv/gconv-modules root/usr/lib/x86_64-linux-gnu/gconv/
+root/usr/lib/x86_64-linux-gnu/gconv/gconv-modules.cache: | root/usr/lib/x86_64-linux-gnu/gconv/
+	@cp -L /usr/lib/x86_64-linux-gnu/gconv/gconv-modules.cache root/usr/lib/x86_64-linux-gnu/gconv/
+root/usr/lib/x86_64-linux-gnu/libgmp.so.10: | root/usr/lib/x86_64-linux-gnu
+	@cp -L /usr/lib/x86_64-linux-gnu/libgmp.so.10 root/usr/lib/x86_64-linux-gnu/
+
+integer-gmp: | root/bin/sh root/lib/x86_64-linux-gnu/libc.so.6 root/lib/x86_64-linux-gnu/libdl.so.2 root/lib/x86_64-linux-gnu/libm.so.6 root/lib/x86_64-linux-gnu/libpthread.so.0 root/lib/x86_64-linux-gnu/librt.so.1 root/lib/x86_64-linux-gnu/libutil.so.1 root/lib/x86_64-linux-gnu/libz.so.1 root/lib64/ld-linux-x86-64.so.2 root/usr/lib/x86_64-linux-gnu/gconv/UTF-16.so root/usr/lib/x86_64-linux-gnu/gconv/UTF-32.so root/usr/lib/x86_64-linux-gnu/gconv/UTF-7.so root/usr/lib/x86_64-linux-gnu/gconv/gconv-modules root/usr/lib/x86_64-linux-gnu/gconv/gconv-modules.cache root/usr/lib/x86_64-linux-gnu/libgmp.so.10 root/lib/x86_64-linux-gnu/libnss_files.so.2 root/lib/x86_64-linux-gnu/libnss_dns.so.2 root/lib/x86_64-linux-gnu/libresolv.so.2 root/etc/protocols root/etc/services
+
+clean:
+	@rm -rf root
+
+.PHONY: default clean


### PR DESCRIPTION
We've been happily using [fpco/haskell-scratch](https://github.com/fpco/haskell-scratch) as the base image for our docker images, not realising that it was last updated about 4 years ago, and inevitably our containers stopped working due to an outdated `libc`.

Since we are linking statically, the only "safe" thing to do is to use the exact same system libraries that are used for building the executables. Hence, we assemble the base image as part of the main build, based on the image we use for building. 

This is rather cheap and prevents any footgunning as we have switched the base image frequently in the past.