### PR TITLE
Change 'Evaluator' type to prepare for OscoinTx

### DIFF
--- a/exe/node/Main.hs
+++ b/exe/node/Main.hs
@@ -116,7 +116,7 @@ main = do
                     gen
             -- FIXME(adn) Replace with a proper evaluator & state once we switch to
             -- the OscoinTx type.
-            let dummyEval _ s = Right ([], s)
+            let dummyEval _ _ s = ([], s)
             ledger <- liftIO $
                 Ledger.newFromBlockStoreIO dummyEval (fst blkStore) mempty
 

--- a/src/Oscoin/Crypto/Blockchain/Eval.hs
+++ b/src/Oscoin/Crypto/Blockchain/Eval.hs
@@ -6,7 +6,6 @@ module Oscoin.Crypto.Blockchain.Eval
     , Receipt(..)
     , buildBlock
     , evalBlock
-    , evalTraverse
     ) where
 
 import           Oscoin.Prelude
@@ -23,7 +22,7 @@ import qualified Generics.SOP as SOP
 
 type EvalResult state output = Either EvalError (output, state)
 
-type Evaluator state tx output = tx -> state -> EvalResult state output
+type Evaluator c state tx output = Beneficiary c -> [tx] -> state -> ([Either EvalError output], state)
 
 newtype EvalError = EvalError { fromEvalError :: Text }
     deriving (Eq, Show, Read, Semigroup, Monoid, IsString, Generic)
@@ -71,7 +70,7 @@ buildBlock
        , Crypto.Hashable c (BlockHeader c Unsealed)
        , AuthTree.MerkleHash (Hash c)
        )
-    => Evaluator st tx o
+    => Evaluator c st tx o
     -> Timestamp
     -> Beneficiary c
     -> st
@@ -80,52 +79,41 @@ buildBlock
     -> (Block c tx Unsealed, st, [Receipt c tx o])
 buildBlock eval tick benef st txs parentBlock =
     let initialState = st
-        (txOutputs, newState) = evalTraverse eval txs initialState
+        (txOutputs, newState) = evalWithTxs eval benef txs initialState
         validTxs = [tx | (tx, Right _) <- txOutputs]
         newBlock = mkUnsealedBlock (Just parentBlock) tick benef validTxs newState
         receipts = map (uncurry $ mkReceipt newBlock) txOutputs
      in (newBlock, newState, receipts)
+
 
 -- | Evaluate the transactions contained in the block against the given
 -- state and return the new state and all the produced Receipts.
 evalBlock
     :: forall c st tx o s.
        (Crypto.Hashable c tx)
-    => Evaluator st tx o
+    => Evaluator c st tx o
     -> st
     -> Block c tx s
     -> (st, [Receipt c tx o])
 evalBlock eval initialState blk =
-    let (txOutputs, newState) = evalTraverse eval (blockTxs blk) initialState
-        receipts = map (uncurry $ mkReceipt blk) txOutputs
+    let (txAndOutputs, newState) = evalWithTxs eval (blockBeneficiary blk) (toList $ blockTxs blk) initialState
+        receipts = [mkReceipt blk tx output | (tx, output) <- txAndOutputs]
      in (newState, toList receipts)
+
 
 -- Internal ------------------------------------------------------
 
--- | Traverses transactions, evalutes them against the
--- given state and provides the output of the transaction.
---
--- If the evaluation of a transaction fails the state remains untouched
--- and we proceed evaluating the next transaction.
-evalTraverse
-    :: (Traversable t)
-    => Evaluator state tx output
-    -> t tx
-    -> state
-    -> (t (tx, Either EvalError output), state)
-evalTraverse eval txs s = runState (traverse go txs) s
-  where
-    go tx = do
-        result <- evalToState eval tx
-        pure (tx, result)
 
-evalToState :: Evaluator state tx output -> tx -> State state (Either EvalError output)
-evalToState eval tx = state go
-  where
-    go st =
-        case eval tx st of
-            Left err            -> (Left err, st)
-            Right (output, st') -> (Right output, st')
+evalWithTxs
+    :: Evaluator c state tx output
+    -> Beneficiary c
+    -> [tx]
+    -> state
+    -> ([(tx, Either EvalError output)], state)
+evalWithTxs eval beneficiary txs oldState =
+    let (txOutputs, newState) = eval beneficiary txs oldState
+        outputsWithTxs = zip txs txOutputs
+    in (outputsWithTxs, newState)
 
 
 -- | Return an unsealed block holding the given transactions and state

