### PR TITLE
Make API polymorphic in 'tx'

### DIFF
--- a/src/Oscoin/API/Client.hs
+++ b/src/Oscoin/API/Client.hs
@@ -13,7 +13,7 @@ class Monad m => MonadClient c m where
 
     -- | Returns an error result if a transaction with the given hash
     -- was not found.
-    getTransaction :: Hashed c (Tx c) -> m (Result (TxLookupResponse c))
+    getTransaction :: Hashed c (Tx c) -> m (Result (TxLookupResponse c (Tx c)))
 
     -- | Returns an error result if a value with the given key was not
     -- found.

--- a/src/Oscoin/API/HTTP.hs
+++ b/src/Oscoin/API/HTTP.hs
@@ -6,11 +6,10 @@ module Oscoin.API.HTTP
 import           Oscoin.Prelude hiding (get)
 
 import           Oscoin.Crypto (Crypto)
-import           Oscoin.Crypto.Blockchain.Block (BlockData, BlockHash)
+import           Oscoin.Crypto.Blockchain.Block (BlockHash, SealedBlock)
 import           Oscoin.Crypto.Hash (toHashed)
 import qualified Oscoin.Crypto.Hash as Crypto
 import           Oscoin.Crypto.Hash.RealWorld ()
-import qualified Oscoin.Crypto.PubKey as Crypto
 import           Oscoin.Crypto.PubKey.RealWorld ()
 import           Oscoin.Data.Tx
 import qualified Oscoin.Node as Node
@@ -43,15 +42,12 @@ run port hdl =
 
 app :: ( Typeable c
        , FromHttpApiData (BlockHash c)
-       , Serialise s
        , Serialise (BlockHash c)
-       , Serialise (BlockData c (Tx c))
-       , Serialise (Crypto.PublicKey c)
-       , Serialise (Crypto.Signature c)
-       , Crypto.HasHashing c
+       , Serialise (SealedBlock c tx s)
        , Buildable (Crypto.Hash c)
+       , ApiTx c tx
        )
-    => Node.Handle c (Tx c) s i
+    => Node.Handle c tx s i
     -> IO Wai.Application
 app hdl =
     withLogging hdl $ \logging ->
@@ -67,16 +63,13 @@ staticFilePolicy =
 -- | Entry point for API.
 api :: ( Typeable c
        , FromHttpApiData (BlockHash c)
-       , Serialise s
        , Serialise (BlockHash c)
-       , Serialise (BlockData c (Tx c))
-       , Serialise (Crypto.PublicKey c)
-       , Serialise (Crypto.Signature c)
-       , Crypto.HasHashing c
+       , Serialise (SealedBlock c tx s)
        , Buildable (Crypto.Hash c)
+       , ApiTx c tx
        )
     => Wai.Middleware
-    -> Api c s i ()
+    -> Api c tx s i ()
 api mdlware = do
     middleware $ mdlware
                . Wai.staticPolicy staticFilePolicy
@@ -99,7 +92,6 @@ api mdlware = do
 
     -- /transactions ----------------------------------------------------------
 
-    get  "transactions" Handlers.getAllTransactions
     post "transactions" Handlers.submitTransaction
 
     -- /transactions/:id ------------------------------------------------------

--- a/src/Oscoin/API/Types.hs
+++ b/src/Oscoin/API/Types.hs
@@ -11,7 +11,6 @@ module Oscoin.API.Types
 import           Oscoin.Crypto.Blockchain.Block (BlockHash)
 import           Oscoin.Crypto.Blockchain.Eval (EvalError)
 import           Oscoin.Crypto.Hash (HasHashing, Hash, Hashed)
-import           Oscoin.Crypto.PubKey (PublicKey, Signature)
 import           Oscoin.Data.Tx
 import           Oscoin.Prelude
 
@@ -37,12 +36,12 @@ resultToEither (Ok a ) = Right a
 resultToEither (Err t) = Left t
 
 -- | Response type of a transaction lookup API operation.
