### PR TITLE
Make withNode and nodeState polymorphic in the seal

### DIFF
--- a/test/Oscoin/Test/API/HTTP/TestClient.hs
+++ b/test/Oscoin/Test/API/HTTP/TestClient.hs
@@ -19,18 +19,18 @@ import           Oscoin.Prelude hiding (get)
 import           Oscoin.API.Client
 import           Oscoin.API.HTTP.Client
 
-import           Oscoin.Test.HTTP.Helpers (Session, liftWaiSession)
+import           Oscoin.Test.HTTP.Helpers (DummySeal, Session, liftWaiSession)
 
 import qualified Network.Wai as Wai
 import qualified Network.Wai.Test as Wai
 
 
-type TestClient c = HttpClientT (Session c)
+type TestClient c = HttpClientT (Session c DummySeal)
 
-run :: TestClient c a -> Session c a
+run :: TestClient c a -> Session c DummySeal a
 run = runHttpClientT' makeWaiRequest
 
-makeWaiRequest :: Request -> Session c Response
+makeWaiRequest :: Request -> Session c DummySeal Response
 makeWaiRequest Request{..} = liftWaiSession $ fromSresp <$> Wai.srequest sreq
   where
     sreq = Wai.SRequest req requestBody

--- a/test/Test/Oscoin/API.hs
+++ b/test/Test/Oscoin/API.hs
@@ -31,13 +31,13 @@ tests Dict = testGroup "Test.Oscoin.API"
         [ testProperty "existing value" $ monadicIO $ do
             key <- pick genAlphaText
             value <- pick arbitrary
-            runSessionWithState @c [(key, value)] $ do
+            runSessionWithState' @c [(key, value)] $ do
                 result <- Client.run (Client.getState (Proxy @c) [key])
                 result @?= API.Ok value
 
         , testProperty "non-existing value" $ monadicIO $ do
             key <- pick genAlphaText
-            runSessionWithState @c [] $ do
+            runSessionWithState' @c [] $ do
               result <- Client.run (Client.getState (Proxy @c) [key])
               result @?= API.Err "Value not found"
         ]

--- a/test/Test/Oscoin/API/HTTP.hs
+++ b/test/Test/Oscoin/API/HTTP.hs
@@ -46,11 +46,11 @@ tests Dict = testGroup "Test.Oscoin.API.HTTP"
             liftIO $ runSession testState testSession
 
 data HTTPTest c = HTTPTest
-    { testState   :: NodeState c
-    , testSession :: Session c ()
+    { testState   :: NodeState c DummySeal
+    , testSession :: Session c DummySeal ()
     }
 
-httpTest :: NodeState c -> Session c () -> IO (HTTPTest c)
+httpTest :: NodeState c DummySeal -> Session c DummySeal () -> IO (HTTPTest c)
 httpTest state sess = pure $ HTTPTest{ testState = state, testSession = sess }
 
 getMissingBlock :: forall c. IsCrypto c => PropertyM IO (HTTPTest c)


### PR DESCRIPTION
This PR makes some of the functions inside `Test.API.HTTP.Helpers` a bit more polymorphic (in the seal) so that `nodeState` and `withNode` can be used also elsewhere (namely, in the tests for node syncing, to name one) skipping the tedious step of crafting a full-fledged `Node.Handle`.