### PR TITLE
Continuous Deployment (aka "devnet")

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -125,7 +125,7 @@ steps:
     - STACK_ROOT=/workspace/.stack # weeder uses stack under the hood
     args: ["stack", "exec", "--", "weeder", "."]
 
-  - id: "Build images"
+  - id: "Publish images"
     waitFor:
     - Lint (weeder)
     name: gcr.io/cloud-builders/docker
@@ -144,7 +144,40 @@ steps:
         /workspace/bin/oscoin-cli
       )
 
-      echo "$${bins[*]}" | xargs -P8 -n1 ./scripts/docker/build-image.sh
+      echo "$${bins[*]}" | xargs -P8 -n1 ./scripts/docker/publish-image.sh
+
+  - id: Deploy
+    waitFor:
+    - Publish images
+    name: "gcr.io/cloud-builders/gcloud"
+    entrypoint: bash
+    env:
+    - BRANCH_NAME=$BRANCH_NAME
+    - OSCOIN_VERSION=$COMMIT_SHA
+    - OSCOIN_NETWORK=devnet
+    - OSCOIN_BENEFICIARY=0x0000000000000000000000000000000000000000
+    - OSCOIN_REPLICAS=3
+    - OSCOIN_GOSSIP_PORT=6942
+    - OSCOIN_API_PORT=8080
+    - OSCOIN_METRICS_PORT=8081
+    - OSCOIN_DEPLOY=bin/oscoin-deploy
+    - GCE_PROJECT_ID=$PROJECT_ID
+    - GCE_REGION=europe-west1
+    - GCE_VPC=devnet
+    - GCE_SERVICEACCOUNT=oscoin-node@opensourcecoin.iam.gserviceaccount.com
+    - GCE_MACHINE_TYPE=n1-standard-1
+    - GCE_DNS_ZONE=oscoin-internal
+    - GCE_DNS_DOMAIN=oscoin.internal
+    args:
+    - "-c"
+    - |
+      set -euo pipefail
+
+      if [[ "$BRANCH_NAME" == "master" ]]; then
+        ./scripts/deploy/gce/node
+      else
+        DRY_RUN=yes ./scripts/deploy/gce/node
+      fi
 
   - id: "Publish Haddocks"
     waitFor:
@@ -161,6 +194,4 @@ steps:
 
       gsutil -m rsync -d -r api-docs gs://oscoin-apidocs/${COMMIT_SHA}
 images:
-- "eu.gcr.io/$PROJECT_ID/oscoin"
-- "eu.gcr.io/$PROJECT_ID/oscoin-cli"
 - "eu.gcr.io/$PROJECT_ID/haskell-scratch:integer-gmp"

--- a/exe/deploy/Main.hs
+++ b/exe/deploy/Main.hs
@@ -1,0 +1,20 @@
+module Main (main) where
+
+import           Oscoin.Prelude
+
+import           Oscoin.Configuration (ConfigPaths, getConfigPaths)
+import           Oscoin.Crypto (Crypto)
+import           Oscoin.Crypto.PubKey.RealWorld ()
+import qualified Oscoin.Deployment as Deployment
+import           Oscoin.Deployment.Options (Command, deploymentCommandParser)
+import           Oscoin.P2P.Disco.Options (OptNetwork)
+
+import           Options.Applicative
+
+main :: IO ()
+main = getConfigPaths >>= execParser . pinfo >>= Deployment.run
+  where
+    pinfo :: ConfigPaths -> ParserInfo (Command Crypto OptNetwork)
+    pinfo cps =
+        info (helper <*> deploymentCommandParser cps) $
+            progDesc "Oscoin Deployment Utility" <> fullDesc

--- a/exe/git-remote-helper/Main.hs
+++ b/exe/git-remote-helper/Main.hs
@@ -1,8 +1,0 @@
-module Main (main) where
-
-import           Oscoin.Prelude
-
-import           Oscoin.Git.Remote.Helper
-
-main :: IO ()
-main = runRemoteHelper

--- a/package.yaml
+++ b/package.yaml
@@ -47,6 +47,7 @@ library:
     - fast-logger
     - filepath
     - formatting
+    - generic-lens
     - generics-sop
     - gossip
     - hashable
@@ -64,6 +65,7 @@ library:
     - multihash-cryptonite
     - multihash-serialise
     - network
+    - network-uri
     - optparse-applicative
     - prettyprinter
     - pretty-terminal
@@ -79,6 +81,7 @@ library:
     - stm >=2.4.5.0
     - text
     - transformers
+    - unix
     - unordered-containers
     - vector
     - wai
@@ -114,6 +117,17 @@ executables:
       ld-options: -static
     dependencies:
       - oscoin
+
+  oscoin-deploy:
+    main: exe/deploy/Main.hs
+    when:
+    - condition: "flag(static)"
+      ld-options: -static
+    dependencies:
+      - optparse-applicative
+      - oscoin
+    ghc-options:
+      - -with-rtsopts=-I0
 
 tests:
   documentation:

--- a/scripts/deploy/gce/bootstrap
+++ b/scripts/deploy/gce/bootstrap
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -eoux pipefail
+
+#
+# GCE deployment prerequisites
+#
+# This exists mostly for documentation purposes. You may want to adapt this to
+# your provisioning tool of choice.
+#
+# Note that, for deploying from Google Cloud Build, you will also need to grant
+# some permissions to the cloud build service account:
+#
+# ```
+# gcloud project add-iam-policy-binding $GCE_PROJECT_ID \
+#   --member="serviceAccount:$NUMERIC_PROJECT_ID@cloudbuild.gserviceaccount.com" \
+#   --role="roles/compute.instanceAdmin.v1"
+#
+# gcloud project add-iam-policy-binding $GCE_PROJECT_ID \
+#   --member="serviceAccount:$NUMERIC_PROJECT_ID@cloudbuild.gserviceaccount.com" \
+#   --role="roles/dns.admin"
+#
+# gcloud iam service-accounts add-iam-policy-binding \
+#   "$GCE_SERVICEACCOUNT_NAME@$GCE_PROJECT_ID.iam.gserviceaccount.com" \
+#   --member="serviceAccount:$NUMERIC_PROJECT_ID@cloudbuild.gserviceaccount.com" \
+#   --role="roles/iam.serviceAccountUser"
+# ```
+#
+
+GCE_PROJECT_ID=${GCE_PROJECT_ID:-opensourcecoin}
+
+GCE_VPC=${GCE_VPC:?VPC name not set}
+GCE_SERVICEACCOUNT_NAME=${GCE_SERVICEACCOUNT_NAME:?Service account name not set}
+GCE_DNS_ZONE=${GCE_DNS_ZONE:?DNS zone name not set}
+GCE_DNS_DOMAIN=${GCE_DNS_DOMAIN:?DNS domain not set}
+
+# create vpc
+gcloud compute networks create $GCE_VPC --subnet-mode=auto
+
+# create firewall rules
+_cidrs=$(gcloud compute networks describe devnet --format="value(subnetworks)" \
+  | tr -d '\n' \
+  | xargs -d';' -n1 -P8 \
+    gcloud compute networks subnets describe --format="value(ipCidrRange)" \
+  | tr '\n' ',')
+
+gcloud compute firewall-rules create "${GCE_VPC}-allow-internal" \
+    --description="Allow all VPC-internal traffic in $GCE_VPC" \
+    --network="$GCE_VPC" \
+    --allow=tcp \
+    --source-ranges="$_cidrs"
+
+# create service account
+gcloud iam service-accounts create $GCE_SERVICEACCOUNT_NAME
+
+_roles="roles/compute.imageUser
+roles/compute.networkUser
+roles/compute.viewer
+roles/logging.logWriter
+roles/monitoring.metricWriter
+"
+_member="serviceAccount:${GCE_SERVICEACCOUNT_NAME}@${GCE_PROJECT_ID}.iam.gserviceaccount.com"
+
+for role in $_roles; do
+    gcloud iam service-accounts add-iam-policy-binding $GCE_PROJECT_ID \
+        --member="$_member" \
+        --role="$role"
+done
+
+# create DNS private zone
+gcloud dns managed-zone create $GCE_DNS_ZONE \
+    --description="The $GCE_DNS_ZONE zone" \
+    --dns-name="$GCE_DNS_DOMAIN" \
+    --visibility=private

