### PR TITLE
Monitoring

### DIFF
--- a/scripts/deploy/gce/bootstrap
+++ b/scripts/deploy/gce/bootstrap
@@ -62,7 +62,7 @@ roles/monitoring.metricWriter
 _member="serviceAccount:${GCE_SERVICEACCOUNT_NAME}@${GCE_PROJECT_ID}.iam.gserviceaccount.com"
 
 for role in $_roles; do
-    gcloud iam service-accounts add-iam-policy-binding $GCE_PROJECT_ID \
+    gcloud projects add-iam-policy-binding $GCE_PROJECT_ID \
         --member="$_member" \
         --role="$role"
 done

--- a/scripts/deploy/gce/etc/cloud-init/monitoring.yaml
+++ b/scripts/deploy/gce/etc/cloud-init/monitoring.yaml
@@ -15,3 +15,6 @@ runcmd:
 
 - mkdir --parents /mnt/disks/persistent/nginx/html
 - mkdir --parents /mnt/disks/persistent/letsencrypt
+
+- iptables -w -a INPUT -p tcp -s 10.128.0.0/9 -j ACCEPT
+- iptables -w -a INPUT -p tcp --dport 3000 -j ACCEPT

--- a/scripts/deploy/gce/etc/cloud-init/monitoring.yaml
+++ b/scripts/deploy/gce/etc/cloud-init/monitoring.yaml
@@ -1,0 +1,17 @@
+#cloud-config
+
+users:
+- name: grafana
+  uid: 9000
+- name: prometheus
+  uid: 9001
+
+runcmd:
+- mkdir /mnt/disks/persistent/grafana
+- chown -R grafana:grafana /mnt/disks/persistent/grafana
+
+- mkdir /mnt/disks/persistent/prometheus
+- chown -R prometheus:prometheus /mnt/disks/persistent/prometheus
+
+- mkdir --parents /mnt/disks/persistent/nginx/html
+- mkdir --parents /mnt/disks/persistent/letsencrypt

