### PR TITLE
cli: Prepare genesis creation for OscoinTx

### DIFF
--- a/src/Oscoin/CLI.hs
+++ b/src/Oscoin/CLI.hs
@@ -18,8 +18,6 @@ import qualified Oscoin.Time as Time
 
 import           Control.Concurrent (threadDelay)
 import           Crypto.Random.Types (MonadRandom(..))
-import qualified Data.Aeson as JSON
-import qualified Data.ByteString.Lazy as LBS
 
 type CommandRunner a = CommandRunnerT IO a
 
@@ -60,8 +58,5 @@ instance
     sleep milliseconds = liftIO $ threadDelay (1000 * milliseconds)
     putLine            = liftIO . putStrLn
     putString          = liftIO . putStr
-    readTxFile path    =
-        either (panic . toS) identity . JSON.eitherDecode <$>
-            liftIO (LBS.readFile path)
     getTime            = liftIO Time.now
     getClient          = API.hoistClient liftIO . commandClient <$> askCommandEnv

--- a/src/Oscoin/CLI/Command.hs
+++ b/src/Oscoin/CLI/Command.hs
@@ -10,18 +10,22 @@ import           Oscoin.Prelude
 import qualified Oscoin.API.Client as API
 import           Oscoin.CLI.KeyStore
 import           Oscoin.Consensus.Mining (mineGenesis)
-import           Oscoin.Consensus.Nakamoto (mineNakamoto)
+import           Oscoin.Consensus.Nakamoto (PoW, mineNakamoto)
 import           Oscoin.Crypto.Blockchain.Block
-                 (Beneficiary, BlockData, BlockHash, Difficulty)
-import           Oscoin.Crypto.Blockchain.Eval (EvalError(..), buildGenesis)
-import qualified Oscoin.Crypto.Hash as Crypto
+                 ( Beneficiary
+                 , Block
+                 , BlockHash
+                 , Difficulty
+                 , SealedBlock
+                 , Unsealed
+                 , emptyGenesisFromState
+                 )
 import qualified Oscoin.Crypto.PubKey as Crypto
 import           Oscoin.Data.Tx
 import qualified Oscoin.Telemetry as Telemetry
 import           Oscoin.Time (Timestamp)
 
 import           Codec.Serialise (Serialise)
-import qualified Crypto.Data.Auth.Tree.Class as AuthTree
 import           Crypto.Random.Types (MonadRandom)
 import           Data.ByteArray (ByteArrayAccess)
 import           Data.ByteArray.Orphans ()
@@ -35,8 +39,6 @@ class (MonadRandom m, MonadKeyStore c m) => MonadCLI c m where
     putString :: Text -> m ()
     -- | Print text to stdout and add a newline
     putLine :: Text -> m ()
-    -- | Read and parse a tx file.
-    readTxFile :: FilePath -> m (Either Text (TxPayload c (Tx c)))
     -- | Get the current time
     getTime :: m Timestamp
 
@@ -48,21 +50,14 @@ data Result
 
 data Command c =
       GenerateKeyPair
-    | GenesisCreate [FilePath] Difficulty (Beneficiary c)
+    | GenesisCreate Difficulty (Beneficiary c)
 
 dispatchCommand
     :: ( MonadCLI c m
        , Serialise (BlockHash c)
-       , Serialise (Beneficiary c)
-       , Serialise (Crypto.Signature c)
-       , Serialise (Crypto.PublicKey c)
-       , AuthTree.MerkleHash (Crypto.Hash c)
        , Crypto.HasDigitalSignature c
        , ByteArrayAccess (BlockHash c)
-       , Yaml.ToJSON (Crypto.Hash c)
-       , Yaml.ToJSON (Crypto.PublicKey c)
-       , Yaml.ToJSON (Crypto.Signature c)
-       , Yaml.ToJSON (BlockData c (Tx c))
+       , Yaml.ToJSON (SealedBlock c (Tx c) PoW)
        )
     => Command c
     -> m Result
@@ -71,66 +66,28 @@ dispatchCommand GenerateKeyPair = do
     writeKeyPair kp
     pure $ ResultOk
 
-dispatchCommand (GenesisCreate [] d benef) =
-    printGenesisYaml benef [] d
-dispatchCommand (GenesisCreate files d benef) = do
-    results <-
-        for files $
-            readTxFile >=> traverse signTransaction
+dispatchCommand (GenesisCreate d benef) = genesisCreate benef d
 
-    case partitionEithers results of
-        (errs, signed)
-            | null errs ->
-                printGenesisYaml benef signed d
-            | otherwise ->
-                pure $ ResultError (mconcat errs)
-
--- | Mine a genesis block from a list of inputs and print it as YAML to
--- the console. Takes the target difficulty.
-printGenesisYaml
+-- | Mine the genesis block print it as YAML to the console. Takes the
+-- target difficulty and the beneficiary of the genesis block.
+genesisCreate
     :: forall c m.
        ( MonadCLI c m
        , Serialise (BlockHash c)
-       , Serialise (Beneficiary c)
-       , Serialise (Crypto.Signature c)
-       , Serialise (Crypto.PublicKey c)
-       , AuthTree.MerkleHash (Crypto.Hash c)
        , ByteArrayAccess (BlockHash c)
-       , Yaml.ToJSON (Crypto.Hash c)
-       , Yaml.ToJSON (Crypto.Signature c)
-       , Yaml.ToJSON (Crypto.PublicKey c)
-       , Yaml.ToJSON (BlockData c (Tx c))
+       , Yaml.ToJSON (SealedBlock c (Tx c) PoW)
        )
     => Beneficiary c