--- a/scripts/deploy/gce/node
+++ b/scripts/deploy/gce/node
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+
+set -eoux pipefail
+
+#
+# Deploy a full node on GCE
+#
+# See ./bootstrap for assumptions about the environment.
+#
+# Note: the 'gcloud' beta commands have to be installed (`gcloud components
+# install beta`).
+#
+
+DRY_RUN=${DRY_RUN:-""}
+
+OSCOIN_VERSION=${OSCOIN_VERSION:-$(git rev-parse HEAD)}
+OSCOIN_NETWORK=${OSCOIN_NETWORK:?Network not set}
+OSCOIN_REPLICAS=${OSCOIN_REPLICAS:-3}
+OSCOIN_GOSSIP_PORT=${OSCOIN_GOSSIP_PORT:-6942}
+OSCOIN_API_PORT=${OSCOIN_API_PORT:-8080}
+OSCOIN_METRICS_PORT=${OSCOIN_METRICS_PORT:-8081}
+OSCOIN_BENEFICIARY=${OSCOIN_BENEFICIARY:?Beneficiary address not set}
+
+GCE_PROJECT_ID=${GCE_PROJECT_ID:-opensourcecoin}
+GCE_REGION=${GCE_REGION:-europe-west1}
+GCE_VPC=${GCE_VPC:-$OSCOIN_NETWORK}
+GCE_SERVICEACCOUNT=${GCE_SERVICEACCOUNT:-oscoin-node@opensourcecoin.iam.gserviceaccount.com}
+GCE_MACHINE_TYPE=${GCE_MACHINE_TYPE:-n1-standard-1}
+GCE_DNS_ZONE=${GCE_DNS_ZONE:-oscoin-internal}
+GCE_DNS_DOMAIN=${GCE_DNS_DOMAIN:-oscoin.internal}
+GCE_NUM_SSDS=${GCE_NUM_SSDS:-1};
+GCE_NUM_SSDS=$((GCE_NUM_SSDS > 8 ? 8 : (GCE_NUM_SSDS < 1 ? 1 : GCE_NUM_SSDS)))
+GCE_UPDATE_MIN_READY=${GCE_UPDATE_MIN_READY:-t2m}
+
+OSCOIN_DEPLOY=${OSCOIN_DEPLOY:-cabal v2-run -- oscoin-deploy}
+
+# create machine config via cloud-init
+_clowninit=$(mktemp "/tmp/node.cloudinit.yaml.XXXXX")
+$OSCOIN_DEPLOY node \
+    --format=cloud-init \
+    --version="$OSCOIN_VERSION" \
+    --network="$OSCOIN_NETWORK" \
+    --host="0.0.0.0" \
+    --gossip-port="$OSCOIN_GOSSIP_PORT" \
+    --api-port="$OSCOIN_API_PORT" \
+    --metrics-port="$OSCOIN_METRICS_PORT" \
+    --sd-domain="$GCE_DNS_DOMAIN" \
+    --environment=development \
+    --beneficiary="$OSCOIN_BENEFICIARY" \
+    --allow-ephemeral-keys \
+    --output="$_clowninit" \
+    "$@" \
+    gce \
+    --num-ssds="${GCE_NUM_SSDS}"
+
+if [[ "x$DRY_RUN" != "x" ]]; then
+    exit 0
+fi
+
+# create instance template per $OSCOIN_NETWORK + $OSCOIN_VERSION
+_ssds=$(for _ in $(seq 1 $GCE_NUM_SSDS); do
+  echo "--local-ssd=interface=nvme"
+done)
+
+gcloud compute instance-templates create \
+    "oscoin-node-${OSCOIN_NETWORK}-${OSCOIN_VERSION}" \
+    --image-project=cos-cloud \
+    --image-family=cos-stable \
+    $_ssds \
+    --machine-type="$GCE_MACHINE_TYPE" \
+    --region="$GCE_REGION" \
+    --service-account="$GCE_SERVICEACCOUNT" \
+    --scopes=monitoring-write,logging-write,storage-ro \
+    --tags="oscoin-node,oscoin-$OSCOIN_NETWORK" \
+    --labels="gossip-port=${OSCOIN_GOSSIP_PORT},api-port=${OSCOIN_API_PORT},metrics-port=${OSCOIN_METRICS_PORT}" \
+    --metadata=google-logging-enabled=true \
+    --metadata-from-file="user-data=$_clowninit"
+
+# find or create instance group per $OSCOIN_NETWORK
+_grp=$(gcloud compute instance-groups managed list \
+    --filter="region:$GCE_REGION AND name:oscoin-node-$OSCOIN_NETWORK" \
+    --format="value(name)" \
+    | wc -l)
+
+if [[ "$_grp" == "0" ]]; then
+    gcloud compute instance-groups managed create \
+        "oscoin-node-$OSCOIN_NETWORK" \
+        --size="$OSCOIN_REPLICAS" \
+        --template="oscoin-node-${OSCOIN_NETWORK}-${OSCOIN_VERSION}" \
+        --region="$GCE_REGION"
+else
+    # replace template and start rolling update
+    gcloud compute instance-groups managed set-instance-template \
+        "oscoin-node-$OSCOIN_NETWORK" \
+        --template="oscoin-node-${OSCOIN_NETWORK}-${OSCOIN_VERSION}" \
+        --region="$GCE_REGION"
+
+    # Note:
+    #
+    # Spin up new instances before demoting old ones, ie.
+    # --max-surge=$OSCOIN_REPLICAS. This allows the new nodes to join via
+    # the SRV records pointing to the old nodes.
+    #
+    # Also, wait $GCE_UPDATE_MIN_READY before a new node is considered up. This
+    # is to allow it to sync with the old nodes. Obviously, this needs to be
+    # reconsidered.
+    gcloud beta compute instance-groups managed rolling-action start-update \
+        "oscoin-node-$OSCOIN_NETWORK" \
+        --version="template=oscoin-node-${OSCOIN_NETWORK}-${OSCOIN_VERSION}" \
+        --max-surge="$OSCOIN_REPLICAS" \
+        --max-unavailable=0 \
+        --min-ready="${GCE_UPDATE_MIN_READY}" \
+        --region="$GCE_REGION" \
+        --type=proactive
+fi
+
+gcloud compute instance-groups managed wait-until-stable \
+    "oscoin-node-$OSCOIN_NETWORK" \
+    --region="$GCE_REGION"
+
+# update SRV records
+_instances=$(gcloud compute instance-groups managed list-instances \
+    "oscoin-node-$OSCOIN_NETWORK" \
+    --format="value(instance)" \
+    --region="$GCE_REGION")
+
+_zonefile=$(mktemp "/tmp/${GCE_DNS_ZONE}.zone.XXXXX")
+for x in $_instances; do
+    echo "_gossip._tcp.oscoin.${OSCOIN_NETWORK}.${GCE_DNS_DOMAIN}. 300 IN SRV 0 1 ${OSCOIN_GOSSIP_PORT} ${x}.c.${GCE_PROJECT_ID}.internal."   >> "$_zonefile"
+    echo "_api._tcp.oscoin.${OSCOIN_NETWORK}.${GCE_DNS_DOMAIN}. 300 IN SRV 0 1 ${OSCOIN_API_PORT} ${x}.c.${GCE_PROJECT_ID}.internal."         >> "$_zonefile"
+    echo "_metrics._tcp.oscoin.${OSCOIN_NETWORK}.${GCE_DNS_DOMAIN}. 300 IN SRV 0 1 ${OSCOIN_METRICS_PORT} ${x}.c.${GCE_PROJECT_ID}.internal." >> "$_zonefile"
+done
+gcloud dns record-sets import --zone="$GCE_DNS_ZONE" \
+    --zone-file-format \
+    --delete-all-existing \
+    "$_zonefile"

