### PR TITLE
Configure logging explicitly, instead of relying on `Environment`

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -174,9 +174,15 @@ steps:
       set -euo pipefail
 
       if [[ "$BRANCH_NAME" == "master" ]]; then
-        ./scripts/deploy/gce/node
+        ./scripts/deploy/gce/node \
+            --log-level=Debug \
+            --no-log-colours \
+            --log-layout=NoLayout
       else
-        DRY_RUN=yes ./scripts/deploy/gce/node
+        DRY_RUN=yes ./scripts/deploy/gce/node \
+            --log-level=Debug \
+            --no-log-colours \
+            --log-layout=NoLayout
       fi
 
   - id: "Publish Haddocks"

--- a/exe/node/Main.hs
+++ b/exe/node/Main.hs
@@ -31,6 +31,7 @@ import           Oscoin.Telemetry.Logging (withStdLogger)
 import qualified Oscoin.Telemetry.Logging as Log
 import           Oscoin.Telemetry.Metrics
 import           Oscoin.Telemetry.Middleware (telemetryMiddleware)
+import qualified Oscoin.Telemetry.Options as Telemetry
 
 import           Control.Monad.Managed (managed, runManaged)
 import qualified Data.Set as Set
@@ -60,6 +61,7 @@ main = do
         , optEkgPort
         , optAllowEphemeralKeys
         , optBeneficiary
+        , optTelemetry
         } <-
         execParser $
             info (helper <*> Node.nodeOptionsParser cfgPaths)
@@ -83,7 +85,11 @@ main = do
             [("env", renderEnvironment optEnvironment)]
 
     let consensusConfig = Consensus.configForEnvironment optEnvironment
-    let logConfig       = Log.configForEnvironment optEnvironment
+    let logConfig       =
+            Log.defaultConfig
+                { Log.cfgLevel = Telemetry.optLogSeverity optTelemetry
+                , Log.cfgStyle = Telemetry.optLogStyle optTelemetry
+                }
 
     optDiscovery' <-
         either (die . toS) pure =<< P2P.Disco.evalOptions optDiscovery

--- a/src/Oscoin/Node/Options.hs
+++ b/src/Oscoin/Node/Options.hs
@@ -25,6 +25,7 @@ import qualified Oscoin.Crypto.Hash as Crypto
 import           Oscoin.Crypto.PubKey as Crypto
 import           Oscoin.P2P.Disco (discoOpts, discoParser)
 import qualified Oscoin.P2P.Disco as P2P.Disco
+import qualified Oscoin.Telemetry.Options as Telemetry
 
 import           Data.IP (IP)
 import qualified Data.Text as T
@@ -47,6 +48,7 @@ data Options crypto network = Options
     , optEkgPort            :: Maybe PortNumber
     , optAllowEphemeralKeys :: Bool
     , optBeneficiary        :: Beneficiary crypto
+    , optTelemetry          :: Telemetry.Options
     } deriving (Generic)
 
 deriving instance (Eq (Crypto.PublicKey c),   Eq   (Beneficiary c), Eq   n) => Eq   (Options c n)
@@ -119,6 +121,7 @@ nodeOptionsParser cps = Options
         ( long "beneficiary"
        <> help "Beneficiary account id for block rewards. Hex encoded with leading 0x"
         )
+    <*> Telemetry.telemetryOptionsParser
   where
     readBeneficiary = Crypto.parseShortHash . T.pack
 
@@ -140,7 +143,8 @@ nodeOptionsOpts
         optEkgHost
         optEkgPort
         optAllowEphemeralKeys
-        optBeneficiary) = concat
+        optBeneficiary
+        optTelemetry) = concat
     [ pure . Opt "host"        $ show optHost
     , pure . Opt "gossip-port" $ show optGossipPort
     , pure . Opt "api-port"    $ show optApiPort
@@ -154,6 +158,7 @@ nodeOptionsOpts
     , maybe [] (pure . Opt "ekg-port"     . show) optEkgPort
     , bool  [] [Flag "allow-ephemeral-keys"] optAllowEphemeralKeys
     , pure . Opt "beneficiary"  $ show optBeneficiary
+    , Telemetry.telemetryOptionsOpts optTelemetry
     ]
 
 renderNodeOptionsOpts

--- a/src/Oscoin/Telemetry/Logging.hs
+++ b/src/Oscoin/Telemetry/Logging.hs
@@ -28,9 +28,8 @@ module Oscoin.Telemetry.Logging
     , Config (..)
     , defaultConfig
 
-    , configForEnvironment
-    , styleForEnvironment
-    , severityForEnvironment
+    , StyleFormatter (..)
+    , LayoutFormat (..)
 
     -- * Constructing 'Logger's
     , withStdLogger
@@ -91,8 +90,6 @@ module Oscoin.Telemetry.Logging
 
 import           Oscoin.Prelude hiding (SrcLoc)
 
-import           Oscoin.Configuration (Environment(..))
-
 import           Control.Concurrent (ThreadId)
 import           Control.Exception.Safe (Exception, MonadMask, SomeException)
 import qualified Control.Exception.Safe as Safe
@@ -128,7 +125,7 @@ data Severity =
       Debug -- ^ Things of interest during development, off in a \"production\" setting
     | Info  -- ^ Context around program execution and/or errors
     | Err   -- ^ Errors
-    deriving (Eq, Ord, Enum, Show, Read)
+    deriving (Eq, Ord, Enum, Bounded, Show, Read)
 
 -- | An arbitrary namespace
 --
@@ -158,13 +155,13 @@ data StyleFormatter = StyleFormatter
     { useColours   :: Bool
       -- ^ Whether or not the output must be coloured
     , layoutFormat :: LayoutFormat
-    }
+    } deriving (Eq, Show)
 
