### PR TITLE
Node syncing - Part 1 (Types, abstractions, sim monad and basic tests)

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -48,3 +48,6 @@
 - ignore:
     name: Avoid restricted qualification
     within: [System.Console.Option]
+- ignore:
+    name: Avoid restricted qualification
+    within: [Oscoin.Protocol.Sync]

--- a/package.yaml
+++ b/package.yaml
@@ -199,6 +199,7 @@ tests:
       - temporary
       - text
       - transformers
+      - unordered-containers
       - wai
       - wai-extra
 

--- a/package.yaml
+++ b/package.yaml
@@ -76,6 +76,7 @@ library:
     - safe-exceptions
     - semigroups
     - serialise
+    - split
     - splitmix
     - sqlite-simple
     - stm >=2.4.5.0
@@ -188,6 +189,7 @@ tests:
       - safe-exceptions
       - serialise
       - sqlite-simple
+      - split
       - splitmix
       - stm-conduit
       - streaming-commons

--- a/package.yaml
+++ b/package.yaml
@@ -189,7 +189,6 @@ tests:
       - safe-exceptions
       - serialise
       - sqlite-simple
-      - split
       - splitmix
       - stm-conduit
       - streaming-commons

--- a/src/Oscoin/Consensus/Types.hs
+++ b/src/Oscoin/Consensus/Types.hs
@@ -31,9 +31,6 @@ type Validate c tx s =
     -> Block c tx (Sealed c s)       -- ^ Block to be validated.
     -> Either (ValidationError c) () -- ^ Either an error or @()@.
 
-type Expected a = a
-type Actual   a = a
-
 -- | A block validation error.
 data ValidationError c =
       InvalidHeight           (Expected Height) (Actual Height)

--- a/src/Oscoin/Prelude.hs
+++ b/src/Oscoin/Prelude.hs
@@ -44,6 +44,8 @@ module Oscoin.Prelude
     , module X
     , module Control.Exception.Safe
 
+    , Actual
+    , Expected
     , String
     , LText
     , LByteString
@@ -461,3 +463,8 @@ notImplemented = withFrozenCallStack (error "Not implemented")
 {-# WARNING undefined "'undefined' remains in code" #-}
 undefined :: (HasCallStack) => a
 undefined = withFrozenCallStack (error "Prelude.undefined")
+
+-- Simple type aliases that makes easier for the reader to distinguish, in
+-- a type signature, which is the expected vs actual value.
+type Expected a = a
+type Actual   a = a

--- a/src/Oscoin/Protocol/Sync.hs
+++ b/src/Oscoin/Protocol/Sync.hs
@@ -6,45 +6,48 @@ module Oscoin.Protocol.Sync
     -- * Types
     , Sync(..)
     , SyncError(..)
+    , Timeout(..)
     , ActivePeer
     , ActivePeers
-    , NetworkLayer(..)
+    , SyncEvent(..)
+    , SyncContext(..)
     , DataFetcher(..)
+    , ProtocolRequest(..)
     , SProtocolRequest(..)
-    , ProtocolResponse(..)
+    , ProtocolResponse
     , Range(..)
+
+    -- * Pure functions
+    , isMutable
+    , isDone
+    , immutableRange
 
     -- * Testing internals
     , withActivePeers
+    , bestTip
+    , bestHeight
     ) where
 
 import           Oscoin.Crypto.Hash (Hash)
 import           Oscoin.Prelude
 
 import           Oscoin.Consensus.Nakamoto (PoW)
+
 import           Oscoin.Crypto.Blockchain.Block
-                 ( Block
-                 , BlockHash
-                 , BlockHeader
-                 , Height
-                 , Sealed
-                 , blockHeader
-                 , blockHeight
-                 )
-import           Oscoin.Crypto.Hash (HasHashing)
+                 (Block, BlockHeader, Height, Sealed, blockHeader, blockHeight)
 import qualified Oscoin.Crypto.PubKey as Crypto
 import           Oscoin.Data.Tx
 import           Oscoin.P2P as P2P
+import           Oscoin.Storage.Block.Abstract (BlockStoreReader)
+import qualified Oscoin.Storage.Block.Abstract as BlockStore
 import           Oscoin.Telemetry.Trace
+import           Oscoin.Time (Duration)
 import           Oscoin.Time.Chrono
 
-import           Codec.Serialise as CBOR
 import           Data.Hashable (Hashable)
 import           Data.HashSet (HashSet)
 import qualified Data.HashSet as HS