--- a/scripts/docker/publish-image.sh
+++ b/scripts/docker/publish-image.sh
@@ -27,4 +27,6 @@ if [[ $BRANCH_NAME == "master" ]]; then
   docker tag "$img:$BRANCH_NAME" "$img:latest"
 fi
 
+docker push "$img"
+
 popd

--- a/src/Oscoin/Deployment.hs
+++ b/src/Oscoin/Deployment.hs
@@ -1,0 +1,12 @@
+module Oscoin.Deployment where
+
+import           Oscoin.Prelude
+
+import qualified Oscoin.Crypto.Hash as Crypto
+import qualified Oscoin.Deployment.Node as Node
+import           Oscoin.Deployment.Options
+import qualified Oscoin.P2P.Disco.Options as Disco
+
+run :: Show (Crypto.ShortHash c) => Command c Disco.OptNetwork -> IO ()
+run = \case
+    DeployNode cmd -> Node.run cmd

--- a/src/Oscoin/Deployment/Internal/CloudInit.hs
+++ b/src/Oscoin/Deployment/Internal/CloudInit.hs
@@ -1,0 +1,241 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+
+module Oscoin.Deployment.Internal.CloudInit
+    ( CloudConfig
+    , mkCloudConfig
+    , renderCloudConfig
+
+    , User
+    , mkUser
+    , rootUser
+    , renderUidOrName
+
+    , Group
+    , mkGroup
+    , rootGroup
+    , renderGidOrName
+
+    , Owner
+    , mkOwner
+    , rootOwner
+
+    , WriteFiles
+    , mkWriteFiles
+
+    , FileContents
+    , plainTextFileContents
+    , base64FileContents
+
+    , FileMode
+    , fromPosixFileMode
+    )
+where
+
+import           Oscoin.Prelude hiding (group)
+
+import           Data.Aeson (ToJSON(..), (.=))
+import qualified Data.Aeson.Types as Aeson
+import           Data.ByteString.BaseN (AtBase, encodedText)
+import           Data.Generics.Product
+import qualified Data.Set as Set
+import           Data.Vector (Vector)
+import qualified Data.Yaml as Yaml
+import           Lens.Micro (set)
+import           Lens.Micro.Extras (view)
+import           Numeric (showIntAtBase)
+import qualified System.Posix as Posix
+
+data CloudConfig = CloudConfig
+    { users       :: Vector User
+    , groups      :: Vector Group
+    , write_files :: Vector WriteFiles
+    , runcmd      :: Vector Text
+    , bootcmd     :: Vector Text
+   } deriving Generic
+
+instance ToJSON CloudConfig where
+    toJSON cc = Aeson.object
+        [ "users"       .= users cc
+        , "groups"      .= map (view (the @"name")) (view (the @"groups") cc)
+        , "write_files" .= write_files cc
+        , "runcmd"      .= runcmd cc
+        , "bootcmd"     .= bootcmd cc
+        ]
+
+    toEncoding cc = Aeson.pairs $
+           "users"       .= users cc
+        <> "groups"      .= map (view (the @"name")) (view (the @"groups") cc)
+        <> "write_files" .= write_files cc
+        <> "runcmd"      .= runcmd cc
+        <> "bootcmd"     .= bootcmd cc
+
+instance Semigroup CloudConfig where
+    a <> b = CloudConfig
+        { users       = on (<>) users a b
+        , groups      = on (<>) (groups :: CloudConfig -> Vector Group) a b
+        , write_files = on (<>) write_files a b
+        , runcmd      = on (<>) runcmd a b
+        , bootcmd     = on (<>) bootcmd a b
+        }
+
+instance Monoid CloudConfig where
+    mempty  = CloudConfig mempty mempty mempty mempty mempty
+    mappend = (<>)
+
+mkCloudConfig :: CloudConfig
+mkCloudConfig = mempty
+
+renderCloudConfig :: CloudConfig -> Text
+renderCloudConfig cc = "#cloud-config\n\n" <> toS (Yaml.encode cc)
+
+data User = User
+    { name   :: Text
+    , uid    :: Maybe Word16
+    , groups :: Set Group
+    } deriving (Eq, Ord, Generic)
+
+instance ToJSON User where
+    toJSON u = Aeson.object $ catMaybes
+        [ Just $ "name" .= view (the @"name") u
+        , ("uid" .=) . toJSON <$> uid u
+        , if Set.null (view (the @"groups") u) then
+            Nothing
+          else
+            Just
+                . ("groups" .=)
+                . toJSON
+                . mconcat
+                . intersperse ", "
+                . Set.toList
+                . Set.map (view (the @"name"))
+                $ view (the @"groups") u
+        ]
+
+    toEncoding u = Aeson.pairs . mconcat $ catMaybes
+        [ Just $ "name" .= view (the @"name") u
+        , ("uid" .=) <$> uid u
+        , if Set.null (view (the @"groups") u) then
+            Nothing
+          else
+            Just
+                . ("groups" .=)
+                . mconcat
+                . intersperse ", "
+                . Set.toList
+                . Set.map (view (the @"name"))
+                $ view (the @"groups") u
+        ]
+
+mkUser :: Text -> User
+mkUser n = User { name = n, uid = Nothing, groups = mempty }
+
+rootUser :: User
+rootUser = mkUser "root" & set (the @"uid") (Just 0)
+
+renderUidOrName :: User -> Text
+renderUidOrName u = maybe (view (the @"name") u) show $ view (the @"uid") u
+
+data Group = Group
+    { name :: Text
+    , gid  :: Maybe Word16
+    } deriving (Eq, Ord, Generic)
+
+instance ToJSON Group where
+    toJSON     = Aeson.genericToJSON     jsonOpts
+    toEncoding = Aeson.genericToEncoding jsonOpts
+
+mkGroup :: Text -> Group
+mkGroup n = Group { name = n, gid = Nothing }
+
+rootGroup :: Group
+rootGroup = mkGroup "root" & set (the @"gid") (Just 0)
+
+renderGidOrName :: Group -> Text
+renderGidOrName g = maybe (view (the @"name") g) show $ view (the @"gid") g
+
+data Owner = Owner
+    { user  :: User
+    , group :: Maybe Group
+    } deriving Generic
+
+renderOwner :: Owner -> Text
+renderOwner (Owner user group) =
+    mconcat . intersperse ":" $ catMaybes
+        [ Just $ view (the @"name") user
+        , view (the @"name") <$> group
+        ]
+
+instance ToJSON Owner where
+    toJSON     = toJSON     . renderOwner
+    toEncoding = toEncoding . renderOwner
+
+mkOwner :: User -> Owner
+mkOwner u = Owner { user = u, group = Nothing }
+
+rootOwner :: Owner
+rootOwner = mkOwner rootUser & set (the @"group") (Just rootGroup)
+
+data WriteFiles = WriteFiles
+    { path        :: FilePath
+    , permissions :: FileMode
+    , owner       :: Owner
+    , content     :: FileContents
+    , append      :: Maybe Bool
+    } deriving Generic
+
+instance ToJSON WriteFiles where
+    toJSON     = Aeson.genericToJSON     jsonOpts
+    toEncoding = Aeson.genericToEncoding jsonOpts
+
+mkWriteFiles
+    :: FilePath
+    -> FileMode
+    -> Owner
+    -> FileContents
+    -> WriteFiles
+mkWriteFiles fp perm own cnt = WriteFiles
+    { path        = fp
+    , permissions = perm
+    , owner       = own
+    , content     = cnt
+    , append      = Nothing
+    }
+
+newtype FileMode = FileMode Posix.FileMode
+    deriving Generic
+
+fromPosixFileMode :: Posix.FileMode -> FileMode
+fromPosixFileMode = FileMode
+
+fileModeOctal :: FileMode -> String
+fileModeOctal (FileMode cmode) =
+    showIntAtBase 8 (toEnum . (+ fromEnum '0')) cmode mempty
+
+instance ToJSON FileMode where
+    toJSON     = toJSON     . fileModeOctal
+    toEncoding = toEncoding . fileModeOctal
+
+data FileContents
+    = Plain  Text
+    | Base64 (AtBase "64")
+    deriving Generic
+
+instance ToJSON FileContents where
+    toJSON (Plain  txt) = toJSON txt
+    toJSON (Base64 b64) = toJSON $ encodedText b64
+
+    toEncoding (Plain  txt) = toEncoding txt
+    toEncoding (Base64 b64) = toEncoding $ encodedText b64
+
+plainTextFileContents :: Text -> FileContents
+plainTextFileContents = Plain
+
+base64FileContents :: AtBase "64" -> FileContents
+base64FileContents = Base64
+
+jsonOpts :: Aeson.Options
+jsonOpts = Aeson.defaultOptions
+    { Aeson.omitNothingFields = True
+    , Aeson.sumEncoding       = Aeson.UntaggedValue
+    }

