### PR TITLE
Actually disco forever

### DIFF
--- a/exe/node/Main.hs
+++ b/exe/node/Main.hs
@@ -8,6 +8,7 @@ import           Oscoin.Configuration
 import qualified Oscoin.Consensus as Consensus
 import qualified Oscoin.Consensus.Config as Consensus
 import qualified Oscoin.Consensus.Nakamoto as Nakamoto
+import           Oscoin.Crypto (Crypto)
 import           Oscoin.Crypto.Blockchain.Genesis (buildGenesisBlock)
 import qualified Oscoin.Crypto.PubKey as Crypto
 import           Oscoin.Data.Tx
@@ -20,6 +21,7 @@ import qualified Oscoin.P2P as P2P
 import qualified Oscoin.P2P.Disco as P2P.Disco
 import qualified Oscoin.P2P.Disco.MDns as MDns
 import qualified Oscoin.P2P.Handshake as Handshake
+import qualified Oscoin.P2P.Trace as P2P (Traceable(TraceDisco))
 import           Oscoin.Protocol (runProtocol)
 import           Oscoin.Storage (hoistStorage)
 import qualified Oscoin.Storage.Block.SQLite as BlockStore.SQLite
@@ -143,7 +145,9 @@ main = do
             disco <- managed $
                 let
                     instr :: HasCallStack => P2P.Disco.DiscoEvent -> IO ()
-                    instr = Telemetry.emit telemetry . Telemetry.DiscoEvent
+                    instr = Telemetry.emit telemetry
+                          . Telemetry.P2PEvent @Crypto
+                          . P2P.TraceDisco
                  in
                     P2P.Disco.withDisco instr optDiscovery' $
                         Set.fromList

--- a/src/Oscoin/P2P/Disco/Trace.hs
+++ b/src/Oscoin/P2P/Disco/Trace.hs
@@ -1,0 +1,22 @@
+module Oscoin.P2P.Disco.Trace
+    ( DiscoEvent (..)
+    )
+where
+
+import           Oscoin.Prelude
+
+import qualified Oscoin.P2P.Disco.MDns as MDns
+
+import           Data.IP (IP)
+import qualified Network.DNS as DNS
+import           Network.Socket (PortNumber)
+
+
+data DiscoEvent =
+      MDnsResponderEvent MDns.ResponderTrace
+    | MDnsResolverEvent  MDns.ResolverTrace
+    | AddrInfoError      IP PortNumber IOException
+    | DNSError           DNS.DNSError
+    | DiscoStartEvent
+    | DiscoCompleteEvent
+    deriving Show

--- a/src/Oscoin/P2P/Handshake/Trace.hs
+++ b/src/Oscoin/P2P/Handshake/Trace.hs
@@ -1,0 +1,14 @@
+module Oscoin.P2P.Handshake.Trace
+    ( HandshakeEvent (..)
+    )
+where
+
+import           Oscoin.Prelude
+
+import qualified Network.Gossip.IO.Peer as Gossip (Peer)
+import           Network.Socket (SockAddr)
+
+data HandshakeEvent n =
+      HandshakeError    SockAddr SomeException
+    | HandshakeComplete (Gossip.Peer n)
+

--- a/src/Oscoin/P2P/Trace.hs
+++ b/src/Oscoin/P2P/Trace.hs
@@ -1,0 +1,21 @@
+module Oscoin.P2P.Trace
+    ( Traceable (..)
+    , P2PEvent (..)
+    )
+where
+
+import           Oscoin.P2P.Disco.Trace (DiscoEvent)
+import           Oscoin.P2P.Handshake.Trace (HandshakeEvent)
+import qualified Oscoin.P2P.Types as Types (ConversionError)
+
+import qualified Network.Gossip.IO.Trace as Gossip
+
+data Traceable n
+    = TraceDisco     DiscoEvent
+    | TraceGossip    (Gossip.Traceable n)
+    | TraceHandshake (HandshakeEvent n)
+    | TraceP2P       P2PEvent
+
+data P2PEvent
+    = ConversionError Types.ConversionError
+    | NodeIsolated

--- a/src/Oscoin/P2P/Types.hs
+++ b/src/Oscoin/P2P/Types.hs
@@ -49,7 +49,6 @@ module Oscoin.P2P.Types
     , Msg(..)
     , MsgId(..)
 
-    , HandshakeEvent(..)
     , ConversionError(..)
 
     -- * Formatters
