### PR TITLE
Improve robustness of syncing tests

### DIFF
--- a/test/Test/Oscoin/Protocol/Sync.hs
+++ b/test/Test/Oscoin/Protocol/Sync.hs
@@ -335,14 +335,16 @@ spinUpNode
     -> TBQueue ()
     -> (ActivePeer c, Blockchain c (Tx c) Nakamoto.PoW)
     -> IO (Async ())
-spinUpNode Dict tokens (peer, peerChain) = async $ do
-    let initialState = nodeState mempty peerChain mempty
-    withNode Nakamoto.emptyPoW initialState $ \hdl ->
-        API.runApi' noLogger
-                    (atomically $ writeTBQueue tokens ())
-                    (API.api identity)
-                    (fromIntegral $ addrPort $ nodeHttpApiAddr peer)
-                    hdl
+spinUpNode Dict tokens (peer, peerChain) = (\a -> link a >> pure a) =<<
+    async (do
+        let initialState = nodeState mempty peerChain mempty
+        withNode Nakamoto.emptyPoW initialState $ \hdl ->
+            API.runApi' noLogger
+                        (atomically $ writeTBQueue tokens ())
+                        (API.api identity)
+                        (fromIntegral $ addrPort $ nodeHttpApiAddr peer)
+                        hdl
+    )
 
 {------------------------------------------------------------------------------
   Constant values


### PR DESCRIPTION
This commit ensures that whenever `spinUpNode` throws and the async is
cancelled, the failure is propagated to the main thread, so that the
test runner doesn't hang. In normal conditions `spinUpNode` should never throw, but as the IO tests try to actually perform HTTP connections, they are by nature a bit flaky, so that's definitely better for the testsuite to fail rather than hang.