### PR TITLE
Make Grafana reachable on port 443

### DIFF
--- a/scripts/deploy/gce/etc/systemd/system/grafana.service
+++ b/scripts/deploy/gce/etc/systemd/system/grafana.service
@@ -6,18 +6,22 @@ ConditionPathExists=/mnt/disks/persistent/grafana/etc/grafana.ini
 ConditionPathExists=/mnt/disks/persistent/grafana/etc/env
 
 [Service]
+ExecStartPre=/sbin/iptables \
+    -t nat -A PREROUTING -p tcp --dport 443 -j REDIRECT --to-port 3000
 ExecStart=/usr/bin/docker run \
     --name=grafana \
     --user=9000:9000 \
     --group-add=9002 \
     --env-file=/mnt/disks/persistent/grafana/etc/env \
-    -p 443:3000 \
+    --network=host \
     --mount=type=bind,source=/mnt/disks/persistent/grafana/etc,target=/etc/grafana,readonly=true \
     --mount=type=bind,source=/mnt/disks/persistent/grafana/storage,target=/storage,readonly=false \
     --mount=type=bind,source=/mnt/disks/persistent/letsencrypt,target=/etc/letsencrypt,readonly=true \
     grafana/grafana@sha256:9e7fe9c7903a77107b28f63842f1fd1f358668933c0c51c0220c9889f1a2d878
 ExecStop=/usr/bin/docker stop grafana
 ExecStopPost=/usr/bin/docker rm grafana
+ExecStopPost=/sbin/iptables \
+    -t nat -D PREROUTING -p tcp --dport 443 -j REDIRECT --to-port 3000
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Note that we need to tear down the iptables rule on ExecStopPost, as it
would interfere with certbot.