-data LayoutFormat = NoLayout
-                  -- ^ Do not use any layout, use unaltered logfmt
-                  | HumanReadable
-                  -- ^ Give the 'msg' tag special treatment, and left-align
-                  -- the severity.
+data LayoutFormat =
+      NoLayout      -- ^ Do not use any layout, use unaltered logfmt
+    | HumanReadable -- ^ Give the 'msg' tag special treatment, and left-align
+                    -- the severity.
+    deriving (Eq, Ord, Enum, Bounded, Show, Read)
 
 -- | The logging environment
 data Logger = Logger
@@ -200,25 +197,6 @@ defaultStyle :: StyleFormatter
 defaultStyle = StyleFormatter
     { useColours   = False
     , layoutFormat = NoLayout
-    }
-
--- | The conventional 'StyleFormatter' for an 'Environment'.
-styleForEnvironment :: Environment -> StyleFormatter
-styleForEnvironment = \case
-    Production  -> StyleFormatter False NoLayout
-    Development -> StyleFormatter True HumanReadable
-
--- | The conventional 'Severity' for an 'Environment'.
-severityForEnvironment :: Environment -> Severity
-severityForEnvironment = \case
-    Production  -> Info
-    Development -> Debug
-
--- | The conventional 'Config' for an 'Environment'.
-configForEnvironment :: Environment -> Config
-configForEnvironment env = defaultConfig
-    { cfgLevel = severityForEnvironment env
-    , cfgStyle = styleForEnvironment env
     }
 
 -- | Default 'Config'

--- a/src/Oscoin/Telemetry/Options.hs
+++ b/src/Oscoin/Telemetry/Options.hs
@@ -1,0 +1,63 @@
+module Oscoin.Telemetry.Options
+    ( Options(..)
+
+    , telemetryOptionsParser
+    , telemetryOptionsOpts
+    , renderTelemetryOptionsOpts
+    )
+where
+
+import           Oscoin.Prelude hiding (option)
+
+import qualified Oscoin.Telemetry.Logging as Log
+
+import qualified Formatting as F
+import           Options.Applicative
+import           System.Console.Option
+
+data Options = Options
+    { optLogSeverity :: Log.Severity
+    , optLogStyle    :: Log.StyleFormatter
+    } deriving (Eq, Show)
+
+telemetryOptionsParser :: Parser Options
+telemetryOptionsParser = Options
+    <$> option auto
+        ( long    "log-level"
+       <> help    "Set the logging verbosity"
+       <> metavar (enumBounded (Proxy @Log.Severity))
+       <> value   Log.Debug
+       <> showDefault
+        )
+    <*> styleParser
+  where
+    styleParser = Log.StyleFormatter
+        <$> switch
+            ( long    "no-log-colours"
+           <> help    "Turn off terminal colors for log output"
+            )
+        <*> option auto
+            ( long    "log-layout"
+           <> help    "Control if and how to layout log messages"
+           <> metavar (enumBounded (Proxy @Log.LayoutFormat))
+           <> value   Log.HumanReadable
+           <> showDefault
+            )
+
+    enumBounded
+        :: forall proxy a. (Show a, Enum a, Bounded a)
+        => proxy a
+        -> String
+    enumBounded _ = intercalate "|" $ map (show @a) [minBound..maxBound]
+
+telemetryOptionsOpts :: Options -> [Opt Text]
+telemetryOptionsOpts
+    (Options
+        optLogSeverity
+        (Log.StyleFormatter useColours layoutFormat)) =
+      Opt "log-level"  (show optLogSeverity)
+    : Opt "log-layout" (show layoutFormat)
+    : bool [] [Flag "no-log-colours"] useColours
+
+renderTelemetryOptionsOpts :: Options -> [Text]
+renderTelemetryOptionsOpts = map (F.sformat F.build) . telemetryOptionsOpts

--- a/test/Test/Oscoin/Node/Options/Gen.hs
+++ b/test/Test/Oscoin/Node/Options/Gen.hs
@@ -13,6 +13,7 @@ import qualified Test.Oscoin.Configuration.Gen as Config.Gen
 import qualified Test.Oscoin.Crypto.Hash.Gen as Hash.Gen
 import qualified Test.Oscoin.P2P.Disco.Options.Gen as Disco.Gen
 import qualified Test.Oscoin.P2P.Gen as P2P.Gen
+import qualified Test.Oscoin.Telemetry.Gen as Telemetry.Gen
 
 import           Hedgehog
 import qualified Hedgehog.Gen as Gen
@@ -36,3 +37,4 @@ genNodeOptions = Options
     <*> Gen.maybe P2P.Gen.genPortNumber
     <*> Gen.bool
     <*> Hash.Gen.genShortHash
+    <*> Telemetry.Gen.genTelemetryOptions

--- a/test/Test/Oscoin/Telemetry/Gen.hs
+++ b/test/Test/Oscoin/Telemetry/Gen.hs
@@ -1,0 +1,14 @@
+module Test.Oscoin.Telemetry.Gen (genTelemetryOptions) where
+
+import           Oscoin.Prelude
+
+import           Oscoin.Telemetry.Logging (StyleFormatter(..))
+import           Oscoin.Telemetry.Options
+
+import           Hedgehog
+import qualified Hedgehog.Gen as Gen
+
+genTelemetryOptions :: MonadGen m => m Options
+genTelemetryOptions = Options
+    <$> Gen.enumBounded
+    <*> (StyleFormatter <$> Gen.bool <*> Gen.enumBounded)


### PR DESCRIPTION
Deploy using debug logging and no layout + colour.


I left the defaults at colourful logging for convenience, at the expense of CLI options and logger defaults no differing.