-data TxLookupResponse c = TxLookupResponse
-    { txHash          :: Hashed c (Tx c)
+data TxLookupResponse c tx = TxLookupResponse
+    { txHash          :: Hashed c tx
     -- ^ Hash of the transaction.
     , txBlockHash     :: Maybe (BlockHash c)
     -- ^ @BlockHash@ of the 'Block' in which the transaction was included.
-    , txOutput        :: Maybe (Either EvalError (TxOutput c (Tx c)))
+    , txOutput        :: Maybe (Either EvalError (TxOutput c tx))
     -- ^ Output of the transaction if it was evaluated. If the
     -- evaluation was successful the transaction is included in the
     -- block 'txBlockHash'.
@@ -50,28 +49,24 @@ data TxLookupResponse c = TxLookupResponse
     -- ^ Block depth of the 'Block' in which the transaction was included,
     -- which is the number of blocks from the tip up until, and including,
     -- the 'Block' referenced by 'txBlockHash'.
-    , txPayload       :: Tx c
+    , txPayload       :: tx
     -- ^ The transaction itself.
     } deriving (Generic)
 
 deriving instance ( HasHashing c
                   , Show (Hash c)
-                  , Show (Tx c)
-                  , Show (Signature c)
-                  , Show (TxOutput c (Tx c))
-                  ) => Show (TxLookupResponse c)
+                  , Show tx
+                  , Show (TxOutput c tx)
+                  ) => Show (TxLookupResponse c tx)
 deriving instance ( Eq (Hash c)
-                  , Eq (Tx c)
-                  , Eq (Signature c)
-                  , Eq (TxOutput c (Tx c))
-                  ) => Eq (TxLookupResponse c)
+                  , Eq tx
+                  , Eq (TxOutput c tx)
+                  ) => Eq (TxLookupResponse c tx)
 
 instance ( Serial.Serialise (Hash c)
-         , Serial.Serialise (PublicKey c)
-         , Serial.Serialise (Signature c)
-         , Serial.Serialise (Tx c)
-         , Serial.Serialise (TxOutput c (Tx c))
-         ) => Serial.Serialise (TxLookupResponse c)
+         , Serial.Serialise tx
+         , Serial.Serialise (TxOutput c tx)
+         ) => Serial.Serialise (TxLookupResponse c tx)
 
 -- | A transaction receipt. Contains the hashed transaction.
 newtype TxSubmitResponse c tx = TxSubmitResponse (Hashed c tx)

--- a/src/Oscoin/Crypto/Blockchain/Block.hs
+++ b/src/Oscoin/Crypto/Blockchain/Block.hs
@@ -5,6 +5,7 @@
 module Oscoin.Crypto.Blockchain.Block
     ( -- * Types
       Block -- opaque to disallow construction of sealed blocks.
+    , SealedBlock
     , BlockHash
     , BlockHeader(..)
     , BlockData(..)
@@ -236,6 +237,8 @@ data Block c tx s = Block
     , blockHash   :: BlockHash c
     , blockData   :: BlockData c tx
     } deriving Generic
