### PR TITLE
Prepare Client.getState for OscoinTx

### DIFF
--- a/src/Oscoin/API/Client.hs
+++ b/src/Oscoin/API/Client.hs
@@ -8,7 +8,7 @@ import           Oscoin.Prelude
 
 import           Oscoin.API.Types
 import           Oscoin.Crypto.Hash (Hashed)
-import           Oscoin.Data.Tx (Tx, TxPayload)
+import           Oscoin.Data.Tx
 
 data Client c m = Client
     { submitTransaction :: Tx c -> m (Result (TxSubmitResponse c (Tx c)))
@@ -17,9 +17,7 @@ data Client c m = Client
     -- was not found.
     , getTransaction :: Hashed c (Tx c) -> m (Result (TxLookupResponse c (Tx c)))
 
-    -- | Returns an error result if a value with the given key was not
-    -- found.
-    , getState :: [Text] -> m (Result (TxPayload c (Tx c)))
+    , getState :: ByteString -> m (Maybe ByteString)
     }
 
 

--- a/src/Oscoin/API/HTTP.hs
+++ b/src/Oscoin/API/HTTP.hs
@@ -107,9 +107,9 @@ api mdlware = do
 
     get ("transactions" <//> var) (Handlers.getTransaction . toHashed)
 
-    -- /state/:chain ----------------------------------------------------------
+    -- /state/:key ------------------------------------------------------------
 
-    get ("state" <//> wildcard) Handlers.getStatePath
+    get ("state" <//> wildcard) Handlers.getStateValue
 
 
 -- Internal --------------------------------------------------------------------

--- a/src/Oscoin/API/HTTP/Internal.hs
+++ b/src/Oscoin/API/HTTP/Internal.hs
@@ -69,7 +69,6 @@ type ApiTx c tx =
     ( Serialise tx
     , Crypto.Hashable c tx
     , Query (TxState c tx)
-    , Serialise (QueryVal (TxState c tx))
     , Serialise (TxOutput c tx)
     )
 

--- a/src/Oscoin/CLI/Command.hs
+++ b/src/Oscoin/CLI/Command.hs
@@ -82,7 +82,7 @@ genesisCreate
     -> m Result
 genesisCreate benef diffi = do
     time <- getTime
-    let unsealedGen :: Block c (Tx c) Unsealed = emptyGenesisFromState time benef (mempty :: DummyEnv)
+    let unsealedGen :: Block c (Tx c) Unsealed = emptyGenesisFromState time benef (mempty :: LegacyTxState)
     result <- mineGenesis
         (mineNakamoto (Telemetry.probed Telemetry.noProbe) (const diffi)) unsealedGen
     case result of

--- a/src/Oscoin/Data/Query.hs
+++ b/src/Oscoin/Data/Query.hs
@@ -3,6 +3,4 @@ module Oscoin.Data.Query where
 import           Oscoin.Prelude
 
 class Query a where
-    type QueryVal a :: *
-
-    query :: [Text] -> a -> Maybe (QueryVal a)
+    query :: ByteString -> a -> Maybe ByteString


### PR DESCRIPTION
As part of implementing the Ledger API for the devnet (#549) we prepare the `Client.getState`. We change the interface of `Client.getState` so that it matches the expected interface defined in #549 while retaining the legacy tx under the hood.

* Eliminate `getPath` as it is unused
* Rename `getPathLatest` to `getStateValue`
* Eliminate the `QueryVal` associated type. State values are (for now) only `ByteString`
* Change the `key` argument type from `[Text]` to `ByteString`. This requires us to encode the keys with base58 when sending it over HTTP.