### PR TITLE
GCE: Funnel logs through journald

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -48,6 +48,7 @@
 - ignore:
     name: Avoid restricted qualification
     within:
+    - Oscoin.Deployment.Internal.GCE
     - Oscoin.P2P
     - Oscoin.Protocol.Sync
     - System.Console.Option

--- a/src/Oscoin/Deployment/Node/GCE.hs
+++ b/src/Oscoin/Deployment/Node/GCE.hs
@@ -98,7 +98,7 @@ gceContainer opts version (storage :| _) = ContainerConfig
     , workingDir = Just "/home/oscoin"
     , entrypoint = Just "/bin/oscoin"
     , hostConfig = HostConfig
-        { logDriver      = JsonFile
+        { logDriver      = Journald
         , networkMode    = NetworkHost
         , mount          =
             [ Mount


### PR DESCRIPTION
Fixes #581

Note: this is mainly for operator convenience (you don't have to remember to type `docker logs` instead of `journalctl` when looking at logs on the machine). There [are some ways](https://docs.docker.com/config/containers/logging/journald/) to customise this further, eg. adding the current `network` as a `journald` tag. I'll leave that for a future PR.