+
+type SealedBlock c tx s = Block c tx (Sealed c s)
 
 data BlockData c tx = BlockData
     { blockDataBeneficiary :: Beneficiary c

--- a/src/Oscoin/Node/Mempool/Internal.hs
+++ b/src/Oscoin/Node/Mempool/Internal.hs
@@ -18,7 +18,6 @@ import qualified Oscoin.Prelude as Prelude
 import           Oscoin.Crypto.Hash (Hash)
 import qualified Oscoin.Crypto.Hash as Crypto
 
-import           Codec.Serialise (Serialise(..))
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 
@@ -32,10 +31,6 @@ deriving instance (Show (Hash c), Show tx) => Show (Mempool c tx)
 deriving instance (Eq (Hash c), Eq tx)  => Eq (Mempool c tx)
 deriving instance Ord (Hash c) => Semigroup (Mempool c tx)
 deriving instance Ord (Hash c) => Monoid (Mempool c tx)
-
-instance (Ord (Hash c), Serialise tx, Serialise (Hash c)) => Serialise (Mempool c tx) where
-    encode (Mempool txs) = encode (Map.elems txs)
-    decode               = Mempool <$> decode
 
 -- | Lookup a transaction in a mempool.
 lookup :: Ord (Hash c) => Crypto.Hashed c tx -> Mempool c tx -> Maybe tx

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -17,6 +17,7 @@ import qualified Test.Control.Concurrent.RateLimit
 import qualified Test.Data.Conduit.Serialise
 import qualified Test.Data.Sequence.Circular
 import qualified Test.Oscoin.API
+import qualified Test.Oscoin.API.HTTP
 import qualified Test.Oscoin.Configuration
 import qualified Test.Oscoin.Crypto.Blockchain.Eval
 import qualified Test.Oscoin.Crypto.Blockchain.GeneratorsTest
@@ -74,6 +75,7 @@ main = do
                 , Test.Data.Conduit.Serialise.tests
                 , Test.Data.Sequence.Circular.tests
                 , Test.Oscoin.API.tests crypto
+                , Test.Oscoin.API.HTTP.tests crypto
                 , Test.Oscoin.Configuration.tests
                 , Test.Oscoin.Crypto.Blockchain.Eval.tests crypto
                 , Test.Oscoin.Crypto.Blockchain.GeneratorsTest.tests crypto

--- a/test/Oscoin/Tests.hs
+++ b/test/Oscoin/Tests.hs
@@ -4,7 +4,6 @@ module Oscoin.Tests
 
 import qualified Oscoin.Consensus.Config as Consensus
 
-import qualified Oscoin.Test.API.HTTP as HTTP
 import qualified Oscoin.Test.CLI as CLI
 import qualified Oscoin.Test.Consensus as Consensus
 import           Oscoin.Test.Crypto
@@ -25,9 +24,7 @@ import           Data.ByteArray.Orphans ()
 
 tests :: forall c. Dict (IsCrypto c) -> Consensus.Config -> TestTree
 tests d@Dict config = testGroup "Oscoin"
-    [ testGroup      "API.HTTP"                       (HTTP.tests d)
-    -- ^ Testing HTTP API constructing HTTP requests manually
-    , testGroup      "CLI"                            CLI.tests
+    [ testGroup      "CLI"                            CLI.tests
     , Consensus.tests d config
     , testGroup      "Address"                        (Address.tests d)
     , testGroup      "P2P"                            (P2P.tests d)

--- a/test/Test/Oscoin/API/HTTP.hs
+++ b/test/Test/Oscoin/API/HTTP.hs
@@ -1,4 +1,4 @@
-module Oscoin.Test.API.HTTP
+module Test.Oscoin.API.HTTP
     ( tests
     ) where
 
@@ -24,8 +24,8 @@ import           Test.QuickCheck.Monadic
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-tests :: forall c. Dict (IsCrypto c) -> [TestTree]
-tests Dict =
+tests :: forall c. Dict (IsCrypto c) -> TestTree
+tests Dict = testGroup "Test.Oscoin.API.HTTP"
     [ test "Smoke test" (smokeTestOscoinAPI @c)
     , testGroup "POST /transactions"
         [ testGroup "400 Bad Request"

--- a/test/Test/Oscoin/API/HTTP.hs
+++ b/test/Test/Oscoin/API/HTTP.hs
@@ -76,27 +76,17 @@ smokeTestOscoinAPI = do
     liftIO $ httpTest emptyNodeState $ do
         get "/" >>= assertStatus ok200
 
-        -- The mempool is empty.
-        get "/transactions" >>=
-            assertStatus ok200 <>
-            assertResultOK ([] @(Tx c))
-
         -- Submit the transaction to the mempool.
         post "/transactions" tx >>=
             assertStatus accepted202 <>
             assertResultOK (API.TxSubmitResponse $ Crypto.hash @c tx)
-
-        -- Get the mempool once again, make sure the transaction is in there.
-        get "/transactions" >>=
-            assertStatus ok200 <>
-            assertResultOK [tx]
 
         getTransactionReturns txHash $ unconfirmedTx tx
 
 unconfirmedTx
     :: IsCrypto c
     => Tx c
-    -> API.TxLookupResponse c
+    -> API.TxLookupResponse c (Tx c)
 unconfirmedTx tx = API.TxLookupResponse
     { txHash = Crypto.hash tx
     , txBlockHash = Nothing
@@ -108,7 +98,7 @@ unconfirmedTx tx = API.TxLookupResponse
 getTransactionReturns
     :: IsCrypto c
     => Hashed c (Tx c)
-    -> API.TxLookupResponse c
+    -> API.TxLookupResponse c (Tx c)
     -> Session c ()
 getTransactionReturns txHash expected =
     get ("/transactions/" <> toUrlPiece (Crypto.fromHashed txHash)) >>=


### PR DESCRIPTION
The code in `Oscoin.API.HTTP.Handlers` and related modules is now 
 polymorphic in the transaction type. See #552.

 As part of this change we also eliminate the `getAllTransactions` endpoint.
 It’s implementation did not use a serialisation of a transaction list but
 rather a serialisation of the Mempool instance. This coupled the API to the
 concrete mempool instance used by the node.