### PR TITLE
Extend API.Client test, remove redundant tests

### DIFF
--- a/test/Oscoin/Test/HTTP/Helpers.hs
+++ b/test/Oscoin/Test/HTTP/Helpers.hs
@@ -13,7 +13,6 @@ module Oscoin.Test.HTTP.Helpers
     , liftNode
 
     , assertResultOK
-    , assertResultErr
     , assertStatus
 
     , get
@@ -229,17 +228,6 @@ assertResultOK expected response = do
     case result of
         API.Err err -> assertFailure $ "Received API error: " <> T.unpack err
         API.Ok v    -> expected @=? v
-
--- | Assert that the response can be deserialised to @API.Err actual@
--- and @actual@ equals @expected@.
-assertResultErr
-    :: (HasCallStack)
-    => Text -> Wai.SResponse -> Session c ()
-assertResultErr expected response = do
-    result <- assertResponseBody @(API.Result ()) response
-    case result of
-        API.Err err -> expected @=? err
-        API.Ok _    -> assertFailure $ "Received unexpected API OK result"
 
 assertResponseBody
     :: (HasCallStack, Serialise a)


### PR DESCRIPTION
We add a test for invalid transactions with `Oscoin.API.Client.submitTransaction` in `Test.Oscoin.API`. This allows us to remove the low-level test from `Test.Oscoin.API.HTTP`.

We also remove the so called “smoke tests” from the API. This behavior is also covered by the tests for `Oscoin.API.Client.submitTransaction`.