--- a/src/Oscoin/Deployment/Internal/Docker.hs
+++ b/src/Oscoin/Deployment/Internal/Docker.hs
@@ -1,0 +1,223 @@
+{-# LANGUAGE DataKinds #-}
+
+module Oscoin.Deployment.Internal.Docker
+    ( Image(..)
+    , ImageTagOrDigest(..)
+    , renderImage
+
+    , RegistryLogin(..)
+    , registryLoginCmd
+
+    , EnvVar
+    , mkEnvVar
+
+    , ContainerConfig(..)
+    , containerConfigOpts
+
+    , HostConfig(..)
+    , hostConfigOpts
+
+    , LogDriver(..)
+    , NetworkMode(..)
+    , MountType(..)
+
+    , Mount(..)
+    , mountOpts
+    )
+where
+
+import           Oscoin.Prelude
+
+import           Oscoin.Deployment.Internal.CloudInit (User, renderUidOrName)
+
+import           Crypto.Hash (Digest, SHA256)
+import           Data.Generics.Product (the)
+import qualified Data.Text as T
+import           Lens.Micro.Extras (view)
+import           Network.URI (URI, uriToString)
+import           System.Console.Option
+import           System.FilePath ((</>))
+
+data ImageTagOrDigest
+    = ImageTag    Text
+    | ImageDigest (Digest SHA256) -- doesn't really make sense to use 'Digest' here
+
+data Image = Image
+    { registry    :: Maybe Text
+    , repository  :: Maybe Text
+    , name        :: Text
+    , tagOrDigest :: ImageTagOrDigest
+    } deriving Generic
+
+renderImage :: Image -> Text
+renderImage Image {..} =
+    (<> renderTagOrDigest tagOrDigest)
+    . mconcat . intersperse "/" . catMaybes
+    $ [ registry
+      , repository
+      , Just name
+      ]
+  where
+    renderTagOrDigest = \case
+        ImageTag    t -> T.cons ':' t
+        ImageDigest d -> "@sha256:" <> show d
+
+data RegistryLogin
+    = DockerLogin Text Var URI
+    | GcrLogin
+
+registryLoginCmd :: FilePath -> RegistryLogin -> SomeCmd
+registryLoginCmd binPath = \case
+    DockerLogin usr passv uri ->
+        SomeCmd (binPath </> "docker")
+                [ LitOpt $ Arg "login"
+                , LitOpt $ Opt "username" usr
+                , ShOpt  $ Opt "password" (ShVar passv)
+                , LitOpt . Arg . toS $ uriToString identity uri ""
+                ]
+
+    GcrLogin ->
+        SomeCmd (binPath </> "docker-credential-gcr")
+                [LitOpt $ Arg "configure-docker"]
+
+data EnvVar = EnvVar Text Text
+    deriving Generic
+
+mkEnvVar :: Text -> Text -> EnvVar
+mkEnvVar = EnvVar
+
+data ContainerConfig = ContainerConfig
+    { user       :: User
+    , env        :: [EnvVar]
+    , cmd        :: [SomeOpt]
+    , image      :: Image
+    , workingDir :: Maybe FilePath
+    , entrypoint :: Maybe FilePath
+    , hostConfig :: HostConfig
+    } deriving Generic
+
+containerConfigOpts :: ContainerConfig -> [SomeOpt]
+containerConfigOpts
+    (ContainerConfig
+        user
+        env
+        cmd
+        image
+        workingDir
+        entrypoint
+        hostConfig) =
+    (<> cmd) . map LitOpt $
+           Opt "user"
+               ( renderUidOrName user
+              -- Nb. assume default behaviour of useradd, which adds a group
+              -- with gid=uid for every user. We need to specify it here to
+              -- avoid the container user to have gid=0 (which is as good as
+              -- running with uid=0).
+              <> maybe mempty ((":" <>) . show) (uid user)
+               )
+{-
+    FIXME: we need the numeric GID for this, but cloud-init won't give it to us
+
+         : map (Opt "group-add" . renderGidOrName)
+               (toList $ view (the @"groups") user)
+-}
+         : map (\(EnvVar k v) -> Opt "env" (k <> "=" <> v)) env
+        <> maybeToList (Opt "workdir" . toS <$> workingDir)
+        <> maybeToList (Opt "entrypoint" . toS <$> entrypoint)
+        <> hostConfigOpts hostConfig
+        <> [Arg (renderImage image)]
+  where
+    uid :: User -> Maybe Word16
+    uid = view (the @"uid")
+
+data HostConfig = HostConfig
+    { logDriver      :: LogDriver
+    , networkMode    :: NetworkMode
+    , mount          :: [Mount]
+    , capAdd         :: [Text]
+    , capDrop        :: [Text]
+    , oomScoreAdj    :: Maybe Int
+    , readonlyRootfs :: Bool
+    , securityOpt    :: [Text]
+    -- we may want to tweak those at some point:
+    -- , resources       :: ContainerResources
+    } deriving Generic
+
+hostConfigOpts :: HostConfig -> [Opt Text]
+hostConfigOpts
+    (HostConfig
+        logDriver
+        networkMode
+        mount
+        capAdd
+        capDrop
+        oomScoreAdj
+        readonlyRootfs
+        securityOpt) =
+
+       [ Opt "log-driver" $ renderLogDriver   logDriver
+       , Opt "network"    $ renderNetworkMode networkMode
+       ]
+    <> map (Opt "cap-add"     ) capAdd
+    <> map (Opt "cap-drop"    ) capDrop
+    <> map (Opt "security-opt") securityOpt
+    <> concatMap mountOpts mount
+    <> catMaybes
+       [ bool Nothing (Just (Arg "readonly")) readonlyRootfs
+       , Opt "oom-score-adj" . show <$> oomScoreAdj
+       ]
+
+data MountType
+    = Bind
+    | Volume
+    | Tmpfs
+
+renderMountType :: MountType -> Text
+renderMountType = \case
+    Bind   -> "bind"
+    Volume -> "volume"
+    Tmpfs  -> "tmpfs"
+
+data Mount = Mount
+    { mountType :: MountType
+    , target    :: FilePath
+    , source    :: FilePath
+    , readOnly  :: Bool
+    -- , consistency :: MountConsistency
+    -- skipping options for now
+    }
+
+mountOpts :: Mount -> [Opt Text]
+mountOpts (Mount mountType target source readOnly) =
+    [ Opt "mount" . mconcat . intersperse "," $
+        [ "type="     <> renderMountType mountType
+        , "source="   <> toS source
+        , "target="   <> toS target
+        , "readonly=" <> bool "false" "true" readOnly
+        ]
+    ]
+
+data LogDriver
+    = JsonFile
+    | Journald
+    | LoggingDisabled
+
+renderLogDriver :: LogDriver -> Text
+renderLogDriver = \case
+    JsonFile        -> "json-file"
+    Journald        -> "journald"
+    LoggingDisabled -> "none"
+
+data NetworkMode
+    = NetworkHost
+    | NetworkDisabled
+
+renderNetworkMode :: NetworkMode -> Text
+renderNetworkMode = \case
+    NetworkHost     -> "host"
+    NetworkDisabled -> "none"
+
+data HostPort = HostPort
+    { hostIp   :: Text
+    , hostPost :: Word16
+    } deriving Generic

--- a/src/Oscoin/Deployment/Internal/GCE.hs
+++ b/src/Oscoin/Deployment/Internal/GCE.hs
@@ -1,0 +1,152 @@
+{-# LANGUAGE DataKinds       #-}
+{-# LANGUAGE OverloadedLists #-}
+
+{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
+
+module Oscoin.Deployment.Internal.GCE
+    ( MountPoint(fromMountPoint)
+    , cloudConfig
+    )
+where
+
+import           Oscoin.Prelude
+
+import           Oscoin.Deployment.Internal.CloudInit
+import           Oscoin.Deployment.Internal.Docker
+                 (ContainerConfig, RegistryLogin(..))
+import           Oscoin.Deployment.Internal.Systemd
+                 (dockerDaemonService, renderService)
+
+import           Data.Generics.Product (the)
+import           Data.List (nubBy)
+import qualified Data.Map as Map
+import qualified Data.Vector as Vector
+import qualified Formatting as F
+import           Lens.Micro (set, to, (.~))
+import           Lens.Micro.Extras (view)
+import           System.Console.Option
+import           System.FilePath ((</>))
+import           System.Posix
+                 (groupReadMode, otherReadMode, ownerReadMode, ownerWriteMode)
+
+newtype MountPoint = MountPoint { fromMountPoint :: FilePath }
+    deriving (Eq, Ord, Show, Read, IsString)
+
+cloudConfig
+    :: Word8
+    -> Map Text (NonEmpty (User -> MountPoint) -> ContainerConfig)
+    -> CloudConfig
+cloudConfig (max 1 . min 8 -> numLocalDisks) containers =
+    mkCloudConfig
+        & the @"users"       .~ usrs
+        & the @"write_files" .~ files
+        & the @"bootcmd"     .~ bootcmds
+        & the @"runcmd"      .~ cmds
+  where
+    localStorageMount = "/mnt/disks/ephemeral"
+
+    containers' =
+        let
+            userDir = view (the @"name" . to toS)
+            mnt usr = MountPoint . (</> userDir usr)
+                    $ fromMountPoint localStorageMount
+         in
+            map ($ mnt :| []) containers
+
+    usrs =
+        Vector.fromList
+            . nubBy (on (==) (view (the @"name")))
+            . map (view (the @"user"))
+            $ Map.elems containers'
+
+    bootcmds =
+        let
+            mnt  = toS $ fromMountPoint localStorageMount
+            fmt  = F.sformat F.build
+         in
+            Vector.fromList $ map fmt $
+                [ Cmd @Text "mdadm"
+                    ( Flag "create"
+                    : Arg "/dev/md0"
+                    : Opt "level" "0"
+                    : Opt "raid-devices" (show numLocalDisks)
+                    : Flag "force"
+                    : map (\i -> Arg $ "/dev/nvme0n" <> show i)
+                          [1 .. numLocalDisks]
+                    )
+                , Cmd "mkfs.ext4"
+                    [ Arg "-F"
+                    , Arg "/dev/md0"
+                    ]
+                , Cmd "mkdir"
+                    [ Flag "parents"
+                    , Arg mnt
+                    ]
+                , Cmd "mount"
+                    [ Arg "/dev/md0"
+                    , Arg mnt
+                    ]
+                , Cmd "chmod"
+                    [ Arg "g+w"
+                    , Arg mnt
+                    ]
+                ]
+
+    -- FIXME: this should be a proper executable, a la coreos-metadata
+    metadataHack =
+        "echo GCE_LOCAL_IPV4=\
+        \$(curl -Ss -H\"Metadata-Flavor: Google\" http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip) > \
+        \/var/run/metadata"
+
+    cmds =
+        let
+            ephemeralUserDirs = flip concatMap usrs $ \usr ->
+                let
+                    mnt  = fromMountPoint localStorageMount
+                    name = view (the @"name") usr
+                    dir  = toS $ mnt </> toS name
+                 in
+                    [ Cmd @Text "mkdir" [Arg dir ]
+                    , Cmd "chown"
+                        [ Arg $ name <> ":" <> name
+                        , Arg dir
+                        ]
+                    ]
+            systemdReload = Cmd @Text "systemctl" [Arg "daemon-reload"]
+            servicesStart = flip concatMap (Map.keys containers') $ \s ->
+                let
+                    cmd x =
+                        Cmd @Text "systemctl"
+                            [Arg x, Arg (s <> ".service")]
+                 in
+                    [cmd "enable", cmd "start"]
+
+            fmt = F.sformat F.build
+         in
+            Vector.fromList
+                $ metadataHack
+                : map fmt ephemeralUserDirs
+               <> map fmt (systemdReload : servicesStart)
+
+    srvs =
+        map ( set (the @"service" . the @"environmentFile")
+                  (Just "/var/run/metadata")
+            . uncurry (dockerDaemonService (pure GcrLogin))
+            )
+            (Map.toList containers')
+
+    srvUnitFile srv =
+        mkWriteFiles ( "/etc/systemd/system/"
+                    <> toS (view (the @"name") srv)
+                    <> ".service"
+                     )
+                     (fromPosixFileMode (  ownerReadMode
+                                       .|. ownerWriteMode
+                                       .|. groupReadMode
+                                       .|. otherReadMode
+                                        ))
+                     rootOwner
+                     (plainTextFileContents $ renderService srv)
+
+    files =
+        Vector.fromList $ map srvUnitFile srvs

--- a/src/Oscoin/Deployment/Internal/Systemd.hs
+++ b/src/Oscoin/Deployment/Internal/Systemd.hs
@@ -1,0 +1,157 @@
+{-# LANGUAGE DataKinds #-}
+
+module Oscoin.Deployment.Internal.Systemd
+    ( Unit
+    , mkUnit
+    , multiUserTarget
+    , gcrOnlineTarget
+
+    , UnitSection
+    , ServiceSection
+    , InstallSection
+
+    , Service
+    , renderService
+    , dockerDaemonService
+    )
+where
+
+import           Oscoin.Prelude
+
+import qualified Oscoin.Deployment.Internal.Docker as Doge
+
+import           Data.Generics.Product (the)
+import qualified Data.Map.Strict as Map
+import qualified Data.Text as T
+import qualified Formatting as F
+import           Lens.Micro.Extras (view)
+import           System.Console.Option
+
+data Unit
+    = KnownUnit Text
+    | Unit      Text UnitSection
+
+multiUserTarget :: Unit
+multiUserTarget = KnownUnit "multi-user.target"
+
+gcrOnlineTarget :: Unit
+gcrOnlineTarget = KnownUnit "gcr-online.target"
+
+mkUnit :: Text -> UnitSection -> Unit
+mkUnit = Unit
+
+data UnitSection = UnitSection
+    { description :: Maybe Text
+    , wants       :: [Unit]
+    , before      :: [Unit]
+    , after       :: [Unit]
+    } deriving Generic
+
+data ServiceSection = ServiceSection
+    { environment     :: Map Text Text
+    , environmentFile :: Maybe FilePath
+    , execStartPre    :: Maybe Text
+    , execStart       :: Text
+    , execStop        :: Maybe Text
+    , execStopPost    :: Maybe Text
+    } deriving Generic
+
+data InstallSection = InstallSection
+    { wantedBy   :: [Unit]
+    , requiredBy :: [Unit]
+    , also       :: [Unit]
+    } deriving Generic
+
+data Service = Service
+    { name    :: Text
+    , unit    :: UnitSection
+    , service :: ServiceSection
+    , install :: Maybe InstallSection
+    } deriving Generic
+
+dockerDaemonService
+    :: Maybe Doge.RegistryLogin
+    -> Text
+    -> Doge.ContainerConfig
+    -> Service
+dockerDaemonService rlogin name container =
+    Service
+        name
+        UnitSection
+            { description = Just name
+            , wants       = depends
+            , after       = depends
+            , before      = mempty
+            }
+        ServiceSection
+            { environment = Map.fromList
+                [("HOME", "/home/" <> view (the @"user" . the @"name") container)]
+
+            , environmentFile = Nothing
+
+            , execStartPre = fmtTxt .
+                Doge.registryLoginCmd "/usr/bin" <$> rlogin
+
+            , execStart    = fmtTxt
+                . SomeCmd "/usr/bin/docker"
+                $ LitOpt (Arg "run")
+                : Doge.containerConfigOpts container
+
+            , execStop     = Just . fmtTxt $
+                Cmd @Text "/usr/bin/docker" [Arg "stop", Arg name]
+
+            , execStopPost = Just . fmtTxt $
+                Cmd @Text "/usr/bin/docker" [Arg "rm", Arg name]
+            }
+        $ pure InstallSection
+            { wantedBy   = depends
+            , requiredBy = mempty
+            , also       = mempty
+            }
+  where
+    fmtTxt :: F.Buildable a => a -> Text
+    fmtTxt = F.sformat F.build
+
+    depends = maybeToList $ rlogin <&> \case
+        Doge.GcrLogin -> gcrOnlineTarget
+        _             -> multiUserTarget
+
+renderService :: Service -> Text
+renderService Service {..} = T.unlines $
+      renderUnitSection unit
+    : renderServiceSection service
+    : maybeToList (renderInstallSection <$> install)
+
+renderUnitSection :: UnitSection -> Text
+renderUnitSection UnitSection {..} = T.unlines $
+    [ "[Unit]"
+    , "Description=" <> fromMaybe mempty description
+    ]
+    <> map (("Wants="  <>) . unitName) wants
+    <> map (("Before=" <>) . unitName) before
+    <> map (("After="  <>) . unitName) after
+
+renderServiceSection :: ServiceSection -> Text
+renderServiceSection ServiceSection {..} = T.unlines . catMaybes $
+      pure "[Service]"
+    : map (("EnvironmentFile=" <>) . toS) environmentFile
+    : map ("ExecStartPre=" <>) execStartPre
+    : pure ("ExecStart=" <> execStart)
+    : map ("ExecStop=" <>) execStop
+    : map ("ExecStopPost=" <>) execStopPost
+    : Map.foldrWithKey
+        (\k v acc -> Just ("Environment=\"" <> k <> "=" <> v <> "\"") : acc)
+        []
+        environment
+
+renderInstallSection :: InstallSection -> Text
+renderInstallSection InstallSection {..} = T.unlines $
+       pure "[Install]"
+    <> map (("WantedBy="   <>) . unitName) wantedBy
+    <> map (("RequiredBy=" <>) . unitName) requiredBy
+    <> map (("Also="       <>) . unitName) also
+
+unitName :: Unit -> Text
+unitName = \case
+    KnownUnit x -> x
+    Unit    x _ -> x

--- a/src/Oscoin/Deployment/Node.hs
+++ b/src/Oscoin/Deployment/Node.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE DataKinds       #-}
+{-# LANGUAGE OverloadedLists #-}
+
+module Oscoin.Deployment.Node (run) where
+
+import           Oscoin.Prelude
+
+import qualified Oscoin.Crypto.Hash as Crypto
+import           Oscoin.Deployment.Internal.CloudInit (renderCloudConfig)
+import qualified Oscoin.Deployment.Internal.GCE as GCE (cloudConfig)
+import           Oscoin.Deployment.Node.GCE
+import           Oscoin.Deployment.Node.Options
+import qualified Oscoin.P2P.Disco.Options as Disco
+
+import           Data.Generics.Product (the)
+import qualified Data.Text.Lazy.Builder as TBuild
+import qualified Formatting as F
+import           Lens.Micro (Lens, over)
+import           Lens.Micro.Extras (view)
+
+run :: Show (Crypto.ShortHash c) => Options c Disco.OptNetwork -> IO ()
+run opts = do
+    Options{..} <-
+        -- Not great do this here instead of main, but I can not convince
+        -- generic-lens that there is a type-changing lens focusing on the disco
+        -- opts from the top-level deployment options.
+        Disco.evalOptions (view discoOpts opts) >>=
+            either (die . toS)
+                   (\x -> pure $ over discoOpts (const x) opts)
+
+    case optProvider of
+        GCE GceOptions { gceNumSSDs } ->
+            case optFormat of
+                CloudInit ->
+                    case gceNodeOptions optNodeOptions of
+                        Left  e    -> die $ show e
+                        Right nopt ->
+                            printCloudConfig optOutput
+                                . GCE.cloudConfig gceNumSSDs
+                                $ [("oscoin", gceContainer nopt optVersion)]
+  where
+    discoOpts :: Lens (Options       c n) (Options       c m)
+                      (Disco.Options c n) (Disco.Options c m)
+    discoOpts = the @"optNodeOptions" . the @"optDiscovery"
+
+    printCloudConfig out cfg =
+        let rendered = TBuild.fromText $ renderCloudConfig cfg
+         in case out of
+                Nothing -> F.fprint F.builder rendered
+                Just fp -> withFile fp WriteMode $ \hdl ->
+                    F.hprint hdl F.builder rendered

--- a/src/Oscoin/Deployment/Node/GCE.hs
+++ b/src/Oscoin/Deployment/Node/GCE.hs
@@ -1,0 +1,123 @@
+{-# LANGUAGE DataKinds       #-}
+{-# LANGUAGE OverloadedLists #-}
+
+module Oscoin.Deployment.Node.GCE
+    ( GceNodeOptions
+    , gceNodeOptions
+    , gceContainer
+    )
+where
+
+import           Oscoin.Prelude
+
+import qualified Oscoin.Crypto.Hash as Crypto
+import           Oscoin.Deployment.Internal.CloudInit
+import           Oscoin.Deployment.Internal.Docker
+import qualified Oscoin.Deployment.Internal.GCE as GCE
+import qualified Oscoin.Node.Options as Node
+import           Oscoin.P2P.Types (Network)
+
+import           Data.Coerce (coerce)
+import           Data.Generics.Product (the)
+import           Data.IP (IP)
+import qualified Data.List as List
+import           Lens.Micro (over, set)
+import           Network.Socket (HostName)
+import           System.Console.Option
+
+newtype GceNodeOptions c = GceNodeOptions [SomeOpt]
+
+data OptError
+    = NoSuchOption Text
+    deriving Show
+
+gceNodeOptions
+    :: Show (Crypto.ShortHash c)
+    => Node.Options c Network
+    -> Either OptError (GceNodeOptions c)
+gceNodeOptions nopt =
+    let
+        adjustments =
+              set  (the @"optHost")                            ("0.0.0.0" :: IP)
+            . set  (the @"optMetricsHost")                     (Nothing @HostName)
+            . set  (the @"optEkgHost")                         (Nothing @HostName)
+            . over (the @"optMetricsPort")                     (Just . fromMaybe 8081)
+            . set  (the @"optPaths" . the @"blockstorePath")   "/storage/blockstore.db"
+            . set  (the @"optDiscovery" . the @"optEnableMDns") False
+
+        removals = removeOpt "keys" >=> removeOpt "genesis"
+
+        -- FIXME: we should track option names at the type level (using e.g.
+        -- @vinyl@)
+        additions xs =
+              ShOpt (Opt "metrics-host" (ShVar "GCE_LOCAL_IPV4"))
+            : ShOpt (Opt "ekg-host"     (ShVar "GCE_LOCAL_IPV4"))
+            : xs
+     in
+        map (GceNodeOptions . additions)
+            . removals
+            . map LitOpt
+            . Node.nodeOptionsOpts
+            $ adjustments nopt
+  where
+    hasOpt :: Text -> Opt a -> Bool
+    hasOpt name = \case
+        Opt x _ -> x == name
+        Flag  x -> x == name
+        _       -> False
+
+    hasOpt' :: Text -> SomeOpt -> Bool
+    hasOpt' name = \case
+        LitOpt x -> hasOpt name x
+        ShOpt  x -> hasOpt name x
+
+    -- error if opt doesn't exist
+    removeOpt :: Text -> [SomeOpt] -> Either OptError [SomeOpt]
+    removeOpt name opts' = do
+        idx <- note (NoSuchOption name) $ List.findIndex (hasOpt' name) opts'
+        let (xs, ys) = List.splitAt idx opts'
+         in pure $ xs <> drop 1 ys
+
+gceContainer
+    :: GceNodeOptions c
+    -> Text
+    -> NonEmpty (User -> GCE.MountPoint)
+    -> ContainerConfig
+gceContainer opts version (storage :| _) = ContainerConfig
+    { user  = usr
+    , env   = [mkEnvVar "HOME" "/home/oscoin"]
+    , cmd   = coerce opts
+    , image = Image
+        { registry    = Just "eu.gcr.io"
+        , repository  = Just "opensourcecoin"
+        , name        = "oscoin"
+        , tagOrDigest = ImageTag version
+        }
+    , workingDir = Just "/home/oscoin"
+    , entrypoint = Just "/bin/oscoin"
+    , hostConfig = HostConfig
+        { logDriver      = JsonFile
+        , networkMode    = NetworkHost
+        , mount          =
+            [ Mount
+                { mountType = Bind
+                , target    = "/home/oscoin"
+                , source    = "/home/oscoin"
+                , readOnly  = False
+                }
+            , Mount
+                { mountType = Bind
+                , target    = "/storage"
+                , source    = toS . GCE.fromMountPoint $ storage usr
+                , readOnly  = False
+                }
+            ]
+        , capAdd         = []
+        , capDrop        = []
+        , oomScoreAdj    = Nothing
+        , readonlyRootfs = False
+        , securityOpt    = []
+        }
+    }
+  where
+    usr = mkUser "oscoin" & set (the @"uid") (Just 9000)

--- a/src/Oscoin/Deployment/Node/Options.hs
+++ b/src/Oscoin/Deployment/Node/Options.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE DataKinds #-}
+
+module Oscoin.Deployment.Node.Options where
+
+import           Oscoin.Prelude hiding (option)
+
+import           Oscoin.Configuration (ConfigPaths)
+import qualified Oscoin.Crypto.Hash as Crypto
+import qualified Oscoin.Node.Options as Node
+import qualified Oscoin.P2P.Disco.Options as Disco
+
+import           Options.Applicative
+
+data CloudProvider
+    = GCE GceOptions
+
+data GceOptions = GceOptions
+    { gceNumSSDs :: Word8
+    }
+
+cloudProviderParser :: Parser CloudProvider
+cloudProviderParser = hsubparser $
+    command "gce"
+            (info (GCE <$> gceOpts) (progDesc "Target Google Compute Engine"))
+  where
+    gceOpts = GceOptions
+        <$> option (map (max 1 . min 8) auto)
+            ( long    "num-ssds"
+           <> help    "Number of local SSDs to provision (min 1, max 8)"
+           <> metavar "INT"
+           <> value   1
+           <> showDefault
+            )
+
+data ConfigFormat
+    = CloudInit
+    deriving (Enum, Bounded)
+
+allConfigFormats :: [ConfigFormat]
+allConfigFormats = [minBound .. maxBound]
+
+readConfigFormat :: String -> Either String ConfigFormat
+readConfigFormat = \case
+    "cloud-init" -> pure CloudInit
+    x            -> Left $ "Unsupported configuration format: " <> x
+
+showConfigFormat :: ConfigFormat -> String
+showConfigFormat = \case
+    CloudInit -> "cloud-init"
+
+data Options crypto network = Options
+    { optVersion     :: Text
+    , optProvider    :: CloudProvider
+    , optFormat      :: ConfigFormat
+    , optOutput      :: Maybe FilePath
+    , optNodeOptions :: Node.Options crypto network
+    } deriving Generic
+
+nodeDeployOptionsParser
+    :: Crypto.HasHashing c
+    => ConfigPaths
+    -> Parser (Options c Disco.OptNetwork)
+nodeDeployOptionsParser cps = Options
+    <$> option str
+        ( long    "version"
+       <> help    "Version to deploy. Should be commit SHA1."
+       <> metavar "STRING"
+        )
+    <*> cloudProviderParser
+    <*> option (eitherReader readConfigFormat)
+        ( long    "format"
+       <> help    "Machine configuration format"
+       <> metavar (intercalate "|" (map showConfigFormat allConfigFormats))
+       <> value   CloudInit
+       <> showDefaultWith showConfigFormat
+        )
+    <*> optional
+        ( option str
+          ( long    "output"
+         <> help    "Store output artifacts here. Prints to stdout if not given."
+         <> metavar "FILEPATH"
+          )
+        )
+    <*> Node.nodeOptionsParser cps

--- a/src/Oscoin/Deployment/Options.hs
+++ b/src/Oscoin/Deployment/Options.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE DataKinds #-}
+
+module Oscoin.Deployment.Options where
+
+import           Oscoin.Prelude hiding (option)
+
+import           Oscoin.Configuration (ConfigPaths)
+import qualified Oscoin.Crypto.Hash as Crypto
+import qualified Oscoin.Deployment.Node.Options as Node
+import qualified Oscoin.P2P.Disco.Options as Disco
+
+import           Options.Applicative
+
+data Command crypto network
+    = DeployNode (Node.Options crypto network)
+    deriving Generic
+
+deploymentCommandParser
+    :: Crypto.HasHashing c
+    => ConfigPaths
+    -> Parser (Command c Disco.OptNetwork)
+deploymentCommandParser cps = hsubparser $
+    command "node" (info deployNode (progDesc "Deploy a Full Node"))
+  where
+    deployNode = DeployNode <$> Node.nodeDeployOptionsParser cps

--- a/src/Oscoin/Node/Options.hs
+++ b/src/Oscoin/Node/Options.hs
@@ -25,7 +25,6 @@ import qualified Oscoin.Crypto.Hash as Crypto
 import           Oscoin.Crypto.PubKey as Crypto
 import           Oscoin.P2P.Disco (discoOpts, discoParser)
 import qualified Oscoin.P2P.Disco as P2P.Disco
-import           Oscoin.Time (Duration, seconds)
 
 import           Data.IP (IP)
 import qualified Data.Text as T
@@ -39,7 +38,7 @@ data Options crypto network = Options
     , optGossipPort         :: PortNumber
     , optApiPort            :: PortNumber
     , optDiscovery          :: P2P.Disco.Options crypto network
-    , optBlockTimeLower     :: Duration
+    , optBlockTimeLower     :: Word8
     , optPaths              :: Paths
     , optEnvironment        :: Environment
     , optMetricsHost        :: Maybe HostName
@@ -77,7 +76,7 @@ nodeOptionsParser cps = Options
        <> showDefault
         )
     <*> discoParser
-    <*> option (map (* seconds) auto)
+    <*> option auto
         ( long "block-time-lower"
        <> help "Lower bound on the block time. Applies only to empty blocks in \
                \the development environment, and is useful to avoid busy looping \
@@ -146,7 +145,7 @@ nodeOptionsOpts
     , pure . Opt "gossip-port" $ show optGossipPort
     , pure . Opt "api-port"    $ show optApiPort
     , discoOpts optDiscovery
-    , pure . Opt "block-time-lower" . show . (`div` seconds) $ optBlockTimeLower
+    , pure . Opt "block-time-lower" . show $ optBlockTimeLower
     , pathsOpts optPaths
     , environmentOpts optEnvironment
     , maybe [] (pure . Opt "metrics-host" . toS)  optMetricsHost

--- a/test/Integration/Test/Executable.hs
+++ b/test/Integration/Test/Executable.hs
@@ -93,7 +93,8 @@ testSmoke :: Assertion
 testSmoke = do
     ports@Ports { apiPort, ekgPort, metricsPort } <- randomPorts
     withOscoinExe ports $ \stdoutHdl _ -> do
-        out <- C8.hGet stdoutHdl 2048
+        threadDelay 2000000
+        out <- C8.hGet stdoutHdl 1024
         expectOutputContains "node starting" out
         expectOutputContains "mined block"   out
 

--- a/test/Test/Oscoin/Node/Options/Gen.hs
+++ b/test/Test/Oscoin/Node/Options/Gen.hs
@@ -26,8 +26,8 @@ genNodeOptions = Options
     <*> P2P.Gen.genPortNumber
     <*> P2P.Gen.genPortNumber
     <*> Disco.Gen.genOptions
-    <*> ((* seconds) . (`div` seconds)
-            <$> Gen.int64 (Range.constant (1 * seconds) Nakamoto.blockTime))
+    <*> Gen.word8
+            (Range.constant 1 (fromIntegral $ Nakamoto.blockTime `div` seconds))
     <*> Config.Gen.paths
     <*> Config.Gen.environment
     <*> Gen.maybe (toS . renderHostname <$> P2P.Gen.genHostname)


### PR DESCRIPTION
# What

Every build will execute a validation of the deployment configuration for a oscoin full node. The buid for the `master` branch will deploy that configuration to Google Compute Engine (GCE).

# How

A machine configuration consists of the CLI options passed to the `oscoin` executable, a systemd unit, and a [cloud-init](https://cloud-init.io) configuration which installs the systemd unit, and does other things which are specific to the cloud provider and VM image used. Currently the only supported configuration is to run `oscoin` as a Docker container on GCE using Google's [Container Optimized OS](https://cloud.google.com/container-optimized-os/docs) (COS).

The cloud (GCE) configuration is kept as minimalistic as possible: a managed instance group is created, for which the instance template (versioned by the commit SHA1) is updated on every deploy. The instance group is then instructed to perform a rolling upgrade, which spins up the new nodes before demoting the old ones. Once that succeeded, the DNS SRV records are updated to point to the new nodes. This way, the new nodes will be able to join the network through the old nodes (if there are no old nodes, #562 applies, ie. nodes will be isolated until the SRV records are set).

#  Known Limitations

* Currently, no stable storage is attached to VMs. This means that after a deployment, new nodes will have to perform a full sync with the old ones. Since we do not currently have a way to determine if a node has finished syncing, the rolling update just waits two minutes until it considers a new instance up.

  Interestingly, stable storage would just reduce the time it takes to catch up, but not eliminate the need for syncing. Thus, we should introduce a health check endpoint which indicates syncing status.

* No attempt is made at (secure) management / provisioning of key material, instead `--allow-ephemeral-keys` is used, which means no node identity will survive a deployment nor an instance restart.

* Log output is rather ugly and useless (cf. #572). It is also not written to the instance's local `journal`, which is somewhat inconvenient.

* There is no documentation (yet)

# Design Decisions

The basic rationale is that the executable's configuration is (in part) specific to the environment - yet the only way to ensure that the configuration is actually valid from the executable's point of view is to run it through it's parsing / validation routines. However, different deployment environments require to _adjust_ certain settings according to it's quirks, which in turn requires _some_ confidence that the result is stil a valid executable configuration.

Based on this, the choice was made that it is the responsibility of the application (Haskell) code to produce valid _machine_-level configuration. The environment-specific deployment code calls an executable to produce this configuration (and may specify additional executable options), and, if it succeeds, uses the resulting artifacts for any further deployment steps. Provisioning of any further infrastructure is up to the deployment code.

# Implementation Choices

* Docker
  There is actually no reason for us to use Docker containers (and it is, in fact, more of a hassle than a benefit), except that this is the only "installable" artifact we currently produce.
* COS
  COS is Google's interpretation of CoreOS, and has a very similar feature set (including automatic updates), tailored to running Docker containers. It seemed like a natural choice, as the future of CoreOS is unknown.
* cloud-init
  While its capabilities are somewhat limited, we also don't (and shouldn't!) need anything fancy which would justify are more heavyweight provisioning tool. [CoreOS's Ignition](https://github.com/coreos/ignition) was conceived as a successor to cloud-init, but there is again uncertainty about it's future, whereas cloud-init remains widely supported.

## Why not Kubernetes?

The promise of Kubernetes is to abstract over all the details of machine provisioning this PR actually deals with. That's nice, but the reality is that it is non-trivial to operate a production Kubernetes cluster in a secure way, worse if all the services are actually internet-facing.

That being said, it should be trivial to extend the code to produce a (sample) Kubernetes manifest people can use if they want to run `oscoin` nodes on K8s.

## Why not terraform?

Simple: `gcloud` is enough for our purposes. Also, terraform is not a deployment tool, but a cloud provisioning system - as such, it requires much broader privileges than absolutely necessary to deploy a single application, which makes it harder to run it securely as part of a CI/CD pipeline. It's configuration "language" also doesn't provide for much modularity and reuse, and the only way to test a typical terraform configuration is by running `terraform plan`, and eyeballing the output.

That being said, it should be trivial to integrate the devised separation of concerns into an existing terraform configuration - one can `local-exec` `oscoin-deploy`, and use the resulting `cloud-config` to provision instances. 