### PR TITLE
hlint: Leave import qualification to the developer

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -2,19 +2,6 @@
 
 - arguments: [-XTypeApplications]
 
-- modules:
-  - {name: [Data.Set, Data.HashSet],     as: Set}
-  - {name: [Data.Map],                   as: Map}
-  - {name: [Data.HashMap],               as: HashMap}
-  - {name: [Data.List.NonEmpty],         as: NonEmpty}
-  - {name: [Data.Sequence],              as: Seq}
-  - {name: [Data.Text],                  as: T}
-  - {name: [Data.Text.Lazy],             as: LT}
-  - {name: [Data.ByteString],            as: BS}
-  - {name: [Data.ByteString.Lazy],       as: LBS}
-  - {name: [Data.ByteString.Char8],      as: C8}
-  - {name: [Data.ByteString.Lazy.Char8], as: L8}
-
 - functions:
   - {name: unsafePerformIO, within: [Oscoin.Test.Crypto.Blockchain.Block.Helpers]}
 
@@ -45,13 +32,6 @@
 - ignore: {name: Use print}
 - ignore: {name: Use camelCase}
 
-- ignore:
-    name: Avoid restricted qualification
-    within:
-    - Oscoin.Deployment.Internal.GCE
-    - Oscoin.P2P
-    - Oscoin.Protocol.Sync
-    - System.Console.Option
 - ignore:
     name: Avoid restricted function
     within:


### PR DESCRIPTION
While the intention is noble (consistency), in practice these rules are often annoying because things may read more natural when given a different name. The rule of qualifiying both `Set` and `HashSet` as `Set` also prevents importing both qualified.

Since naming things is considered part of computer science (and one of the hardest parts about it), I am proposing to leave it up to the author.