--- a/src/Oscoin/Storage/Ledger.hs
+++ b/src/Oscoin/Storage/Ledger.hs
@@ -50,7 +50,7 @@ data Ledger crypto seal tx output state (m :: * -> *) = Ledger
     { ledgerBlockStoreReader :: BlockStoreReader crypto tx seal m
     , ledgerStateStore       :: HashStore crypto state m
     , ledgerReceiptStore     :: ReceiptStore.ReceiptStore crypto tx output m
-    , ledgerEvaluator        :: Evaluator state tx output
+    , ledgerEvaluator        :: Evaluator crypto state tx output
     }
 
 hoist
@@ -76,7 +76,7 @@ newFromBlockStoreIO
        , Crypto.Hashable crypto state
        , Crypto.Hashable crypto tx
        )
-    => Evaluator state tx output
+    => Evaluator crypto state tx output
     -> BlockStoreReader crypto tx seal IO
     -> state
     -> IO (Ledger crypto seal tx output state m)
@@ -94,7 +94,7 @@ mkLedger
     :: BlockStoreReader crypto tx seal m
     -> HashStore crypto state m
     -- ^ State store
-    -> Evaluator state tx output
+    -> Evaluator crypto state tx output
     -> ReceiptStore.ReceiptStore crypto tx output m
     -> Ledger crypto seal tx output state m
 mkLedger ledgerBlockStoreReader ledgerStateStore ledgerEvaluator ledgerReceiptStore =

--- a/test/Oscoin/Test/Consensus/Nakamoto.hs
+++ b/test/Oscoin/Test/Consensus/Nakamoto.hs
@@ -87,7 +87,7 @@ instance (IsCrypto c) => TestableNode c PoW (NakamotoNode c) (NakamotoNodeState 
         let blockStore = testableBlockStore
         let stateStore = mkStateHashStore nakStateStoreL
         let receiptStore = mkStateReceiptStore nakReceiptStoreL
-        let ledger = Ledger.mkLedger (fst blockStore) stateStore dummyEval receiptStore
+        let ledger = Ledger.mkLedger (fst blockStore) stateStore dummyEvalBlock receiptStore
         maybeBlock <- mineBlock ledger nakConsensus tn defaultBeneficiary
         -- NOTE (adn): We are bypassing the protocol at the moment, but we
         -- probably shouldn't.

--- a/test/Oscoin/Test/HTTP/Helpers.hs
+++ b/test/Oscoin/Test/HTTP/Helpers.hs
@@ -162,8 +162,8 @@ withNode seal NodeState{..} k = do
         pure mp
 
     blkStore@(blockStoreReader, _) <- newBlockStoreIO (blocks' blockstoreState)
-    let dummyEval _ s = Right ([], s)
-    ledger <- Ledger.newFromBlockStoreIO dummyEval blockStoreReader statestoreState
+    let dummyEvalBlock _ txs s = (map (\_ -> Right []) txs, s)
+    ledger <- Ledger.newFromBlockStoreIO dummyEvalBlock blockStoreReader statestoreState
     runProtocol (\_ _ -> Right ()) blockScore metrics blkStore config $ \dispatchBlock ->
         Node.withNode
             cfg

--- a/test/Test/Oscoin/DummyLedger.hs
+++ b/test/Test/Oscoin/DummyLedger.hs
@@ -11,7 +11,7 @@ module Test.Oscoin.DummyLedger
     ( DummyTx(..)
     , DummyState
     , DummyOutput
-    , dummyEval
+    , dummyEvalBlock
     ) where
 
 
@@ -63,5 +63,5 @@ type DummyState = [DummyTx]
 type DummyOutput = DummyTx
 
 -- | Prepends the transaction to the state and output the transaction.
-dummyEval :: Evaluator DummyState DummyTx DummyOutput
-dummyEval tx txs = Right (tx, tx:txs)
+dummyEvalBlock :: Evaluator c DummyState DummyTx DummyOutput
+dummyEvalBlock _beneficiary txs st = (map Right txs, reverse txs <> st )


### PR DESCRIPTION
We change the `Evaluator` type to make it compatible with the evaluation functions of the Oscoin ledger. 

Fixes #591

This commit eliminates the tests for `buildBlock`. The function is now mainly glue code and tests would require substantial ammounts of code.