### PR TITLE
Better suited genesis block constructors for tests

### DIFF
--- a/src/Oscoin/Crypto/Blockchain/Block.hs
+++ b/src/Oscoin/Crypto/Blockchain/Block.hs
@@ -27,8 +27,6 @@ module Oscoin.Crypto.Blockchain.Block
     , blockData
     , blockTxs
     , blockBeneficiary
-    , emptyGenesisBlock
-    , emptyGenesisFromState
     , isGenesisBlock
     , headerHash
     , parentHash
@@ -299,29 +297,6 @@ mkBlockData benef txs =
         , blockDataTxs         = Seq.fromList (toList txs)
         }
 
-emptyGenesisBlock
-    :: (HasBlockHeader c Unsealed)
-    => Timestamp
-    -> Beneficiary c
-    -> Block c tx Unsealed
-emptyGenesisBlock blockTimestamp benef =
-    mkBlock header benef []
-  where
-    header = emptyHeader { blockTimestamp }
-
-emptyGenesisFromState
-    :: ( HasBlockHeader c Unsealed
-       , Crypto.Hashable c st
-       )
-    => Timestamp
-    -> Beneficiary c
-    -> st
-    -> Block c tx Unsealed
-emptyGenesisFromState blockTimestamp benef st =
-    mkBlock header benef []
-  where
-    header = emptyHeader { blockTimestamp, blockStateHash = stHash }
-    stHash = Crypto.fromHashed . Crypto.hash $ st
 
 isGenesisBlock
     :: (Crypto.HasHashing c)

--- a/test/Integration/Test/Executable.hs
+++ b/test/Integration/Test/Executable.hs
@@ -8,8 +8,8 @@ import           Oscoin.Crypto (Crypto)
 import           Oscoin.Crypto.Blockchain.Block (Beneficiary)
 import           Oscoin.Crypto.PubKey.RealWorld ()
 
-import           Oscoin.Test.Crypto.Blockchain.Block.Helpers
-                 (defaultBeneficiary)
+import           Oscoin.Test.Crypto.Blockchain.Block.Generators
+                 (someBeneficiary)
 import           Oscoin.Test.Crypto.PubKey.Arbitrary ()
 
 import qualified Data.ByteString.Char8 as C8
@@ -52,7 +52,7 @@ randomPorts = Ports
 withOscoinExe :: Ports -> (Handle -> Handle -> Assertion) -> Assertion
 withOscoinExe Ports{..} f = do
     randomNetwork <- take 63 . randomRs ('a', 'z') <$> getStdGen
-    let beneficiary :: Beneficiary Crypto = defaultBeneficiary
+    let beneficiary :: Beneficiary Crypto = someBeneficiary
 
     -- Generates a temporary directory where to store some ephemeral keys, which
     -- are needed for the test to pass on CI.

--- a/test/Oscoin/Test/Consensus/Nakamoto.hs
+++ b/test/Oscoin/Test/Consensus/Nakamoto.hs
@@ -19,12 +19,10 @@ import qualified Oscoin.Storage.Block.Pure as BlockStore.Pure
 import           Oscoin.Storage.HashStore
 import qualified Oscoin.Storage.Ledger as Ledger
 import           Oscoin.Storage.Receipt
-import           Oscoin.Time
 
 import           Oscoin.Test.Consensus.Network
 import           Oscoin.Test.Crypto
-import           Oscoin.Test.Crypto.Blockchain.Block.Helpers
-                 (defaultBeneficiary)
+import           Oscoin.Test.Crypto.Blockchain.Block.Generators
 import           Test.Oscoin.DummyLedger
 
 import           Codec.Serialise (Serialise)
@@ -88,7 +86,7 @@ instance (IsCrypto c) => TestableNode c PoW (NakamotoNode c) (NakamotoNodeState 
         let stateStore = mkStateHashStore nakStateStoreL
         let receiptStore = mkStateReceiptStore nakReceiptStoreL
         let ledger = Ledger.mkLedger (fst blockStore) stateStore dummyEvalBlock receiptStore
-        maybeBlock <- mineBlock ledger nakConsensus tn defaultBeneficiary
+        maybeBlock <- mineBlock ledger nakConsensus tn someBeneficiary
         -- NOTE (adn): We are bypassing the protocol at the moment, but we
         -- probably shouldn't.
         forM maybeBlock $ \blk -> do
@@ -125,7 +123,7 @@ initNakamoto nid = NakamotoNodeState
     , nakReceiptStore = Map.empty
     }
   where
-    genBlk   = sealBlock emptyPoW $ emptyGenesisFromState epoch defaultBeneficiary genesisState
+    genBlk = someGenesisBlock' emptyPoW $ Crypto.fromHashed $ Crypto.hash genesisState
     genesisState = mempty :: DummyState
 
 