@@ -63,8 +62,6 @@ import           Oscoin.Crypto.Blockchain.Block (Beneficiary, Block, BlockHash)
 import           Oscoin.Crypto.Hash (Hash, Hashed)
 import           Oscoin.Crypto.PubKey (PublicKey)
 import           Oscoin.Telemetry.Logging as Log
-
-import qualified Network.Gossip.IO.Peer as Gossip (Peer)
 
 import           Codec.Serialise (Serialise)
 import qualified Codec.Serialise as CBOR
@@ -84,7 +81,7 @@ import qualified Data.Vector.Unboxed as V.Unboxed
 import           Formatting as F
 import qualified Generics.SOP as SOP
 import qualified Network.DNS as DNS
-import           Network.Socket (PortNumber, SockAddr)
+import           Network.Socket (PortNumber)
 import qualified Network.Socket as Network
 import           System.Random (RandomGen, randomR)
 
@@ -460,10 +457,6 @@ instance
             (2, 1) -> TxId    <$> CBOR.decode
             (2, _) -> fail "Oscoin.P2P.Types: Unknown tag for `MsgId`"
             (_, _) -> fail "Oscoin.P2P.Types: Invalid listLen for `MsgId`"
-
-data HandshakeEvent n =
-      HandshakeError    SockAddr SomeException
-    | HandshakeComplete (Gossip.Peer n)
 
 data ConversionError =
       DeserialiseFailure CBOR.DeserialiseFailure

--- a/src/Oscoin/Telemetry/Events.hs
+++ b/src/Oscoin/Telemetry/Events.hs
@@ -9,11 +9,9 @@ import           Oscoin.Crypto.Blockchain.Block.Difficulty (Difficulty)
 import qualified Oscoin.Crypto.Blockchain.Eval as Eval
 import           Oscoin.Crypto.Hash (HasHashing, Hash, Hashable, Hashed)
 import           Oscoin.Crypto.PubKey (PublicKey)
-import qualified Oscoin.P2P.Disco as P2P.Disco
-import qualified Oscoin.P2P.Types as P2P
+import qualified Oscoin.P2P.Trace as P2P (Traceable)
+import qualified Oscoin.P2P.Types as P2P (NodeInfo)
 import           Oscoin.Time (Duration)
-
-import qualified Network.Gossip.IO.Trace as Gossip (Traceable)
 
 import           Formatting.Buildable (Buildable)
 import           Network.HTTP.Types as HTTP
@@ -105,17 +103,11 @@ data NotableEvent where
     TxsRemovedFromMempoolEvent :: forall c. Buildable (Hash c)
                                => [Hash c]
                                -> NotableEvent
-    -- | Triggered every time the P2P layer returns a 'ConversionError'.
-    Peer2PeerErrorEvent :: P2P.ConversionError -> NotableEvent
     -- | Triggered every time a new HTTP request is issued to the node's API.
     HttpApiRequest :: HTTP.Request -> HTTP.Status -> Duration -> NotableEvent
-    -- | Events emitted by the @gossip@ library
-    GossipEvent :: forall c. (Hashable c (PublicKey c), Buildable (Hash c))
-                => Gossip.Traceable (P2P.NodeInfo c)
-                -> NotableEvent
-    -- | Events emitted during the p2p handshake phase
-    HandshakeEvent :: forall c. (Hashable c (PublicKey c), Buildable (Hash c))
-                   => P2P.HandshakeEvent (P2P.NodeInfo c)
-                   -> NotableEvent
-    -- | Peer discovery discovery events
-    DiscoEvent :: P2P.Disco.DiscoEvent -> NotableEvent
+
+    -- | Events emitted from the P2P subsystem
+    P2PEvent
+        :: forall c. (Hashable c (PublicKey c), Buildable (Hash c))
+        => P2P.Traceable (P2P.NodeInfo c)
+        -> NotableEvent

--- a/test/Integration/Test/Executable.hs
+++ b/test/Integration/Test/Executable.hs
@@ -94,7 +94,7 @@ testSmoke = do
     ports@Ports { apiPort, ekgPort, metricsPort } <- randomPorts
     withOscoinExe ports $ \stdoutHdl _ -> do
         threadDelay 2000000
-        out <- C8.hGet stdoutHdl 1024
+        out <- C8.hGet stdoutHdl 2048
         expectOutputContains "node starting" out
         expectOutputContains "mined block"   out
 


### PR DESCRIPTION
Also:

* emit `NodeIsolated` event if/when we don't have any peers during continuous disco
* tame the giant NotableEvent pattern match a bit.