--- a/scripts/deploy/gce/etc/grafana/grafana.ini
+++ b/scripts/deploy/gce/etc/grafana/grafana.ini
@@ -1,0 +1,529 @@
+##################### Grafana Configuration Example #####################
+#
+# Everything has defaults so you only need to uncomment things you want to
+# change
+
+# possible values : production, development
+;app_mode = production
+
+# instance name, defaults to HOSTNAME environment variable value or hostname if HOSTNAME var is empty
+;instance_name = ${HOSTNAME}
+
+#################################### Paths ####################################
+[paths]
+# Path to where grafana can store temp files, sessions, and the sqlite3 db (if that is used)
+data = /storage
+
+# Temporary files in `data` directory older than given duration will be removed
+;temp_data_lifetime = 24h
+
+# Directory where grafana can store logs
+logs = /storage/logs
+
+# Directory where grafana will automatically scan and look for plugins
+;plugins = /var/lib/grafana/plugins
+
+# folder that contains provisioning config files that grafana will apply on startup and while running.
+provisioning = /etc/grafana/provisioning
+
+#################################### Server ####################################
+[server]
+# Protocol (http, https, socket)
+protocol = https
+
+# The ip address to bind to, empty will bind to all interfaces
+;http_addr =
+
+# The http port  to use
+http_port = 3000
+
+# The public facing domain name used to access grafana from a browser
+;domain =
+
+# Redirect to correct domain if host header does not match domain
+# Prevents DNS rebinding attacks
+enforce_domain = true
+
+# The full public facing url you use in browser, used for redirects and emails
+# If you use reverse proxy and sub path specify full url (with sub path)
+;root_url =
+
+# Log web requests
+;router_logging = false
+
+# the path relative working path
+;static_root_path = public
+
+# enable gzip
+enable_gzip = true
+
+# https certs & key file
+;cert_file =
+;cert_key =
+
+# Unix socket path
+;socket =
+
+#################################### Database ####################################
+[database]
+# You can configure the database connection by specifying type, host, name, user and password
+# as separate properties or as on string using the url properties.
+
+# Either "mysql", "postgres" or "sqlite3", it's your choice
+type = sqlite3
+;host = 127.0.0.1:3306
+;name = grafana
+;user = root
+# If the password contains # or ; you have to wrap it with triple quotes. Ex """#password;"""
+;password =
+
+# Use either URL or the previous fields to configure the database
+# Example: mysql://user:secret@host:port/database
+;url =
+
+# For "postgres" only, either "disable", "require" or "verify-full"
+;ssl_mode = disable
+
+# For "sqlite3" only, path relative to data_path setting
+;path = grafana.db
+
+# Max idle conn setting default is 2
+;max_idle_conn = 2
+
+# Max conn setting default is 0 (mean not set)
+;max_open_conn =
+
+# Connection Max Lifetime default is 14400 (means 14400 seconds or 4 hours)
+;conn_max_lifetime = 14400
+
+# Set to true to log the sql calls and execution times.
+log_queries =
+
+# For "sqlite3" only. cache mode setting used for connecting to the database. (private, shared)
+;cache_mode = private
+
+#################################### Cache server #############################
+[remote_cache]
+# Either "redis", "memcached" or "database" default is "database"
+;type = database
+
+# cache connectionstring options
+# database: will use Grafana primary database.
+# redis: config like redis server e.g. `addr=127.0.0.1:6379,pool_size=100,db=grafana`
+# memcache: 127.0.0.1:11211
+;connstr =
+
+#################################### Data proxy ###########################
+[dataproxy]
+
+# This enables data proxy logging, default is false
+;logging = false
+
+# How long the data proxy should wait before timing out default is 30 (seconds)
+;timeout = 30
+
+# If enabled and user is not anonymous, data proxy will add X-Grafana-User header with username into the request, default is false.
+;send_user_header = false
+
+#################################### Analytics ####################################
+[analytics]
+# Server reporting, sends usage counters to stats.grafana.org every 24 hours.
+# No ip addresses are being tracked, only simple counters to track
+# running instances, dashboard and error counts. It is very helpful to us.
+# Change this option to false to disable reporting.
+reporting_enabled = false
+
+# Set to false to disable all checks to https://grafana.net
+# for new vesions (grafana itself and plugins), check is used
+# in some UI views to notify that grafana or plugin update exists
+# This option does not cause any auto updates, nor send any information
+# only a GET request to http://grafana.com to get latest versions
+check_for_updates = false
+
+# Google Analytics universal tracking code, only enabled if you specify an id here
+;google_analytics_ua_id =
+
+# Google Tag Manager ID, only enabled if you specify an id here
+;google_tag_manager_id =
+
+#################################### Security ####################################
+[security]
+# default admin user, created on startup
+;admin_user = admin
+
+# default admin password, can be changed before first start of grafana,  or in profile settings
+;admin_password = admin
+
+# used for signing
+;secret_key = SW2YcwTIb9zpOOhoPsMm
+
+# disable gravatar profile images
+;disable_gravatar = false
+
+# data source proxy whitelist (ip_or_domain:port separated by spaces)
+;data_source_proxy_whitelist =
+
+# disable protection against brute force login attempts
+;disable_brute_force_login_protection = false
+
+# set to true if you host Grafana behind HTTPS. default is false.
+cookie_secure = true
+
+# set cookie SameSite attribute. defaults to `lax`. can be set to "lax", "strict" and "none"
+;cookie_samesite = lax
+
+# set to true if you want to allow browsers to render Grafana in a <frame>, <iframe>, <embed> or <object>. default is false.
+allow_embedding = true
+
+#################################### Snapshots ###########################
+[snapshots]
+# snapshot sharing options
+;external_enabled = true
+;external_snapshot_url = https://snapshots-origin.raintank.io
+;external_snapshot_name = Publish to snapshot.raintank.io
+
+# remove expired snapshot
+;snapshot_remove_expired = true
+
+#################################### Dashboards History ##################
+[dashboards]
+# Number dashboard versions to keep (per dashboard). Default: 20, Minimum: 1
+;versions_to_keep = 20
+
+#################################### Users ###############################
+[users]
+# disable user signup / registration
+allow_sign_up = false
+
+# Allow non admin users to create organizations
+;allow_org_create = true
+
+# Set to true to automatically assign new users to the default organization (id 1)
+;auto_assign_org = true
+
+# Default role new users will be automatically assigned (if disabled above is set to true)
+auto_assign_org_role = Admin
+
+# Background text for the user field on the login page
+;login_hint = email or username
+;password_hint = password
+
+# Default UI theme ("dark" or "light")
+;default_theme = dark
+
+# External user management, these options affect the organization users view
+;external_manage_link_url =
+;external_manage_link_name =
+;external_manage_info =
+
+# Viewers can edit/inspect dashboard settings in the browser. But not save the dashboard.
+;viewers_can_edit = false
+
+# Editors can administrate dashboard, folders and teams they create
+editors_can_admin = true
+
+[auth]
+# Login cookie name
+;login_cookie_name = grafana_session
+
+# The lifetime (days) an authenticated user can be inactive before being required to login at next visit. Default is 7 days,
+;login_maximum_inactive_lifetime_days = 7
+
+# The maximum lifetime (days) an authenticated user can be logged in since login time before being required to login. Default is 30 days.
+;login_maximum_lifetime_days = 30
+
+# How often should auth tokens be rotated for authenticated users when being active. The default is each 10 minutes.
+;token_rotation_interval_minutes = 10
+
+# Set to true to disable (hide) the login form, useful if you use OAuth, defaults to false
+;disable_login_form = false
+
+# Set to true to disable the signout link in the side menu. useful if you use auth.proxy, defaults to false
+;disable_signout_menu = false
+
+# URL to redirect the user to after sign out
+;signout_redirect_url =
+
+# Set to true to attempt login with OAuth automatically, skipping the login screen.
+# This setting is ignored if multiple OAuth providers are configured.
+oauth_auto_login = true
+
+#################################### Anonymous Auth ######################
+[auth.anonymous]
+# enable anonymous access
+enabled = false
+
+# specify organization name that should be used for unauthenticated users
+org_name = Oscoin
+
+# specify role for unauthenticated users
+org_role = Viewer
+
+#################################### Github Auth ##########################
+[auth.github]
+;enabled = false
+;allow_sign_up = true
+;client_id = some_id
+;client_secret = some_secret
+;scopes = user:email,read:org
+;auth_url = https://github.com/login/oauth/authorize
+;token_url = https://github.com/login/oauth/access_token
+;api_url = https://api.github.com/user
+;team_ids =
+;allowed_organizations =
+
+#################################### Google Auth ##########################
+[auth.google]
+enabled = true
+allow_sign_up = true
+;client_id = some_client_id
+;client_secret = some_client_secret
+scopes = https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email
+auth_url = https://accounts.google.com/o/oauth2/auth
+token_url = https://accounts.google.com/o/oauth2/token
+api_url = https://www.googleapis.com/oauth2/v1/userinfo
+;allowed_domains =
+
+#################################### Generic OAuth ##########################
+[auth.generic_oauth]
+;enabled = false
+;name = OAuth
+;allow_sign_up = true
+;client_id = some_id
+;client_secret = some_secret
+;scopes = user:email,read:org
+;auth_url = https://foo.bar/login/oauth/authorize
+;token_url = https://foo.bar/login/oauth/access_token
+;api_url = https://foo.bar/user
+;team_ids =
+;allowed_organizations =
+;tls_skip_verify_insecure = false
+;tls_client_cert =
+;tls_client_key =
+;tls_client_ca =
+
+; Set to true to enable sending client_id and client_secret via POST body instead of Basic authentication HTTP header
+; This might be required if the OAuth provider is not RFC6749 compliant, only supporting credentials passed via POST payload
+;send_client_credentials_via_post = false
+
+#################################### Grafana.com Auth ####################
+[auth.grafana_com]
+;enabled = false
+;allow_sign_up = true
+;client_id = some_id
+;client_secret = some_secret
+;scopes = user:email
+;allowed_organizations =
+
+#################################### Auth Proxy ##########################
+[auth.proxy]
+;enabled = false
+;header_name = X-WEBAUTH-USER
+;header_property = username
+;auto_sign_up = true
+;ldap_sync_ttl = 60
+;whitelist = 192.168.1.1, 192.168.2.1
+;headers = Email:X-User-Email, Name:X-User-Name
+
+#################################### Basic Auth ##########################
+[auth.basic]
+;enabled = true
+
+#################################### Auth LDAP ##########################
+[auth.ldap]
+;enabled = false
+;config_file = /etc/grafana/ldap.toml
+;allow_sign_up = true
+
+#################################### SMTP / Emailing ##########################
+[smtp]
+;enabled = false
+;host = localhost:25
+;user =
+# If the password contains # or ; you have to wrap it with trippel quotes. Ex """#password;"""
+;password =
+;cert_file =
+;key_file =
+;skip_verify = false
+;from_address = admin@grafana.localhost
+;from_name = Grafana
+# EHLO identity in SMTP dialog (defaults to instance_name)
+;ehlo_identity = dashboard.example.com
+
+[emails]
+;welcome_email_on_sign_up = false
+
+#################################### Logging ##########################
+[log]
+# Either "console", "file", "syslog". Default is console and  file
+# Use space to separate multiple modes, e.g. "console file"
+mode = console
+
+# Either "debug", "info", "warn", "error", "critical", default is "info"
+;level = info
+
+# optional settings to set different levels for specific loggers. Ex filters = sqlstore:debug
+;filters =
+
+# For "console" mode only
+[log.console]
+;level =
+
+# log line format, valid options are text, console and json
+;format = console
+
+# For "file" mode only
+[log.file]
+;level =
+
+# log line format, valid options are text, console and json
+;format = text
+
+# This enables automated log rotate(switch of following options), default is true
+;log_rotate = true
+
+# Max line number of single file, default is 1000000
+;max_lines = 1000000
+
+# Max size shift of single file, default is 28 means 1 << 28, 256MB
+;max_size_shift = 28
+
+# Segment log daily, default is true
+;daily_rotate = true
+
+# Expired days of log file(delete after max days), default is 7
+;max_days = 7
+
+[log.syslog]
+;level =
+
+# log line format, valid options are text, console and json
+;format = text
+
+# Syslog network type and address. This can be udp, tcp, or unix. If left blank, the default unix endpoints will be used.
+;network =
+;address =
+
+# Syslog facility. user, daemon and local0 through local7 are valid.
+;facility =
+
+# Syslog tag. By default, the process' argv[0] is used.
+;tag =
+
+#################################### Alerting ############################
+[alerting]
+# Disable alerting engine & UI features
+enabled = false
+# Makes it possible to turn off alert rule execution but alerting UI is visible
+;execute_alerts = true
+
+# Default setting for new alert rules. Defaults to categorize error and timeouts as alerting. (alerting, keep_state)
+;error_or_timeout = alerting
+
+# Default setting for how Grafana handles nodata or null values in alerting. (alerting, no_data, keep_state, ok)
+;nodata_or_nullvalues = no_data
+
+# Alert notifications can include images, but rendering many images at the same time can overload the server
+# This limit will protect the server from render overloading and make sure notifications are sent out quickly
+;concurrent_render_limit = 5
+
+
+# Default setting for alert calculation timeout. Default value is 30
+;evaluation_timeout_seconds = 30
+
+# Default setting for alert notification timeout. Default value is 30
+;notification_timeout_seconds = 30
+
+# Default setting for max attempts to sending alert notifications. Default value is 3
+;max_attempts = 3
+
+#################################### Explore #############################
+[explore]
+# Enable the Explore section
+;enabled = true
+
+#################################### Internal Grafana Metrics ##########################
+# Metrics available at HTTP API Url /metrics
+[metrics]
+# Disable / Enable internal metrics
+enabled = false
+
+# Publish interval
+;interval_seconds  = 10
+
+# Send internal metrics to Graphite
+[metrics.graphite]
+# Enable by setting the address setting (ex localhost:2003)
+;address =
+;prefix = prod.grafana.%(instance_name)s.
+
+#################################### Distributed tracing ############
+[tracing.jaeger]
+# Enable by setting the address sending traces to jaeger (ex localhost:6831)
+;address = localhost:6831
+# Tag that will always be included in when creating new spans. ex (tag1:value1,tag2:value2)
+;always_included_tag = tag1:value1
+# Type specifies the type of the sampler: const, probabilistic, rateLimiting, or remote
+;sampler_type = const
+# jaeger samplerconfig param
+# for "const" sampler, 0 or 1 for always false/true respectively
+# for "probabilistic" sampler, a probability between 0 and 1
+# for "rateLimiting" sampler, the number of spans per second
+# for "remote" sampler, param is the same as for "probabilistic"
+# and indicates the initial sampling rate before the actual one
+# is received from the mothership
+;sampler_param = 1
+
+#################################### Grafana.com integration  ##########################
+# Url used to import dashboards directly from Grafana.com
+[grafana_com]
+;url = https://grafana.com
+
+#################################### External image storage ##########################
+[external_image_storage]
+# Used for uploading images to public servers so they can be included in slack/email messages.
+# you can choose between (s3, webdav, gcs, azure_blob, local)
+;provider =
+
+[external_image_storage.s3]
+;bucket =
+;region =
+;path =
+;access_key =
+;secret_key =
+
+[external_image_storage.webdav]
+;url =
+;public_url =
+;username =
+;password =
+
+[external_image_storage.gcs]
+;key_file =
+;bucket =
+;path =
+
+[external_image_storage.azure_blob]
+;account_name =
+;account_key =
+;container_name =
+
+[external_image_storage.local]
+# does not require any configuration
+
+[rendering]
+# Options to configure external image rendering server like https://github.com/grafana/grafana-image-renderer
+;server_url =
+;callback_url =
+
+[enterprise]
+# Path to a valid Grafana Enterprise license.jwt file
+;license_path =
+
+[panels]
+# If set to true Grafana will allow script tags in text panels. Not recommended as it enable XSS vulnerabilities.
+;disable_sanitize_html = false
+
+[plugins]
+;enable_alpha = false
+;app_tls_skip_verify_insecure = false