--- a/test/Oscoin/Test/Crypto/Blockchain/Block/Helpers.hs
+++ b/test/Oscoin/Test/Crypto/Blockchain/Block/Helpers.hs
@@ -1,8 +1,0 @@
-module Oscoin.Test.Crypto.Blockchain.Block.Helpers where
-
-import           Oscoin.Crypto.Blockchain.Block (Beneficiary)
-import           Oscoin.Crypto.Hash (HasHashing, zeroShortHash)
-
--- | The default beneficiary.
-defaultBeneficiary :: HasHashing c => Beneficiary c
-defaultBeneficiary = zeroShortHash

--- a/test/Oscoin/Test/Crypto/Blockchain/Generators.hs
+++ b/test/Oscoin/Test/Crypto/Blockchain/Generators.hs
@@ -1,7 +1,7 @@
 module Oscoin.Test.Crypto.Blockchain.Generators
     ( ForkParams(..)
 
-    , defaultBeneficiary
+    , someBeneficiary
 
       -- * Generating generic chains
     , genBlockchain
@@ -26,9 +26,9 @@ import qualified Oscoin.Time.Chrono as Chrono
 import           Oscoin.Test.Crypto
 import           Oscoin.Test.Crypto.Blockchain.Block.Arbitrary ()
 import           Oscoin.Test.Crypto.Blockchain.Block.Generators
-import           Oscoin.Test.Crypto.Blockchain.Block.Helpers
-                 (defaultBeneficiary)
+import           Test.Oscoin.Crypto.Hash.Gen
 import           Test.QuickCheck
+import           Test.QuickCheck.Hedgehog
 
 -- | Generates a 'Blockchain' starting with the provided genesis block.
 --
@@ -80,9 +80,8 @@ genBlockchain
        )
     => Gen (Blockchain c tx s)
 genBlockchain = do
-    ts <- arbitrary
     seal <- arbitrary
-    genBlockchainFrom (sealBlock seal (emptyGenesisBlock ts defaultBeneficiary))
+    genBlockchainFrom $ someGenesisBlock seal
 
 
 data ForkParams = ForkParams
@@ -216,7 +215,8 @@ genNakamotoBlockchain
 genNakamotoBlockchain = do
     blockTimestamp <- arbitrary
     genesisSeal <- genPoWSeal