-    -> [Tx c]
     -> Difficulty
     -> m Result
-printGenesisYaml benef txs diffi = do
+genesisCreate benef diffi = do
     time <- getTime
-
-    -- FIXME(adn) Pass a real evaluator and a real state.
-    let dummyEval _ s = Right ([], s)
-    case buildGenesis @c dummyEval time benef txs (mempty :: DummyEnv) of
-        Left (_, err) ->
-            pure $ ResultError (fromEvalError err)
-        Right blk -> do
-            result <- mineGenesis
-                (mineNakamoto (Telemetry.probed Telemetry.noProbe) (const diffi)) blk
-
-            case result of
-                Left err  ->
-                    pure $ ResultError err
-                Right gen -> do
-                    putLine . decodeUtf8 . Yaml.encode $ gen
-                    pure ResultOk
-
-signTransaction
-    :: ( Crypto.HasDigitalSignature c
-       , MonadCLI c m
-       )
-    => TxPayload c (Tx c)
-    -> m (Tx c)
-signTransaction payload = do
-    (pk, sk) <- readKeyPair
-    msg      <- Crypto.sign sk payload
-    pure $ mkTx msg pk
+    let unsealedGen :: Block c (Tx c) Unsealed = emptyGenesisFromState time benef (mempty :: DummyEnv)
+    result <- mineGenesis
+        (mineNakamoto (Telemetry.probed Telemetry.noProbe) (const diffi)) unsealedGen
+    case result of
+        Left err  ->
+            pure $ ResultError err
+        Right gen -> do
+            putLine . decodeUtf8 . Yaml.encode $ gen
+            pure ResultOk

--- a/src/Oscoin/CLI/Parser.hs
+++ b/src/Oscoin/CLI/Parser.hs
@@ -58,13 +58,8 @@ keyPairParser = subparser
 
 genesisParser :: HasHashing c => Parser (Command c)
 genesisParser =
-    GenesisCreate <$> genesisFrom <*> genesisDifficulty <*> genesisBeneficiary
+    GenesisCreate <$> genesisDifficulty <*> genesisBeneficiary
   where
-    genesisFrom = many $ option str
-        (  long "from"
-        <> help ".rad input file"
-        <> metavar "FILE"
-        )
     genesisDifficulty = option (maybeReader (parseDifficulty . T.pack))
         (  long "difficulty"
         <> help "target difficulty"

--- a/src/Oscoin/Crypto/Blockchain/Eval.hs
+++ b/src/Oscoin/Crypto/Blockchain/Eval.hs
@@ -7,7 +7,6 @@ module Oscoin.Crypto.Blockchain.Eval
     , Receipt(..)
     , buildBlock
     , buildBlockStrict
-    , buildGenesis
     , evalBlock
     , evalTraverse
     ) where
@@ -112,23 +111,6 @@ buildBlockStrict
     -> Either (tx, EvalError) (Block c tx Unsealed)
 buildBlockStrict eval tick benef st txs parent =
     mkUnsealedBlock (Just parent) tick benef txs <$> evalEither txs eval st
-
--- | Try to build a genesis block. See 'buildBlockStrict' for more information.
-buildGenesis
-    :: ( Crypto.Hashable c st
-       , Serialise tx
-       , Serialise (Beneficiary c)
-       , Crypto.Hashable c (BlockHeader c Unsealed)
-       , AuthTree.MerkleHash (Hash c)
-       )
-    => Evaluator st tx o
-    -> Timestamp
-    -> Beneficiary c
-    -> [tx]
-    -> st
-    -> Either (tx, EvalError) (Block c tx Unsealed)
-buildGenesis eval tick benef txs st =
-    mkUnsealedBlock Nothing tick benef txs <$> evalEither txs eval st
 
 -- | Evaluate the transactions contained in the block against the given
 -- state and return the new state and all the produced Receipts.

--- a/test/Oscoin/Test/CLI/Helpers.hs
+++ b/test/Oscoin/Test/CLI/Helpers.hs
@@ -90,7 +90,6 @@ instance IsCrypto c => MonadCLI c (TestCommandRunner c) where
     sleep _       = pure ()
     putLine t     = putStr (t <> "\n")
     putString t   = modify $ \s -> s { commandOutput = commandOutput s <> t }
-    readTxFile _  = pure $ Left "can't read file in tests"
     getTime       = pure Time.epoch
     getClient     = panic "Test client not implemented"
 

--- a/test/Oscoin/Test/HTTP/Helpers.hs
+++ b/test/Oscoin/Test/HTTP/Helpers.hs
@@ -187,7 +187,7 @@ genDummyTx = do
 createValidTx
     :: forall c m.
        (IsCrypto c, MonadIO m)
-    => TxPayload c (Tx c)
+    => DummyPayload
     -> m (Hashed c (Tx c), Tx c)
 createValidTx payload = liftIO $ do
     (pubKey, priKey) <- Crypto.generateKeyPair


### PR DESCRIPTION
To run the node with OscoinTx (#568) we need to create a genesis block for the Oscoin ledger (#589). We prepare for this by removing the inclusion of transactions in the genesis block. While we might want to have that feature later the current implementation will not work with the Oscoin ledger. The reason is that currently transactions are signed with the node key, but we need to sign it with a fixed account owner key.