--- a/scripts/deploy/gce/etc/grafana/provisioning/dashboards/oscoin.json
+++ b/scripts/deploy/gce/etc/grafana/provisioning/dashboards/oscoin.json
@@ -1,0 +1,401 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(oscoin_blocks_sent_total[5m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Blocks Sent (5min rate)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(oscoin_blocks_mined_total[5m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Blocks Mined (5m rate)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 6,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(oscoin_consensus_difficulty_adjustments_total[5m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Consensus Difficulty Adjustments (5min rate)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 8,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(oscoin_api_http_requests_total[5m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "HTTP Requests (5min rate)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "schemaVersion": 18,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Oscoin",
+  "uid": "We-_3kMWz",
+  "version": 5
+}

--- a/scripts/deploy/gce/etc/grafana/provisioning/dashboards/p2p.json
+++ b/scripts/deploy/gce/etc/grafana/provisioning/dashboards/p2p.json
@@ -1,0 +1,317 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 2,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 6,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(oscoin_p2p_handshake_errors_total[5m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Handshake Errors (5min rate)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(oscoin_p2p_gossip_connection_connect_errors_total[5m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Connect Errors (5min rate)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(oscoin_p2p_gossip_connection_accepted_total[5m])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Connections Accepted (5min rate)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "schemaVersion": 18,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "P2P",
+  "uid": "egN46kGWk",
+  "version": 3
+}

--- a/scripts/deploy/gce/etc/grafana/provisioning/dashboards/rts.json
+++ b/scripts/deploy/gce/etc/grafana/provisioning/dashboards/rts.json
@@ -1,0 +1,401 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 3,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(rts_gc_num_gcs[5m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Num GCs",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rts_gc_bytes_allocated",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Bytes Allocated",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(rts_gc_cumulative_bytes_used[5m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Bytes Used",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 5,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(rts_gc_gc_wall_ms[5m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "GC Wall",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "schemaVersion": 18,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "RTS",
+  "uid": "a6IF6zMZk",
+  "version": 5
+}

--- a/scripts/deploy/gce/etc/grafana/provisioning/datasources/prometheus.yaml
+++ b/scripts/deploy/gce/etc/grafana/provisioning/datasources/prometheus.yaml
@@ -1,0 +1,7 @@
+apiVersion: 1
+
+datasources:
+- name: Prometheus
+  type: prometheus
+  access: proxy
+  url: http://localhost:9090

--- a/scripts/deploy/gce/etc/letsencrypt/renewal-hooks/deploy/fix-permissions
+++ b/scripts/deploy/gce/etc/letsencrypt/renewal-hooks/deploy/fix-permissions
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+chmod 750 /mnt/disks/persistent/letsencrypt/live
+chmod 750 /mnt/disks/persistent/letsencrypt/archive
+
+find /mnt/disks/persistent/letsencrypt/archive -name "*.pem" -exec chmod g+r {} \;

--- a/scripts/deploy/gce/etc/prometheus/prometheus.yaml
+++ b/scripts/deploy/gce/etc/prometheus/prometheus.yaml
@@ -1,0 +1,6 @@
+scrape_configs:
+- job_name: oscoin
+  dns_sd_configs:
+  - type: SRV
+    names:
+    - _metrics._tcp.oscoin.devnet.oscoin.internal

--- a/scripts/deploy/gce/etc/systemd/system/certbot-renew.service
+++ b/scripts/deploy/gce/etc/systemd/system/certbot-renew.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Let's Encrypt Renewal
+
+[Service]
+Type=oneshot
+# Should this use Conflicts= and ???
+ExecStartPre=/usr/bin/systemctl stop grafana
+ExecStopPost=/usr/bin/systemctl start grafana
+ExecStart=/usr/bin/docker run --rm \
+    --name=certbot-renew \
+    --mount=type=bind,source=/mnt/disks/persistent/letsencrypt,target=/etc/letsencrypt,readonly=false \
+    certbot/certbot@sha256:ec4383b768b6a162889adcdce2d60cb4c760d2fa48287a354c0182c5e2330fed \
+    renew --non-interactive
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/deploy/gce/etc/systemd/system/certbot-renew.timer
+++ b/scripts/deploy/gce/etc/systemd/system/certbot-renew.timer
@@ -1,0 +1,6 @@
+[Timer]
+OnCalendar=Weekly
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/deploy/gce/etc/systemd/system/grafana.service
+++ b/scripts/deploy/gce/etc/systemd/system/grafana.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Grafana Dashboards
+Wants=multi-user.target
+After=multi-user.target
+ConditionPathExists=/mnt/disks/persistent/grafana/etc/grafana.ini
+ConditionPathExists=/mnt/disks/persistent/grafana/etc/env
+
+[Service]
+ExecStart=/usr/bin/docker run \
+    --name=grafana \
+    --user=9000:9000 \
+    --group-add=9002 \
+    --env-file=/mnt/disks/persistent/grafana/etc/env \
+    -p 443:3000 \
+    --mount=type=bind,source=/mnt/disks/persistent/grafana/etc,target=/etc/grafana,readonly=true \
+    --mount=type=bind,source=/mnt/disks/persistent/grafana/storage,target=/storage,readonly=false \
+    --mount=type=bind,source=/mnt/disks/persistent/letsencrypt,target=/etc/letsencrypt,readonly=true \
+    grafana/grafana@sha256:9e7fe9c7903a77107b28f63842f1fd1f358668933c0c51c0220c9889f1a2d878
+ExecStop=/usr/bin/docker stop grafana
+ExecStopPost=/usr/bin/docker rm grafana
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/deploy/gce/etc/systemd/system/prometheus.service
+++ b/scripts/deploy/gce/etc/systemd/system/prometheus.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Prometheus Monitoring
+Wants=multi-user.target
+After=multi-user.target
+ConditionPathExists=/mnt/disks/persistent/prometheus/etc/prometheus.yaml
+
+[Service]
+ExecStart=/usr/bin/docker run \
+    --name=prometheus \
+    --user=9001:9001 \
+    --network=host \
+    --mount=type=bind,source=/mnt/disks/persistent/prometheus/etc,target=/etc/prometheus,readonly=true \
+    --mount=type=bind,source=/mnt/disks/persistent/prometheus/storage,target=/storage,readonly=false \
+    quay.io/prometheus/prometheus@sha256:05350e0d1a577674442046961abf56b3e883dcd82346962f9e73f00667958f6b \
+    --config.file=/etc/prometheus/prometheus.yaml \
+    --storage.tsdb.path=/storage
+ExecStop=/usr/bin/docker stop prometheus
+ExecStopPost=/usr/bin/docker rm prometheus
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/deploy/gce/monitoring
+++ b/scripts/deploy/gce/monitoring
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+GCE_REGION=${GCE_REGION:-europe-west3}
+GCE_ZONE=${GCE_ZONE:-$GCE_REGION-a}
+GCE_VPC=${GCE_VPC:-devnet}
+GCE_SERVICEACCOUNT=${GCE_SERVICEACCOUNT:-oscoin-monitoring@opensourcecoin.iam.gserviceaccount.com}
+
+GCE_DNS_ZONE=${GCE_DNS_ZONE:-os-computer}
+GCE_DNS_DOMAIN=${GCE_DNS_DOMAIN:-monitoring.os.computer}
+
+# For Google authentication against Grafana
+GCE_OAUTH_CLIENT_ID=${GCE_OAUTH_CLIENT_ID:?Google OAuth client_id not set}
+GCE_OAUTH_CLIENT_SECRET=${GCE_OAUTH_CLIENT_SECRET:?Google OAuth client_secret not set}
+GCE_OAUTH_DOMAIN=${GCE_OAUTH_DOMAIN:-monadic.xyz}
+
+LETSENCRYPT_CONTACT=${LETSENCRYPT_CONTACT:?You need to provide an email address for Lets Encrypt}
+
+VERBOSE=${VERBOSE:-0}
+
+if [[ "$VERBOSE" != "0" ]]; then
+    set -x
+fi
+
+# get / create persistent IP
+echo "Determining external IP address..."
+_have_addr=$(gcloud compute addresses list \
+    --filter="name:oscoin-monitoring AND region:${GCE_REGION}" \
+    --format='value(name)' | wc -l)
+
+if [[ "$_have_addr" == "0" ]]; then
+    echo "Creating external IP address..."
+    gcloud compute addresses create oscoin-monitoring --region="${GCE_REGION}"
+fi
+_addr=$(gcloud compute addresses describe oscoin-monitoring \
+    --region="$GCE_REGION" \
+    --format='value(address)')
+
+# get / create resource record
+echo "Checking if domain name $GCE_DNS_DOMAIN exists..."
+_have_rr=$(gcloud dns record-sets list \
+    --zone="${GCE_DNS_ZONE}" \
+    --filter="name:${GCE_DNS_DOMAIN}" \
+    --format='value(name)' | wc -l)
+
+if [[ "$_have_rr" == "0" ]]; then
+    echo "Creating domain name $GCE_DNS_DOMAIN ..."
+    gcloud dns record-sets transaction start --zone="$GCE_DNS_ZONE"
+    gcloud dns record-sets transaction add \
+        --zone="$GCE_DNS_ZONE" \
+        --name="$GCE_DNS_DOMAIN" \
+        --ttl=600 \
+        --type=A \
+        $_addr
+    gcloud dns record-sets transaction execute --zone="$GCE_DNS_ZONE"
+
+    echo "Domain name $GCE_DNS_DOMAIN created."
+    echo "In order to obtain an SSL certificate via Let's Encrypt, this domain"
+    echo "needs to be resolvable by the larger internet. Please wait a few"
+    echo "minutes before running this script again."
+    exit 1
+fi
+
+# get / create persistent disk
+echo "Checking if a persistent disk already exists..."
+_have_pd=$(gcloud compute disks list \
+    --filter="name:oscoin-monitoring-pd AND zone:${GCE_ZONE}" \
+    --format='value(name)' | wc -l)
+
+if [[ "$_have_pd" == "0" ]]; then
+    echo "Creating persistent disk..."
+    gcloud compute disks create oscoin-monitoring-pd \
+        --size=500GB \
+        --type=pd-ssd \
+        --zone="$GCE_ZONE"
+fi
+
+# create instance
+echo "Checking if instance already exists..."
+_have_instance=$(gcloud compute instances list \
+    --filter="name:oscoin-monitoring AND zone:${GCE_ZONE}" \
+    --format='value(name)' | wc -l)
+
+if [[ "$_have_instance" == "0" ]]; then
+    echo "Creating instance..."
+    gcloud compute instances create oscoin-monitoring \
+        --address="$_addr" \
+        --image-project=cos-cloud \
+        --image-family=cos-stable \
+        --machine-type=n1-standard-8 \
+        --zone="$GCE_ZONE" \
+        --network="$GCE_VPC" \
+        --service-account="$GCE_SERVICEACCOUNT" \
+        --scopes=monitoring-write,logging-write \
+        --tags="oscoin-monitoring,http-server,https-server" \
+        --metadata="google-logging-enabled=true" \
+        --metadata-from-file=user-data=etc/cloud-init/monitoring.yaml \
+        --disk=auto-delete=no,boot=no,device-name=pd-0,mode=rw,name=oscoin-monitoring-pd
+
+    echo "Starting instance..."
+    gcloud compute instances start oscoin-monitoring --zone="$GCE_ZONE"
+fi
+
+echo "Mounting persistent disk. The PD may need formatting."
+gcloud compute ssh oscoin-monitoring --zone="$GCE_ZONE" -- <<EOF
+    set -eou pipefail
+
+    sudo toolbox apt-get update || true
+    sudo toolbox apt-get install -y file
+    sudo toolbox --bind-ro=/dev:/dev-host file -sL /dev-host/disk/by-id/google-pd-0 2>/dev/null|grep -s UUID || {
+        sudo mkfs.ext4 -m 0 -F -E lazy_itable_init=0,lazy_journal_init=0,discard /dev/disk/by-id/google-pd-0
+    }
+    sudo mkdir -p /mnt/disks/persistent
+    sudo mount -o discard,defaults \
+        /dev/disk/by-id/google-pd-0 \
+        /mnt/disks/persistent || true
+EOF
+
+echo "Creating directories on persistent disk..."
+gcloud compute ssh oscoin-monitoring --zone="$GCE_ZONE" -- <<EOF
+    set -eou pipefail
+    sudo mkdir -p /mnt/disks/persistent/{grafana,prometheus,letsencrypt}
+    sudo mkdir -p /mnt/disks/persistent/{grafana,prometheus}/{etc,storage}
+    sudo chown -R grafana:grafana /mnt/disks/persistent/grafana
+    sudo chown -R prometheus:prometheus /mnt/disks/persistent/prometheus
+EOF
+
+# This succeeds non-interactively approx. 9 out of 10 times
+echo "Obtaining SSL certificate via Let's Encrypt..."
+gcloud compute ssh oscoin-monitoring --zone="$GCE_ZONE" -- <<EOF
+set -eoux pipefail
+
+sudo systemctl stop grafana || true
+sudo docker run --rm \
+    --mount=type=bind,source=/mnt/disks/persistent/letsencrypt,target=/etc/letsencrypt,readonly=false \
+    -p 80:80 \
+    -p 443:443 \
+    certbot/certbot@sha256:ec4383b768b6a162889adcdce2d60cb4c760d2fa48287a354c0182c5e2330fed \
+    certonly \
+    --non-interactive \
+    --standalone \
+    --agree-tos \
+    -m $LETSENCRYPT_CONTACT \
+    --domain="$GCE_DNS_DOMAIN"
+sudo systemctl start grafana || true
+EOF
+
+echo "Copying configuration files..."
+gcloud compute scp --zone="$GCE_ZONE" --recurse \
+    $(dirname $BASH_SOURCE)/etc oscoin-monitoring:/tmp
+
+_grafana_env=$(mktemp grafana.env.XXXXX)
+cat > "$_grafana_env" <<EOF
+GF_AUTH_GOOGLE_CLIENT_ID=$GCE_OAUTH_CLIENT_ID
+GF_AUTH_GOOGLE_CLIENT_SECRET=$GCE_OAUTH_CLIENT_SECRET
+GF_AUTH_GOOGLE_ALLOWED_DOMAINS=$GCE_OAUTH_DOMAIN
+GF_SERVER_DOMAIN=$GCE_DNS_DOMAIN
+GF_SERVER_ROOT_URL=https://$GCE_DNS_DOMAIN
+GF_SERVER_CERT_FILE=/etc/letsencrypt/live/$GCE_DNS_DOMAIN/fullchain.pem
+GF_SERVER_CERT_KEY=/etc/letsencrypt/live/$GCE_DNS_DOMAIN/privkey.pem
+EOF
+gcloud compute scp --zone="$GCE_ZONE" \
+    "$_grafana_env" oscoin-monitoring:/tmp/etc/grafana/env
+rm "$_grafana_env"
+
+gcloud compute ssh oscoin-monitoring --zone="$GCE_ZONE" -- <<EOF
+set -eoux pipefail
+
+sudo chown root:root /tmp/etc
+sudo chmod 400 /tmp/etc/grafana/env
+
+sudo cp -r /tmp/etc/grafana/* /mnt/disks/persistent/grafana/etc
+sudo cp -r /tmp/etc/prometheus/* /mnt/disks/persistent/prometheus/etc
+sudo cp -r /tmp/etc/systemd/system/* /etc/systemd/system
+sudo cp -r /tmp/etc/letsencrypt/renewal-hooks/* /mnt/disks/persistent/letsencrypt/renewal-hooks
+
+sudo rm -rf /tmp/etc
+
+sudo chown -R grafana:grafana /mnt/disks/persistent/grafana/etc
+sudo chown -R prometheus:prometheus /mnt/disks/persistent/prometheus/etc
+
+# Can't use cloud-init, because we need the GID for docker
+sudo groupadd --gid 9002 letsencrypt || true
+sudo usermod -G letsencrypt grafana || true
+
+# Towers of Annoy
+sudo chgrp -R letsencrypt /mnt/disks/persistent/letsencrypt
+sudo chmod 750 /mnt/disks/persistent/letsencrypt/live
+sudo chmod 750 /mnt/disks/persistent/letsencrypt/archive
+sudo chmod g+r \
+    /mnt/disks/persistent/letsencrypt/archive/$GCE_DNS_DOMAIN/fullchain1.pem
+sudo chmod g+r \
+    /mnt/disks/persistent/letsencrypt/archive/$GCE_DNS_DOMAIN/privkey1.pem
+
+sudo systemctl daemon-reload
+units="grafana.service prometheus.service certbot-renew.service certbot-renew.timer"
+for s in \$units; do
+    sudo systemctl enable \$s
+    sudo systemctl start  \$s
+done
+EOF

--- a/scripts/deploy/gce/monitoring
+++ b/scripts/deploy/gce/monitoring
@@ -2,6 +2,20 @@
 
 set -euo pipefail
 
+#
+# Deploy a simple monitoring server on GCE (Grafana + Prometheus)
+#
+# Exposes Grafana with a Let's Encrypt certificate. Prometheus' Web UI is not
+# exposed, advanced users may want to forward port 9090 over SSH. Both the TSDB
+# and Grafana (SQLite) database reside on a persistent disk.
+#
+# A number of standard dashboards is maintained under
+# `etc/grafana/provisioning/dashboards`. Please follow this guide when making
+# changes:
+#
+# https://grafana.com/docs/administration/provisioning/#dashboards
+#
+
 GCE_REGION=${GCE_REGION:-europe-west3}
 GCE_ZONE=${GCE_ZONE:-$GCE_REGION-a}
 GCE_VPC=${GCE_VPC:-devnet}
@@ -194,9 +208,14 @@ sudo chmod g+r \
     /mnt/disks/persistent/letsencrypt/archive/$GCE_DNS_DOMAIN/privkey1.pem
 
 sudo systemctl daemon-reload
-units="grafana.service prometheus.service certbot-renew.service certbot-renew.timer"
+
+units="grafana.service
+prometheus.service
+certbot-renew.service
+certbot-renew.timer
+"
 for s in \$units; do
-    sudo systemctl enable \$s
-    sudo systemctl start  \$s
+    sudo systemctl enable  \$s
+    sudo systemctl restart \$s
 done
 EOF

--- a/scripts/deploy/gce/node
+++ b/scripts/deploy/gce/node
@@ -22,7 +22,7 @@ OSCOIN_METRICS_PORT=${OSCOIN_METRICS_PORT:-8081}
 OSCOIN_BENEFICIARY=${OSCOIN_BENEFICIARY:?Beneficiary address not set}
 
 GCE_PROJECT_ID=${GCE_PROJECT_ID:-opensourcecoin}
-GCE_REGION=${GCE_REGION:-europe-west1}
+GCE_REGION=${GCE_REGION:-europe-west3}
 GCE_VPC=${GCE_VPC:-$OSCOIN_NETWORK}
 GCE_SERVICEACCOUNT=${GCE_SERVICEACCOUNT:-oscoin-node@opensourcecoin.iam.gserviceaccount.com}
 GCE_MACHINE_TYPE=${GCE_MACHINE_TYPE:-n1-standard-1}
@@ -70,6 +70,7 @@ gcloud compute instance-templates create \
     --machine-type="$GCE_MACHINE_TYPE" \
     --region="$GCE_REGION" \
     --service-account="$GCE_SERVICEACCOUNT" \
+    --network="$GCE_VPC" \
     --scopes=monitoring-write,logging-write,storage-ro \
     --tags="oscoin-node,oscoin-$OSCOIN_NETWORK" \
     --labels="gossip-port=${OSCOIN_GOSSIP_PORT},api-port=${OSCOIN_API_PORT},metrics-port=${OSCOIN_METRICS_PORT}" \

--- a/scripts/gce/port-forward
+++ b/scripts/gce/port-forward
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+instance="$1"
+remote_port="$2"
+local_port="${3:-$2}"
+zone="${GCE_ZONE:-""}"
+
+if [[ -z "$instance" || -z "$remote_port" ]]; then
+    echo "Usage: port-forward <instance name> <remote port> [<local port>]"
+    echo "You may need to set the GCE_ZONE environment variable."
+    exit 1;
+fi
+
+if [[ -n "$zone" ]]; then
+    zone="--zone=$zone"
+fi
+
+echo "Establishing SSH tunnel..."
+gcloud compute ssh "$instance" \
+    "$zone" \
+    --ssh-flag='-N' \
+    --ssh-flag="-L ${local_port}:localhost:${remote_port}" 2>&1>/dev/null &
+echo "Tunnel ${local_port}:${instance}:${remote_port} up"

--- a/src/Oscoin/Deployment/Internal/GCE.hs
+++ b/src/Oscoin/Deployment/Internal/GCE.hs
@@ -98,6 +98,10 @@ cloudConfig (max 1 . min 8 -> numLocalDisks) containers =
         \$(curl -Ss -H\"Metadata-Flavor: Google\" http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip) > \
         \/var/run/metadata"
 
+    -- FIXME: support non-default topologies
+    iptablesAllowVPCInternal =
+        "iptables -w -A INPUT -p tcp -s 10.128.0.0/9 -j ACCEPT"
+
     cmds =
         let
             ephemeralUserDirs = flip concatMap usrs $ \usr ->
@@ -125,6 +129,7 @@ cloudConfig (max 1 . min 8 -> numLocalDisks) containers =
          in
             Vector.fromList
                 $ metadataHack
+                : iptablesAllowVPCInternal
                 : map fmt ephemeralUserDirs
                <> map fmt (systemdReload : servicesStart)
 

--- a/src/Oscoin/Deployment/Internal/Systemd.hs
+++ b/src/Oscoin/Deployment/Internal/Systemd.hs
@@ -95,6 +95,7 @@ dockerDaemonService rlogin name container =
             , execStart    = fmtTxt
                 . SomeCmd "/usr/bin/docker"
                 $ LitOpt (Arg "run")
+                : LitOpt (Opt "name" name)
                 : Doge.containerConfigOpts container
 
             , execStop     = Just . fmtTxt $


### PR DESCRIPTION
Makes available a simple monitoring server at https://monitoring.os.computer:3000

The provisioning is rather procedural atm due to various quirks. After running it for another 300x, I might feel confident to collapse more things into the cloud-init config.

**Caveats**

* The prometheus Web UI is not exposed on the internet, as it doesn't support authentication.

   Use SSH port-forwarding to access it: `gcloud compute ssh oscoin-monitoring --zone=europe-west3-a --ssh-flag="-L 9090:localhost:9090"`, or the included script `scripts/gce/port-forward`

* Using port 3000 instead of 443 is a bit unfortunate, we'll have to build a custom `grafana` image with the `net_bind_service` capability set on the executable

* Annoyingly, there is still no sane method to manage a set of "default" dashboards, apart from making a database backup, or saving the dashboard as JSON. 

  **If you adjust the provided dashboards (which are mostly wrong), please grab the JSON and check it into version control**