-    let blockData@BlockData{..} = mkBlockData defaultBeneficiary ([] @tx)
+    beneficiary <- hedgehog genShortHash
+    let blockData@BlockData{..} = mkBlockData beneficiary ([] @tx)
     let genHeader = emptyHeader
             { blockSeal = genesisSeal
             , blockTimestamp

--- a/test/Oscoin/Test/Storage/Block/SQLite.hs
+++ b/test/Oscoin/Test/Storage/Block/SQLite.hs
@@ -13,11 +13,9 @@ import           Oscoin.Data.OscoinTx
 import qualified Oscoin.Storage.Block.Abstract as Abstract
 import           Oscoin.Storage.Block.SQLite as Sqlite
 import           Oscoin.Storage.Block.SQLite.Internal as Sqlite
-import qualified Oscoin.Time as Time
 
 import           Oscoin.Test.Crypto
-import           Oscoin.Test.Crypto.Blockchain.Block.Helpers
-                 (defaultBeneficiary)
+import           Oscoin.Test.Crypto.Blockchain.Block.Generators
 import           Oscoin.Test.Data.Tx.Arbitrary ()
 
 import           Test.QuickCheck
@@ -27,8 +25,7 @@ type DummySeal = Text
 
 -- | Generates a genesis block with a slightly more realistic 'Difficulty'.
 defaultGenesis :: IsCrypto c => Block c tx (Sealed c DummySeal)
-defaultGenesis =
-    sealBlock mempty (emptyGenesisBlock Time.epoch defaultBeneficiary)
+defaultGenesis = someGenesisBlock ""
 
 {------------------------------------------------------------------------------
   Useful combinators & helpers

--- a/test/Test/Oscoin/Crypto/Blockchain/Eval.hs
+++ b/test/Test/Oscoin/Crypto/Blockchain/Eval.hs
@@ -13,8 +13,7 @@ import           Codec.Serialise
 
 import           Oscoin.Test.Crypto
 import           Oscoin.Test.Crypto.Blockchain.Block.Arbitrary ()
-import           Oscoin.Test.Crypto.Blockchain.Block.Helpers
-                 (defaultBeneficiary)
+import           Oscoin.Test.Crypto.Blockchain.Block.Generators
 import           Test.QuickCheck (Arbitrary)
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
@@ -79,4 +78,4 @@ buildTestBlock
     -> [Tx]
     -> (Block c Tx Unsealed, St, [Receipt c Tx Output])
 buildTestBlock Dict st txs =
-    buildBlock blockEval epoch defaultBeneficiary st txs (emptyGenesisBlock epoch defaultBeneficiary)
+    buildBlock blockEval epoch someBeneficiary st txs (someGenesisBlock ())

--- a/test/Test/Oscoin/Protocol/Sync.hs
+++ b/test/Test/Oscoin/Protocol/Sync.hs
@@ -14,13 +14,7 @@ import qualified Oscoin.Consensus.Nakamoto as Nakamoto
 import           Oscoin.Crypto.Blockchain
                  (Blockchain, blocks, tip, unsafeToBlockchain, (|>))
 import           Oscoin.Crypto.Blockchain.Block
-                 ( Block
-                 , Sealed
-                 , blockHash
-                 , blockHeader
-                 , emptyGenesisBlock
-                 , sealBlock
-                 )
+                 (Block, Sealed, blockHash, blockHeader)
 import           Oscoin.Data.OscoinTx
 import           Oscoin.P2P
                  ( Addr(..)
@@ -39,7 +33,6 @@ import           Oscoin.Telemetry as Telemetry
 import           Oscoin.Telemetry.Logging (noLogger)
 import           Oscoin.Telemetry.Metrics (labelsFromList, newMetricsStore)
 import           Oscoin.Telemetry.Trace (noProbe)
-import qualified Oscoin.Time as Time
 import           Oscoin.Time.Chrono as Chrono
 
 import           Codec.Serialise
@@ -61,9 +54,7 @@ import           Hedgehog.Internal.Property (forAllT)
 import qualified Oscoin.Storage.Block.SQLite as SQLite
 import qualified Oscoin.Storage.Block.STM as STM
 import           Oscoin.Test.Consensus.Nakamoto.Arbitrary ()
-import           Oscoin.Test.Crypto.Blockchain.Block.Generators (genBlockFrom)
-import           Oscoin.Test.Crypto.Blockchain.Block.Helpers
-                 (defaultBeneficiary)
+import           Oscoin.Test.Crypto.Blockchain.Block.Generators
 import           Oscoin.Test.Crypto.Blockchain.Generators (genBlockchainFrom)
 import           Oscoin.Test.Crypto.PubKey.Arbitrary (arbitraryKeyPair)
 import           Oscoin.Test.HTTP.Helpers (nodeState, withNode)
@@ -429,8 +420,7 @@ defaultGenesis
     => Dict (IsCrypto c)
     -> s
     -> Block c tx (Sealed c s)
-defaultGenesis Dict emptySeal =
-    sealBlock emptySeal (emptyGenesisBlock Time.epoch defaultBeneficiary)
+defaultGenesis Dict seal = someGenesisBlock seal
 
 nakamotoGenesis :: Dict (IsCrypto c) -> Block c tx (Sealed c Nakamoto.PoW)
 nakamotoGenesis d = defaultGenesis d Nakamoto.emptyPoW

--- a/test/Test/Oscoin/Storage/Block/Orphanage.hs
+++ b/test/Test/Oscoin/Storage/Block/Orphanage.hs
@@ -12,13 +12,10 @@ import           Oscoin.Consensus.Nakamoto (blockScore)
 import           Oscoin.Crypto.Blockchain
 import qualified Oscoin.Crypto.Blockchain as Blockchain
 import           Oscoin.Storage.Block.Orphanage
-import qualified Oscoin.Time as Time
 import           Oscoin.Time.Chrono (OldestFirst(..), reverse, toNewestFirst)
 
 import           Oscoin.Test.Crypto
 import           Oscoin.Test.Crypto.Blockchain.Block.Generators
-import           Oscoin.Test.Crypto.Blockchain.Block.Helpers
-                 (defaultBeneficiary)
 import           Oscoin.Test.Crypto.Blockchain.Generators
 import           Oscoin.Test.Util (Condensed(..), condensedS)
 
@@ -294,7 +291,7 @@ insertOrphans xs o =
     foldl' (flip insertOrphan) o xs
 
 defaultGenesis :: IsCrypto c => Block c () (Sealed c ())
-defaultGenesis = sealBlock mempty (emptyGenesisBlock Time.epoch defaultBeneficiary)
+defaultGenesis = someGenesisBlock ()
 
 totalScore :: Blockchain c tx s -> Score
 totalScore = sum . map blockScore . toNewestFirst . blocks


### PR DESCRIPTION
We introduce `someSealedGenesisBlock` and `someSealedGenesisBlock'` in `Oscoin.Test.Crypto.Blockchain.Block.Generators` which allow us to simplify test code that relies on some fixed genesis block

As a result we can eliminate the block constructors `emptyGenesisBlock` and `emptyGenesisFromState` from `Oscoin.Crypto.Blockchain.Block`.

As part of the change we also merge `defaultBeneficiary` into the `Block.Generators` module and delete `Oscoin.Test.Crypto.Blockchain.Block.Helpers`