### PR TITLE
Set region for CD to europe-west3

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -162,7 +162,7 @@ steps:
     - OSCOIN_METRICS_PORT=8081
     - OSCOIN_DEPLOY=bin/oscoin-deploy
     - GCE_PROJECT_ID=$PROJECT_ID
-    - GCE_REGION=europe-west1
+    - GCE_REGION=europe-west3
     - GCE_VPC=devnet
     - GCE_SERVICEACCOUNT=oscoin-node@opensourcecoin.iam.gserviceaccount.com
     - GCE_MACHINE_TYPE=n1-standard-1


### PR DESCRIPTION
We have a quota of 24 CPUs/region, and run almost everything in europe-west1, exceeding the quota on a rolling update.