-import qualified Network.Gossip.HyParView as Gossip
-import           Network.Gossip.IO.Peer (Peer(..))
-import qualified Network.HTTP.Client as HTTP
+import           GHC.Natural
 
 {------------------------------------------------------------------------------
   Types
@@ -53,12 +56,25 @@ import qualified Network.HTTP.Client as HTTP
 type ActivePeer c  = NodeInfo c
 type ActivePeers c = HashSet (ActivePeer c)
 
+data SyncEvent c tx s=
+      SyncBlock (Block c tx (Sealed c s))
+    | SyncBlockHeader (BlockHeader c s)
+
 data SyncError c =
-      RequestTimeout ProtocolRequest (NodeInfo c) Int
+      RequestTimeout ProtocolRequest (NodeInfo c) Timeout
       -- ^ The given peer exceeded the request timeout when serving this
       -- 'SyncProtocolRequest'.
     | NoActivePeers
       -- ^ There are not active peers to talk to.
+    | NoBestTipFound
+      -- ^ It was not possible to fetch a valid tip from our peers.
+    | AllPeersTimeoutError
+      -- ^ All the queried peers didn't respond in the allocated timeout.
+
+data Timeout =
+    MaxTimeoutExceeded (Expected Duration)
+    -- ^ The operation exceeded the expected timeout, in nanoseconds.
+    deriving (Show, Eq)
 
 deriving instance (Show (Crypto.PublicKey c)) => Show (SyncError c)
 deriving instance (Eq (Crypto.PublicKey c)) => Eq (SyncError c)
@@ -95,119 +111,149 @@ type family ProtocolRequestArgs (c :: ProtocolRequest) :: * where
 
 -- | A protocol response, indexed by the corresponding 'ProtocolRequest, so
 -- that matching the wrong type will result in a type error.
-data ProtocolResponse (r :: ProtocolRequest) where
-    GetTipResp :: forall c tx s. Serialise (BlockHash c)
-               => Block c tx (Sealed c s)
-               -> ProtocolResponse 'GetTip
-    GetBlocksResp :: forall c tx s. (NewestFirst [] (Block c tx (Sealed c s)))
-                  -> ProtocolResponse 'GetBlocks
-    GetBlockHeadersResp :: forall c s. (NewestFirst [] (BlockHeader c (Sealed c s)))
-                  -> ProtocolResponse 'GetBlockHeaders
+type family ProtocolResponse c tx s (r :: ProtocolRequest) :: *
+
+type instance ProtocolResponse c (Tx c) PoW 'GetTip =
+        Block c (Tx c) (Sealed c PoW)
+type instance ProtocolResponse c (Tx c) PoW 'GetBlocks =
+        OldestFirst [] (Block c (Tx c) (Sealed c PoW))
+type instance ProtocolResponse c tx PoW 'GetBlockHeaders =
+        OldestFirst [] (BlockHeader c (Sealed c PoW))
 
 -- | A data fetcher is a wrapper around an action that given a (singleton)
 -- 'SProtocolRequest' and a set of arguments, returns a 'ProtocolResponse'
 -- while producting some side-effect in @m@.
-newtype DataFetcher c m =
+newtype DataFetcher c tx s m =
     DataFetcher {
       fetch :: forall r. ActivePeer c
             -> SProtocolRequest r
             -> ProtocolRequestArgs r
-            -> m (ProtocolResponse r)
+            -> m (Either Timeout (ProtocolResponse c tx s r))
                 }
 
 -- | An opaque reference to a record of functions which can be used to query
--- the network for information.
-data NetworkLayer c m = NetworkLayer
-    { nlActivePeers :: m (ActivePeers c)
-    , nlDataFetcher :: DataFetcher c m
-    , nlEventTracer :: Tracer m
+-- the network and the other parts of the system for information.
+data SyncContext c tx s m = SyncContext
+    { scNu               :: Nu
+    -- ^ The number of maximum allowed rollbacks. It corresponds to /nu/ from
+    -- the spec and it's known as the 'mutableChainSuffix' in the rest of the
+    -- codebase.
+    , scActivePeers      :: m (ActivePeers c)
+    , scDataFetcher      :: DataFetcher c tx s m
+    , scEventTracer      :: Tracer m
+    , scConcurrently     :: forall a b t.  Traversable t => t a -> (a -> m b) -> m (t b)
+    , scLocalChainReader :: BlockStoreReader c tx s m
     }
 
-newtype Sync c m a =
-    Sync { runSync :: ExceptT (SyncError c) (ReaderT (NetworkLayer c m) m) a }
+-- | A sync monad over @m@, that can throw 'SyncError's.
+newtype Sync c tx s m a =
+    Sync { runSync :: ExceptT (SyncError c) (ReaderT (SyncContext c tx s m) m) a }
     deriving ( Functor
              , Applicative
              , Monad
              , MonadError (SyncError c)
-             , MonadReader (NetworkLayer c m)
+             , MonadReader (SyncContext c tx s m)
              )
 
-instance MonadTrans (Sync c) where
+instance MonadTrans (Sync c tx s) where
     lift = Sync . lift . lift
 
 {------------------------------------------------------------------------------
   Convenience functions over Sync
 ------------------------------------------------------------------------------}
 
-withActivePeers :: Monad m => (ActivePeers c -> Sync c m a) -> Sync c m a
+withActivePeers
+    :: Monad m
+    => (ActivePeers c -> Sync c tx s m a)
+    -> Sync c tx s m a
 withActivePeers f = do
-    net <- ask
-    activePeers <- lift (nlActivePeers net)
+    ctx <- ask
+    activePeers <- lift (scActivePeers ctx)
     when (HS.null activePeers) $ throwError NoActivePeers
     f activePeers
-
-{------------------------------------------------------------------------------
-  Scary IO implementation
-------------------------------------------------------------------------------}
-
-newDataFetcherIO
-    :: forall c.
-    ( Serialise (BlockHash c)
-    , Serialise (Crypto.PublicKey c)
-    , Serialise (Crypto.Signature c)
-    , HasHashing c
-    )
-    => HTTP.Manager
-    -> DataFetcher c IO
-newDataFetcherIO httpManager = DataFetcher $ \peer -> \case
-    SGetTip -> \() -> do
-        rq0 <- HTTP.parseUrlThrow "/blockchain/tip"
-        let rq = rq0 { HTTP.port = 8477 -- FIXME(adn) broadcast & handshake.
-                     }
-
-       -- Trying to issue a wrong response type will trigger a compilation
-       -- error similar to:
-       -- • Couldn't match type ‘'GetBlockHeaders’ with ‘'GetTip’
-       -- Expected type: IO (ProtocolResponse r)
-       -- Actual type: IO (ProtocolResponse 'GetBlockHeaders)
-
-        HTTP.withResponse rq httpManager $ \res -> do
-            cborBlob <- HTTP.brRead (HTTP.responseBody res)
-            pure $ GetTipResp @c @(Tx c) @PoW (CBOR.deserialise . toS $ cborBlob)
-
-    SGetBlocks -> \Range{..} -> notImplemented
-    SGetBlockHeaders -> \Range{..} -> notImplemented
-
--- | Constructs a new 'Tracer' over @IO@.
-newEventTracerIO :: Probe IO -> Tracer IO
-newEventTracerIO = probed
-
--- | Constructs a new 'NetworkLayer' over @IO@.
-newNetworkLayerIO
-    :: ( Eq (Crypto.PublicKey c)
-       , Hashable (Crypto.PublicKey c)
-       , Serialise (BlockHash c)
-       , Serialise (Crypto.PublicKey c)
-       , Serialise (Crypto.Signature c)
-       , HasHashing c
-       )
-    => Probe IO
-    -> GossipT c IO (NetworkLayer c IO)
-newNetworkLayerIO probe = do
-    env <- ask
-    mgr <- liftIO (HTTP.newManager HTTP.defaultManagerSettings)
-    pure $ NetworkLayer
-        { nlActivePeers = HS.map peerNodeId . Gossip.active <$> P2P.getPeers' env
-        , nlDataFetcher = newDataFetcherIO mgr
-        , nlEventTracer = newEventTracerIO probe
-        }
 
 {------------------------------------------------------------------------------
   Monadic operations
 ------------------------------------------------------------------------------}
 
-bestTip :: Sync c m (Block c tx s)
-bestTip = notImplemented
+-- The 'bestTip' operation from the spec. It tries to fetch the tips
+-- concurrently, and picks the highest one.
+-- TODO(adn) /Optimisation/: Build a frequency map and pick the one
+-- returned by most peers. In case of draws, pick the highest one.
+bestTip
+    :: ( ProtocolResponse c tx s 'GetTip ~ Block c tx (Sealed c s)
+       , Monad m
+       ) => Sync c tx s m (ProtocolResponse c tx s 'GetTip)
+bestTip = withActivePeers $ \active -> do
+    dataFetcher     <- scDataFetcher  <$> ask
+    forConcurrently <- scConcurrently <$> ask
+    results  <- lift $
+        forConcurrently (HS.toList active) (\a -> fetch dataFetcher a SGetTip ())
+    case partitionEithers results of
+      (_t:_, [])           -> throwError AllPeersTimeoutError
+      ([], [])             -> throwError NoBestTipFound
+      (_timeouts, allTips) -> pure $ maximumBy highest allTips
+  where
+      highest b1 b2 = height b1 `compare` height b2
+
+bestHeight
+    :: ( ProtocolResponse c tx s 'GetTip ~ Block c tx (Sealed c s)
+       , Monad m
+       )
+    => Sync c tx s m Height
+bestHeight = map height bestTip
+
+
+syncImmutable
+    :: ( ProtocolResponse c tx s 'GetTip ~ Block c tx (Sealed c s)
+       , ProtocolResponse c tx s 'GetBlocks ~ OldestFirst [] (Block c tx (Sealed c s))
+       , Hashable (Block c tx (Sealed c s))
+       , Monad m
+       , Eq tx
+       , Eq s
+       , Eq (Hash c)
+       )
+    => Sync c tx s m ()
+syncImmutable = do
+    ctx <- ask
+    let nu      = scNu ctx
+    let fetcher = scDataFetcher ctx
+
+    bestRemoteTip <- bestTip
+    localTip      <- lift (BlockStore.getTip (scLocalChainReader ctx))
+    unless (isDone localTip bestRemoteTip) $ do
+        case immutableRange nu localTip bestRemoteTip of
+          Nothing | isMutable nu localTip bestRemoteTip ->
+              syncMutable
+          Nothing  -> pure ()
+          Just rng -> withActivePeers $ \ activePeers -> do
+              -- FIXME(adn) Extremely naive and wrong implementation
+              -- for now, we basically request the /full range/ to everybody,
+              -- filtering out dupes, which is not feasible for production and
+              -- is terribly wasteful, obviously. A better strategy might be
+              -- to split the work equally into multiple (capped) ranges
+              -- (say, 500 blocks at the time) and then try to fetch each of
+              -- those from all the peers.
+              requestedBlocks <- lift $
+                  foldM (\blocks activePeer -> do
+                           res <- fetch fetcher activePeer SGetBlocks rng
+                           case res of
+                             Left _timeout -> pure blocks -- TODO(adn) Telemetry
+                             Right blks    -> pure $ foldl' (flip HS.insert) blocks (toOldestFirst blks)
+                        )
+                        HS.empty
+                        activePeers
+              forM (HS.toList requestedBlocks) $ \_ -> pure ()
+
+              -- Chase the best tip, which might have moved in the meantime
+              syncImmutable
+
+syncMutable
+    :: ( ProtocolResponse c tx s 'GetTip ~ Block c tx (Sealed c s)
+       , Monad m
+       )
+    => Sync c tx s m ()
+syncMutable = notImplemented
 
 {------------------------------------------------------------------------------
   Pure functions
@@ -217,13 +263,13 @@ height :: Block c tx s -> Height
 height = blockHeight . blockHeader
 
 -- | The mutable chain suffix, from the spec.
-type Nu = Integer
+type Nu = Natural
 
 -- | Returns 'True' if the difference between the height of the best tip and
 -- the tip of the node falls within the \"mutable range\" of the blockchain.
 isMutable :: Nu -> Block c tx s -> Block c tx s -> Bool
 isMutable nu myTip bestRemoteTip =
-    height bestRemoteTip - height myTip <= nu
+    height bestRemoteTip - height myTip <= toInteger nu
 
 -- | Returns 'True' if the node finished syncing all the blocks.
 isDone
@@ -234,10 +280,25 @@ isDone
     => Block c tx s -> Block c tx s -> Bool
 isDone myTip bestRemoteTip = bestRemoteTip == myTip
 
+-- | Returns the immutable range of blocks that can be safely fetched without
+-- worrying about rollbacks.
+immutableRange
+    :: Nu
+    -> Block c tx s
+    -> Block c tx s
+    -> Maybe Range
+immutableRange nu localTip remoteBestTip
+  | outOfRange = Nothing
+  | otherwise  = Just (Range start end)
+  where
+    start      = succ (height localTip)
+    end        = height remoteBestTip - toInteger nu
+    outOfRange = end < start
+
 {------------------------------------------------------------------------------
   Monad-agnostic algorithm
 ------------------------------------------------------------------------------}
 
 -- | The syncing algorithm proper.
-syncNode :: NetworkLayer c m -> m ()
+syncNode :: SyncContext c tx s m -> m ()
 syncNode = notImplemented

--- a/src/Oscoin/Protocol/Sync.hs
+++ b/src/Oscoin/Protocol/Sync.hs
@@ -1,0 +1,243 @@
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE UndecidableInstances #-}
+module Oscoin.Protocol.Sync
+    ( syncNode
+
+    -- * Types
+    , Sync(..)
+    , SyncError(..)
+    , ActivePeer
+    , ActivePeers
+    , NetworkLayer(..)
+    , DataFetcher(..)
+    , SProtocolRequest(..)
+    , ProtocolResponse(..)
+    , Range(..)
+
+    -- * Testing internals
+    , withActivePeers
+    ) where
+
+import           Oscoin.Crypto.Hash (Hash)
+import           Oscoin.Prelude
+
+import           Oscoin.Consensus.Nakamoto (PoW)
+import           Oscoin.Crypto.Blockchain.Block
+                 ( Block
+                 , BlockHash
+                 , BlockHeader
+                 , Height
+                 , Sealed
+                 , blockHeader
+                 , blockHeight
+                 )
+import           Oscoin.Crypto.Hash (HasHashing)
+import qualified Oscoin.Crypto.PubKey as Crypto
+import           Oscoin.Data.Tx
+import           Oscoin.P2P as P2P
+import           Oscoin.Telemetry.Trace
+import           Oscoin.Time.Chrono
+
+import           Codec.Serialise as CBOR
+import           Data.Hashable (Hashable)
+import           Data.HashSet (HashSet)
+import qualified Data.HashSet as HS
+import qualified Network.Gossip.HyParView as Gossip
+import           Network.Gossip.IO.Peer (Peer(..))
+import qualified Network.HTTP.Client as HTTP
+
+{------------------------------------------------------------------------------
+  Types
+------------------------------------------------------------------------------}
+
+type ActivePeer c  = NodeInfo c
+type ActivePeers c = HashSet (ActivePeer c)
+
+data SyncError c =
+      RequestTimeout ProtocolRequest (NodeInfo c) Int
+      -- ^ The given peer exceeded the request timeout when serving this
+      -- 'SyncProtocolRequest'.
+    | NoActivePeers
+      -- ^ There are not active peers to talk to.
+
+deriving instance (Show (Crypto.PublicKey c)) => Show (SyncError c)
+deriving instance (Eq (Crypto.PublicKey c)) => Eq (SyncError c)
+
+-- | A closed range [lo,hi].
+data Range = Range
+    { start :: Height
+    , end   :: Height
+    }
+
+data ProtocolRequest =
+      GetTip
+    -- ^ Get the tip of the best chain.
+    | GetBlocks
+    -- ^ Get some blocks.
+    | GetBlockHeaders
+    -- ^ Get some block headers.
+    deriving (Show, Eq)
+
+-- | The singleton type for 'ProtocolRequest', capable of carrying some
+-- witness (in this case, 'ProtocolRequest').
+data SProtocolRequest r where
+  SGetTip :: SProtocolRequest 'GetTip
+  SGetBlocks :: SProtocolRequest 'GetBlocks
+  SGetBlockHeaders :: SProtocolRequest 'GetBlockHeaders
+
+-- | A closed type family mapping each 'ProtocolRequest' to its list of
+-- arguments, so that we can use the 'ProtocolRequest' (where all constructors
+-- have kind /*/) as a constraint.
+type family ProtocolRequestArgs (c :: ProtocolRequest) :: * where
+    ProtocolRequestArgs 'GetTip          = ()
+    ProtocolRequestArgs 'GetBlocks       = Range
+    ProtocolRequestArgs 'GetBlockHeaders = Range
+
+-- | A protocol response, indexed by the corresponding 'ProtocolRequest, so
+-- that matching the wrong type will result in a type error.
+data ProtocolResponse (r :: ProtocolRequest) where
+    GetTipResp :: forall c tx s. Serialise (BlockHash c)
+               => Block c tx (Sealed c s)
+               -> ProtocolResponse 'GetTip
+    GetBlocksResp :: forall c tx s. (NewestFirst [] (Block c tx (Sealed c s)))
+                  -> ProtocolResponse 'GetBlocks
+    GetBlockHeadersResp :: forall c s. (NewestFirst [] (BlockHeader c (Sealed c s)))
+                  -> ProtocolResponse 'GetBlockHeaders
+
+-- | A data fetcher is a wrapper around an action that given a (singleton)
+-- 'SProtocolRequest' and a set of arguments, returns a 'ProtocolResponse'
+-- while producting some side-effect in @m@.
+newtype DataFetcher c m =
+    DataFetcher {
+      fetch :: forall r. ActivePeer c
+            -> SProtocolRequest r
+            -> ProtocolRequestArgs r
+            -> m (ProtocolResponse r)
+                }
+
+-- | An opaque reference to a record of functions which can be used to query
+-- the network for information.
+data NetworkLayer c m = NetworkLayer
+    { nlActivePeers :: m (ActivePeers c)
+    , nlDataFetcher :: DataFetcher c m
+    , nlEventTracer :: Tracer m
+    }
+
+newtype Sync c m a =
+    Sync { runSync :: ExceptT (SyncError c) (ReaderT (NetworkLayer c m) m) a }
+    deriving ( Functor
+             , Applicative
+             , Monad
+             , MonadError (SyncError c)
+             , MonadReader (NetworkLayer c m)
+             )
+
+instance MonadTrans (Sync c) where
+    lift = Sync . lift . lift
+
+{------------------------------------------------------------------------------
+  Convenience functions over Sync
+------------------------------------------------------------------------------}
+
+withActivePeers :: Monad m => (ActivePeers c -> Sync c m a) -> Sync c m a
+withActivePeers f = do
+    net <- ask
+    activePeers <- lift (nlActivePeers net)
+    when (HS.null activePeers) $ throwError NoActivePeers
+    f activePeers
+
+{------------------------------------------------------------------------------
+  Scary IO implementation
+------------------------------------------------------------------------------}
+
+newDataFetcherIO
+    :: forall c.
+    ( Serialise (BlockHash c)
+    , Serialise (Crypto.PublicKey c)
+    , Serialise (Crypto.Signature c)
+    , HasHashing c
+    )
+    => HTTP.Manager
+    -> DataFetcher c IO
+newDataFetcherIO httpManager = DataFetcher $ \peer -> \case
+    SGetTip -> \() -> do
+        rq0 <- HTTP.parseUrlThrow "/blockchain/tip"
+        let rq = rq0 { HTTP.port = 8477 -- FIXME(adn) broadcast & handshake.
+                     }
+
+       -- Trying to issue a wrong response type will trigger a compilation
+       -- error similar to:
+       -- • Couldn't match type ‘'GetBlockHeaders’ with ‘'GetTip’
+       -- Expected type: IO (ProtocolResponse r)
+       -- Actual type: IO (ProtocolResponse 'GetBlockHeaders)
+
+        HTTP.withResponse rq httpManager $ \res -> do
+            cborBlob <- HTTP.brRead (HTTP.responseBody res)
+            pure $ GetTipResp @c @(Tx c) @PoW (CBOR.deserialise . toS $ cborBlob)
+
+    SGetBlocks -> \Range{..} -> notImplemented
+    SGetBlockHeaders -> \Range{..} -> notImplemented
+
+-- | Constructs a new 'Tracer' over @IO@.
+newEventTracerIO :: Probe IO -> Tracer IO
+newEventTracerIO = probed
+
+-- | Constructs a new 'NetworkLayer' over @IO@.
+newNetworkLayerIO
+    :: ( Eq (Crypto.PublicKey c)
+       , Hashable (Crypto.PublicKey c)
+       , Serialise (BlockHash c)
+       , Serialise (Crypto.PublicKey c)
+       , Serialise (Crypto.Signature c)
+       , HasHashing c
+       )
+    => Probe IO
+    -> GossipT c IO (NetworkLayer c IO)
+newNetworkLayerIO probe = do
+    env <- ask
+    mgr <- liftIO (HTTP.newManager HTTP.defaultManagerSettings)
+    pure $ NetworkLayer
+        { nlActivePeers = HS.map peerNodeId . Gossip.active <$> P2P.getPeers' env
+        , nlDataFetcher = newDataFetcherIO mgr
+        , nlEventTracer = newEventTracerIO probe
+        }
+
+{------------------------------------------------------------------------------
+  Monadic operations
+------------------------------------------------------------------------------}
+
+bestTip :: Sync c m (Block c tx s)
+bestTip = notImplemented
+
+{------------------------------------------------------------------------------
+  Pure functions
+------------------------------------------------------------------------------}
+
+height :: Block c tx s -> Height
+height = blockHeight . blockHeader
+
+-- | The mutable chain suffix, from the spec.
+type Nu = Integer
+
+-- | Returns 'True' if the difference between the height of the best tip and
+-- the tip of the node falls within the \"mutable range\" of the blockchain.
+isMutable :: Nu -> Block c tx s -> Block c tx s -> Bool
+isMutable nu myTip bestRemoteTip =
+    height bestRemoteTip - height myTip <= nu
+
+-- | Returns 'True' if the node finished syncing all the blocks.
+isDone
+    :: ( Eq tx
+       , Eq s
+       , Eq (Hash c)
+       )
+    => Block c tx s -> Block c tx s -> Bool
+isDone myTip bestRemoteTip = bestRemoteTip == myTip
+
+{------------------------------------------------------------------------------
+  Monad-agnostic algorithm
+------------------------------------------------------------------------------}
+
+-- | The syncing algorithm proper.
+syncNode :: NetworkLayer c m -> m ()
+syncNode = notImplemented

--- a/src/Oscoin/Protocol/Sync/Mock.hs
+++ b/src/Oscoin/Protocol/Sync/Mock.hs
@@ -1,15 +1,20 @@
+{-# LANGUAGE DataKinds #-}
 module Oscoin.Protocol.Sync.Mock where
 
 import           Oscoin.Crypto
 import           Oscoin.Prelude
 
-import           Oscoin.Crypto.Blockchain (Blockchain, tip)
-import           Oscoin.Crypto.Blockchain.Block (BlockHash)
+import           Oscoin.Crypto.Blockchain (Blockchain, blocks, tip)
+import           Oscoin.Crypto.Blockchain.Block
+                 (Block, BlockHeader, Score, Sealed, blockHeader, blockHeight)
+import           Oscoin.Crypto.Hash (Hash)
+import qualified Oscoin.Crypto.Hash as Crypto
 import qualified Oscoin.Crypto.PubKey as Crypto
 import           Oscoin.Protocol.Sync
+import qualified Oscoin.Storage.Block.Pure as BlockStore.Pure
 import           Oscoin.Telemetry.Trace
+import           Oscoin.Time.Chrono as Chrono
 
-import           Codec.Serialise as CBOR
 import           Data.Hashable (Hashable)
 import           Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HM
@@ -17,16 +22,34 @@ import           Data.HashSet (HashSet)
 import qualified Data.HashSet as HS
 import           Lens.Micro (Lens', lens)
 
+
+{------------------------------------------------------------------------------
+  Instances
+------------------------------------------------------------------------------}
+
+type instance ProtocolResponse c MockTx MockSeal 'GetTip =
+        Block c MockTx (Sealed c MockSeal)
+type instance ProtocolResponse c MockTx MockSeal 'GetBlocks =
+        NewestFirst [] (Block c MockTx (Sealed c MockSeal))
+type instance ProtocolResponse c MockTx MockSeal 'GetBlockHeaders =
+        NewestFirst [] (BlockHeader c (Sealed c MockSeal))
+
 {------------------------------------------------------------------------------
   Types
 ------------------------------------------------------------------------------}
 
+type MockTx = Word8
+
+type MockSeal = Text
+
 type MockPeer = ActivePeer MockCrypto
 
-type PeerData = Blockchain MockCrypto [Word8] Text
+type PeerData = Blockchain MockCrypto MockTx MockSeal
 
 data WorldState = WorldState
-    { _mockPeerState :: HashMap MockPeer PeerData
+    { _mockPeerState  :: HashMap MockPeer PeerData
+    , _mockLocalChain :: BlockStore.Pure.Handle MockCrypto MockTx MockSeal
+
     }
 
 type Sim = StateT WorldState Identity
@@ -37,47 +60,84 @@ type Sim = StateT WorldState Identity
 
 mockPeers :: Lens' WorldState (HashMap MockPeer PeerData)
 mockPeers = lens _mockPeerState (\s a -> s { _mockPeerState = a })
-{-# INLINE mockPeers #-}
+
+chainReaderL :: Lens' WorldState    (BlockStore.Pure.Handle MockCrypto MockTx MockSeal)
+chainReaderL = lens _mockLocalChain (\s a -> s { _mockLocalChain = a })
+
+
+-- Score blocks by height.
+mockScore :: Block c tx (Sealed c s) -> Score
+mockScore = blockHeight . blockHeader
 
 emptyWorldState
     :: ( Eq (Crypto.PublicKey MockCrypto)
+       , Ord (Hash MockCrypto)
        , Hashable (Crypto.PublicKey MockCrypto)
        )
-    => WorldState
-emptyWorldState = WorldState mempty
+    => Block MockCrypto MockTx (Sealed MockCrypto MockSeal)
+    -- ^ The genesis block.
+    -> WorldState
+emptyWorldState genesisBlock =
+    WorldState mempty (BlockStore.Pure.genesisBlockStore genesisBlock mockScore)
 
 toMockPeers :: WorldState -> HashSet MockPeer
-toMockPeers (WorldState m) = HS.fromMap (() <$ m)
+toMockPeers (WorldState m _) = HS.fromMap (() <$ m)
 
--- | A mock 'NetworkLayer' operating in a mock/simulated environment.
-mockLayer
+-- | A mock 'SyncContext' operating in a mock/simulated environment.
+mockContext
     :: ( Eq (Crypto.PublicKey MockCrypto)
        , Hashable (Crypto.PublicKey MockCrypto)
-       , Serialise (BlockHash MockCrypto)
+       , Crypto.Hashable MockCrypto MockTx
        )
-    => NetworkLayer MockCrypto Sim
-mockLayer =
-    NetworkLayer
-        { nlActivePeers = gets toMockPeers
-        , nlDataFetcher = mkDataFetcherSim
-        , nlEventTracer = probed noProbe
+    => SyncContext MockCrypto MockTx MockSeal Sim
+mockContext =
+    SyncContext
+        { scNu               = 0  -- can be adjusted later.
+        , scActivePeers      = gets toMockPeers
+        , scDataFetcher      = mkDataFetcherSim
+        , scEventTracer      = probed noProbe
+        , scConcurrently     = forM
+        , scLocalChainReader = fst (BlockStore.Pure.mkStateBlockStore chainReaderL)
         }
+
 
 -- | Creates a new simulation 'DataFetcher'.
 mkDataFetcherSim
     :: ( Eq (Crypto.PublicKey MockCrypto)
        , Hashable (Crypto.PublicKey MockCrypto)
-       , Serialise (BlockHash MockCrypto)
        )
-    => DataFetcher MockCrypto Sim
+    => DataFetcher MockCrypto MockTx MockSeal Sim
 mkDataFetcherSim = DataFetcher $ \peer -> \case
     SGetTip -> \() -> do
         WorldState{..} <- get
         case HM.lookup peer _mockPeerState of
             Nothing -> panic "newDataFetcherSim - precondition violation, empty blockchain."
-            Just bc -> pure $ GetTipResp (tip bc)
-    SGetBlocks -> \Range{..} -> notImplemented
-    SGetBlockHeaders -> \Range{..} -> notImplemented
+            Just bc -> pure $ Right $ (tip bc)
+    -- NOTE(adn) We are leaking our abstractions here and bypassing the
+    -- 'BlockStoreReader' interface, but this is an interim measure while we
+    -- wait for oscoin#550.
+    SGetBlocks -> \Range{..} ->   Right
+                                . NewestFirst
+                                . take (fromIntegral $ end - start)
+                                . drop (fromIntegral start)
+                              <$> getAllBlocks
+    -- NOTE(adn) We are leaking our abstractions here and bypassing the
+    -- 'BlockStoreReader' interface, but this is an interim measure while we
+    -- wait for oscoin#550.
+    SGetBlockHeaders -> \Range{..} ->   Right
+                                      . NewestFirst
+                                      . take (fromIntegral $ end - start)
+                                      . drop (fromIntegral start)
+                                      . map blockHeader
+                                    <$> getAllBlocks
+  where
+      getAllBlocks :: Sim [Block MockCrypto MockTx (Sealed MockCrypto MockSeal)]
+      getAllBlocks = gets ( Chrono.toOldestFirst
+                          . Chrono.reverse
+                          . blocks
+                          . BlockStore.Pure.getBestChain
+                          . _mockLocalChain
+                          )
 
 {------------------------------------------------------------------------------
   Running a Sync operation
@@ -86,10 +146,10 @@ mkDataFetcherSim = DataFetcher $ \peer -> \case
 -- | Runs a 'Sync' operation on the simulated environment.
 runMockSync
     :: WorldState
-    -> NetworkLayer MockCrypto Sim
-    -> Sync MockCrypto Sim a
+    -> SyncContext MockCrypto MockTx MockSeal Sim
+    -> Sync MockCrypto MockTx MockSeal Sim a
     -> Either (SyncError MockCrypto) a
-runMockSync ws netLayer (Sync s) =
+runMockSync ws syncContext (Sync s) =
     runIdentity . flip evalStateT ws
                 . runReaderT (runExceptT s)
-                $ netLayer
+                $ syncContext

--- a/src/Oscoin/Protocol/Sync/Mock.hs
+++ b/src/Oscoin/Protocol/Sync/Mock.hs
@@ -152,6 +152,6 @@ runMockSync
     :: WorldState
     -> SyncContext MockCrypto MockTx MockSeal Sim
     -> Sync MockCrypto MockTx MockSeal Sim a
-    -> (Either (SyncError MockCrypto) a, [SyncEvent MockCrypto MockTx MockSeal])
+    -> (Either SyncError a, [SyncEvent MockCrypto MockTx MockSeal])
 runMockSync ws syncContext (Sync s) =
     evalRWS (runReaderT (runExceptT s) $ syncContext) () ws

--- a/src/Oscoin/Protocol/Sync/Mock.hs
+++ b/src/Oscoin/Protocol/Sync/Mock.hs
@@ -1,0 +1,95 @@
+module Oscoin.Protocol.Sync.Mock where
+
+import           Oscoin.Crypto
+import           Oscoin.Prelude
+
+import           Oscoin.Crypto.Blockchain (Blockchain, tip)
+import           Oscoin.Crypto.Blockchain.Block (BlockHash)
+import qualified Oscoin.Crypto.PubKey as Crypto
+import           Oscoin.Protocol.Sync
+import           Oscoin.Telemetry.Trace
+
+import           Codec.Serialise as CBOR
+import           Data.Hashable (Hashable)
+import           Data.HashMap.Strict (HashMap)
+import qualified Data.HashMap.Strict as HM
+import           Data.HashSet (HashSet)
+import qualified Data.HashSet as HS
+import           Lens.Micro (Lens', lens)
+
+{------------------------------------------------------------------------------
+  Types
+------------------------------------------------------------------------------}
+
+type MockPeer = ActivePeer MockCrypto
+
+type PeerData = Blockchain MockCrypto [Word8] Text
+
+data WorldState = WorldState
+    { _mockPeerState :: HashMap MockPeer PeerData
+    }
+
+type Sim = StateT WorldState Identity
+
+{------------------------------------------------------------------------------
+  Smart constructors / helper functions / combinators
+------------------------------------------------------------------------------}
+
+mockPeers :: Lens' WorldState (HashMap MockPeer PeerData)
+mockPeers = lens _mockPeerState (\s a -> s { _mockPeerState = a })
+{-# INLINE mockPeers #-}
+
+emptyWorldState
+    :: ( Eq (Crypto.PublicKey MockCrypto)
+       , Hashable (Crypto.PublicKey MockCrypto)
+       )
+    => WorldState
+emptyWorldState = WorldState mempty
+
+toMockPeers :: WorldState -> HashSet MockPeer
+toMockPeers (WorldState m) = HS.fromMap (() <$ m)
+
+-- | A mock 'NetworkLayer' operating in a mock/simulated environment.
+mockLayer
+    :: ( Eq (Crypto.PublicKey MockCrypto)
+       , Hashable (Crypto.PublicKey MockCrypto)
+       , Serialise (BlockHash MockCrypto)
+       )
+    => NetworkLayer MockCrypto Sim
+mockLayer =
+    NetworkLayer
+        { nlActivePeers = gets toMockPeers
+        , nlDataFetcher = mkDataFetcherSim
+        , nlEventTracer = probed noProbe
+        }
+
+-- | Creates a new simulation 'DataFetcher'.
+mkDataFetcherSim
+    :: ( Eq (Crypto.PublicKey MockCrypto)
+       , Hashable (Crypto.PublicKey MockCrypto)
+       , Serialise (BlockHash MockCrypto)
+       )
+    => DataFetcher MockCrypto Sim
+mkDataFetcherSim = DataFetcher $ \peer -> \case
+    SGetTip -> \() -> do
+        WorldState{..} <- get
+        case HM.lookup peer _mockPeerState of
+            Nothing -> panic "newDataFetcherSim - precondition violation, empty blockchain."
+            Just bc -> pure $ GetTipResp (tip bc)
+    SGetBlocks -> \Range{..} -> notImplemented
+    SGetBlockHeaders -> \Range{..} -> notImplemented
+
+{------------------------------------------------------------------------------
+  Running a Sync operation
+------------------------------------------------------------------------------}
+
+-- | Runs a 'Sync' operation on the simulated environment.
+runMockSync
+    :: WorldState
+    -> NetworkLayer MockCrypto Sim
+    -> Sync MockCrypto Sim a
+    -> Either (SyncError MockCrypto) a
+runMockSync ws netLayer (Sync s) =
+    runIdentity . flip evalStateT ws
+                . runReaderT (runExceptT s)
+                $ netLayer

--- a/src/Oscoin/Protocol/Sync/RealWorld.hs
+++ b/src/Oscoin/Protocol/Sync/RealWorld.hs
@@ -139,7 +139,6 @@ syncNode
     :: forall c tx s m.
        ( ProtocolResponse c tx s 'GetTip ~ Block c tx (Sealed c s)
        , ProtocolResponse c tx s 'GetBlocks ~ OldestFirst [] (Block c tx (Sealed c s))
-       , Hashable (Block c tx (Sealed c s))
        , MonadIO m
        , Ord tx
        , Ord s

--- a/src/Oscoin/Protocol/Sync/RealWorld.hs
+++ b/src/Oscoin/Protocol/Sync/RealWorld.hs
@@ -1,0 +1,120 @@
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE UndecidableInstances #-}
+module Oscoin.Protocol.Sync.RealWorld where
+
+import           Oscoin.Crypto.Hash (Hash)
+import           Oscoin.Prelude
+
+import           Oscoin.Consensus.Nakamoto (PoW)
+
+import qualified Oscoin.Consensus.Config as Consensus
+import           Oscoin.Crypto.Blockchain.Block
+                 ( Block
+                 , BlockHash
+                 , BlockHeader
+                 , Height
+                 , Sealed
+                 , blockHeader
+                 , blockHeight
+                 )
+import           Oscoin.Crypto.Hash (HasHashing)
+import qualified Oscoin.Crypto.PubKey as Crypto
+import           Oscoin.Data.Tx
+import           Oscoin.P2P as P2P
+import           Oscoin.Protocol.Sync
+import           Oscoin.Storage.Block.Abstract (BlockStoreReader)
+import           Oscoin.Telemetry.Trace
+import           Oscoin.Time (Duration, microseconds, seconds)
+import           Oscoin.Time.Chrono
+
+import           Codec.Serialise as CBOR
+import qualified Control.Concurrent.Async as Async
+import           Data.Hashable (Hashable)
+import           Data.HashSet (HashSet)
+import qualified Data.HashSet as HS
+import qualified Network.Gossip.HyParView as Gossip
+import           Network.Gossip.IO.Peer (Peer(..))
+import qualified Network.HTTP.Client as HTTP
+
+{------------------------------------------------------------------------------
+  Scary IO implementation
+------------------------------------------------------------------------------}
+
+maxAllowedNetworkLatency :: Duration
+maxAllowedNetworkLatency = 1 * seconds
+
+newDataFetcherIO
+    :: forall c tx s.
+    ( Serialise (ProtocolResponse c tx s 'GetTip) )
+    => HTTP.Manager
+    -> DataFetcher c tx s IO
+newDataFetcherIO httpManager = DataFetcher $ \peer -> \case
+    -- This implementation is basically 'fetchTip' function from the spec.
+    SGetTip -> \() -> timed maxAllowedNetworkLatency $ do
+        let hn = (addrHost . nodeHttpApiAddr $ peer)
+        -- FIXME(adn) Support for https if needed.
+        rq0 <- HTTP.parseUrlThrow ("http://" <> toS (renderHost hn) <> "/blockchain/tip")
+        let rq = rq0 { HTTP.port = fromIntegral (addrPort . nodeHttpApiAddr $ peer) }
+
+       -- Trying to issue a wrong response type will trigger a compilation
+       -- error similar to:
+       -- • Couldn't match type ‘'GetBlockHeaders’ with ‘'GetTip’
+       -- Expected type: IO (ProtocolResponse r)
+       -- Actual type: IO (ProtocolResponse 'GetBlockHeaders)
+
+        HTTP.withResponse rq httpManager $ \res -> do
+            cborBlob <- HTTP.brRead (HTTP.responseBody res)
+            pure $ CBOR.deserialise . toS $ cborBlob
+
+    -- This implementation is basically 'fetchBlocks' from the spec.
+    SGetBlocks -> \Range{..} -> notImplemented
+
+    -- This implementation is basically 'fetchBlockHeaders' from the spec.
+    SGetBlockHeaders -> \Range{..} -> notImplemented
+
+-- | Constructs a new 'Tracer' over @IO@.
+newEventTracerIO :: Probe IO -> Tracer IO
+newEventTracerIO = probed
+
+-- ^ Given a monadic IO operation and a maximum Duration for this action to
+-- take, it either returns the value @a@ or a 'Timeout'.
+timed :: Duration -> IO a -> IO (Either Timeout a)
+timed maxTimeout action = do
+    raceResult <- Async.race (threadDelay (fromIntegral $ nsToMicro maxTimeout)) action
+    case raceResult of
+      Left () -> pure $ Left $ MaxTimeoutExceeded maxTimeout
+      Right r -> pure $ Right r
+  where
+      nsToMicro :: Duration -> Duration
+      nsToMicro s = round (realToFrac s / (fromIntegral microseconds :: Double))
+
+-- | Constructs a new 'SyncContext' over @IO@.
+newSyncContextIO
+    :: ( Eq (Crypto.PublicKey c)
+       , Hashable (Crypto.PublicKey c)
+       , Serialise (BlockHash c)
+       , Serialise (Crypto.PublicKey c)
+       , Serialise (Crypto.Signature c)
+       , Serialise (ProtocolResponse c tx s 'GetTip)
+       , HasHashing c
+       )
+    => Consensus.Config
+    -> BlockStoreReader c tx s IO
+    -> Probe IO
+    -> GossipT c IO (SyncContext c tx s IO)
+newSyncContextIO config chainReader probe = do
+    env <- ask
+    mgr <- liftIO (HTTP.newManager HTTP.defaultManagerSettings)
+    pure $ SyncContext
+        { scNu          = Consensus.mutableChainDepth config
+        , scActivePeers = HS.map peerNodeId . Gossip.active <$> P2P.getPeers' env
+        , scDataFetcher = newDataFetcherIO mgr
+        , scEventTracer = newEventTracerIO probe
+        , scConcurrently = Async.forConcurrently
+        -- FIXME(adn) The above is nonoptimal for this syncing code, as /any/
+        -- exception will cause all the other actions to be cancelled. This is
+        -- hardly what we want here, as we do want other peers to carry on
+        -- undisturbed if one of the HTTP requests / CBOR deserialisation fails.
+        , scLocalChainReader = chainReader
+        }
+

--- a/src/Oscoin/Protocol/Sync/RealWorld.hs
+++ b/src/Oscoin/Protocol/Sync/RealWorld.hs
@@ -141,10 +141,10 @@ syncNode
        , ProtocolResponse c tx s 'GetBlocks ~ OldestFirst [] (Block c tx (Sealed c s))
        , Hashable (Block c tx (Sealed c s))
        , MonadIO m
-       , Eq tx
-       , Eq s
-       , Eq (Hash c)
-       , Eq (PublicKey c)
+       , Ord tx
+       , Ord s
+       , Ord (Hash c)
+       , Ord (PublicKey c)
        )
     => Sync c tx s m ()
 syncNode = do

--- a/src/Oscoin/Storage/Block/Pure.hs
+++ b/src/Oscoin/Storage/Block/Pure.hs
@@ -17,6 +17,9 @@ module Oscoin.Storage.Block.Pure
     , lookupBlockByHeight
     , lookupBlocksByHeight
     , lookupTx
+
+    -- * Internals, use carefully
+    , getBestChain
     ) where
 
 import           Oscoin.Prelude

--- a/test/Test/Oscoin/Protocol.hs
+++ b/test/Test/Oscoin/Protocol.hs
@@ -24,6 +24,7 @@ import           Control.Monad.State (modify')
 import           Data.ByteArray.Orphans ()
 
 import           Test.Oscoin.DummyLedger
+import qualified Test.Oscoin.Protocol.Sync as Sync
 import           Test.QuickCheck.Extended
 import           Test.QuickCheck.Monadic
 import           Test.Tasty
@@ -32,6 +33,7 @@ import           Test.Tasty.QuickCheck hiding ((===))
 tests :: Dict (IsCrypto c) -> TestTree
 tests d = testGroup "Test.Oscoin.Protocol"
     [ testProperty "prop_forkInsertGetTipEquivalence"  (prop_forkInsertGetTipEquivalence d)
+    , Sync.tests d
     ]
 
 

--- a/test/Test/Oscoin/Protocol/Sync.hs
+++ b/test/Test/Oscoin/Protocol/Sync.hs
@@ -18,6 +18,8 @@ import           Lens.Micro (over)
 import           Hedgehog
 import           Hedgehog.Gen.QuickCheck (quickcheck)
 import           Oscoin.Test.Crypto.Blockchain.Block.Generators (genBlockFrom)
+import           Oscoin.Test.Crypto.Blockchain.Block.Helpers
+                 (defaultBeneficiary)
 import           Oscoin.Test.Crypto.Blockchain.Generators (genBlockchainFrom)
 import           Oscoin.Test.Crypto.PubKey.Arbitrary (arbitraryKeyPair)
 import           Test.Oscoin.P2P.Gen (genNodeInfo)
@@ -79,7 +81,7 @@ prop_getRemoteTip_sim_two_peers = property $ do
 ------------------------------------------------------------------------------}
 
 defaultGenesis :: Block MockCrypto Mock.MockTx (Sealed MockCrypto Mock.MockSeal)
-defaultGenesis = sealBlock mempty (emptyGenesisBlock Time.epoch)
+defaultGenesis = sealBlock mempty (emptyGenesisBlock Time.epoch defaultBeneficiary)
 
 {------------------------------------------------------------------------------
   Generators

--- a/test/Test/Oscoin/Protocol/Sync.hs
+++ b/test/Test/Oscoin/Protocol/Sync.hs
@@ -1,0 +1,57 @@
+module Test.Oscoin.Protocol.Sync (tests, props) where
+
+import           Oscoin.Prelude
+
+import           Oscoin.Crypto
+import           Oscoin.Test.Crypto
+
+import           Oscoin.Crypto.Blockchain.Block
+                 (Block, Sealed, emptyGenesisBlock, sealBlock)
+import           Oscoin.Protocol.Sync as Sync
+import qualified Oscoin.Protocol.Sync.Mock as Mock
+import qualified Oscoin.Time as Time
+
+import qualified Data.HashMap.Strict as HM
+import           Lens.Micro (over)
+
+import           Hedgehog
+import           Hedgehog.Gen.QuickCheck (quickcheck)
+import           Oscoin.Test.Crypto.Blockchain.Generators (genBlockchainFrom)
+import           Oscoin.Test.Crypto.PubKey.Arbitrary (arbitraryKeyPair)
+import           Test.Oscoin.P2P.Gen (genNodeInfo)
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.Hedgehog (testProperty)
+
+tests :: Dict (IsCrypto c) -> TestTree
+tests _d = testGroup "Test.Oscoin.Protocol.Sync"
+    [ testProperty "prop_withActivePeers_no_active_peers"  prop_withActivePeers_no_active_peers
+    , testProperty "prop_withActivePeers" prop_withActivePeers
+    ]
+
+-- | For GHCi use.
+props :: Dict (IsCrypto c) -> IO Bool
+props _d = checkParallel $ Group "Test.Oscoin.Protocol.Sync"
+    [("prop_withActivePeers_no_active_peers", prop_withActivePeers_no_active_peers)
+    ,("prop_withActivePeers", prop_withActivePeers)
+    ]
+
+prop_withActivePeers_no_active_peers :: Property
+prop_withActivePeers_no_active_peers = withTests 1 . property $ do
+    let res = Mock.runMockSync Mock.emptyWorldState Mock.mockLayer (Sync.withActivePeers (const (pure ())))
+    annotate "withActivePeers must fail with NoActivePeers" *> (res === Left NoActivePeers)
+
+prop_withActivePeers :: Property
+prop_withActivePeers = withTests 1 . property $ do
+    testPeer <- forAll genActivePeer
+    let worldState = Mock.emptyWorldState
+                   & over Mock.mockPeers (uncurry HM.insert testPeer)
+    let res = Mock.runMockSync worldState Mock.mockLayer (Sync.withActivePeers (const (pure ())))
+    annotate "withActivePeers must succeed" *> (res === Right ())
+
+genActivePeer :: Gen (Mock.MockPeer, Mock.PeerData)
+genActivePeer = do
+  (pk, _) <- quickcheck arbitraryKeyPair
+  (,) <$> genNodeInfo pk <*> quickcheck (genBlockchainFrom defaultGenesis)
+  where
+      defaultGenesis :: Block MockCrypto [Word8] (Sealed MockCrypto Text)
+      defaultGenesis = sealBlock mempty (emptyGenesisBlock Time.epoch)


### PR DESCRIPTION
This PR ships the first part of #531 , and follows the spec outlined [here](https://hackmd.io/2cPkrWTjTIWo2EmHZpPIQw?both). 

It's unfortunately another almost-1k-big PR, but the commit should be hopefully be reviewable in isolation and I am happy to pair-review this with people. As the PR is already quite substantial but definitely more stuff needs to be implemented, I think it's beneficial if we start with the basics. I wouldn't antagonise too much on the performance side of things as I am aware this is pretty much just a reference implementation and I didn't even try to be efficient here 😬 .

## What's in here

- [x] Basic types, abstractions and data structures;
- [x] Mostly monad-agnostic syncing algorithm;
- [x] Two concrete implementations, one for a `Sim` monad and another one for `IO/GossipT`;
- [x] Tests for the syncing over `Sim`.

## What is (obviously) missing

- [ ] Any form of wiring to the `Protocol`, in order to actually kick off syncing at node startup.

## What is (not-so-obviously) missing

- [ ] A real implementation for the IO data fetcher, which requires #550 , but subsequent PRs can fake this using an `IORef` for now;
- [ ] Some kind of support for streaming blocks efficiently from the data fetcher to the guts of the syncing. I have to think about this a bit more but we have tests to catch any regression in this area;
 - [ ] Performance optimisations when it comes to not only parallelism but also the algorithm to handle missing blocks;
- [ ] Tests for the `IO` implementation -- I think I can generalise a bit what I have now to reuse pretty much the same tests without all the boilerplate (but boilerplate might do for now);
- [ ] Telemetry and logging -- for now we don't log/emit anything substantial;
- [ ] Use the `OscoinTx` rather than the `Tx` in the `IO` `DataFetcher`.