### PR TITLE
Document beneficiary option in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ First, generate a key pair for your node::
 
 Then run the full node with::
 
-   stack exec oscoin -- --no-empty-blocks
+   stack exec oscoin -- --no-empty-blocks --beneficiary 0x0000000000000000000000000000000000000000
 
 Testing
 -------

--- a/src/Oscoin/Node/Options.hs
+++ b/src/Oscoin/Node/Options.hs
@@ -117,7 +117,7 @@ nodeOptionsParser cps = Options
         )
     <*> option (maybeReader readBeneficiary)
         ( long "beneficiary"
-       <> help "Beneficiary id for block rewards"
+       <> help "Beneficiary account id for block rewards. Hex encoded with leading 0x"
         )
   where
     readBeneficiary = Crypto.parseShortHash . T.pack


### PR DESCRIPTION
To make it easier to start nodes we document the `--beneficiary` in the Readme and provide better help text.

Closes #570.