### PR TITLE
Reusable keypair file storage

### DIFF
--- a/exe/node/Main.hs
+++ b/exe/node/Main.hs
@@ -3,7 +3,6 @@ module Main (main) where
 import           Oscoin.Prelude hiding (option)
 
 import qualified Oscoin.API.HTTP as HTTP
-import           Oscoin.CLI.KeyStore (KeyStoreError(..), readKeyPair)
 import           Oscoin.Configuration
 import qualified Oscoin.Consensus as Consensus
 import qualified Oscoin.Consensus.Config as Consensus
@@ -11,6 +10,7 @@ import qualified Oscoin.Consensus.Nakamoto as Nakamoto
 import           Oscoin.Crypto (Crypto)
 import           Oscoin.Crypto.Blockchain.Genesis (buildGenesisBlock)
 import qualified Oscoin.Crypto.PubKey as Crypto
+import qualified Oscoin.Crypto.PubKey.FileStore as Crypto
 import           Oscoin.Data.Tx
 import           Oscoin.Node (runNodeT, withNode)
 import qualified Oscoin.Node as Node
@@ -39,6 +39,7 @@ import qualified Data.Yaml as Yaml
 import           Network.HTTP.Types.Status (notFound404)
 import qualified Network.Wai as Wai
 import qualified Network.Wai.Handler.Warp as Warp
+import           System.FilePath
 
 import           Options.Applicative
 
@@ -65,10 +66,9 @@ main = do
                  (progDesc "Oscoin Node")
 
     keys <-
-        flip runReaderT (Just $ keysDir optPaths) $
-            catches readKeyPair
+            catches (Crypto.readKeyPair $ keysDir optPaths </> "id")
                 [ Handler $ \case
-                    KeyNotFound{}
+                    Crypto.KeyNotFound{}
                       | optAllowEphemeralKeys -> liftIO Crypto.generateKeyPair
                     e                         -> throwM e
                 ]

--- a/package.yaml
+++ b/package.yaml
@@ -104,6 +104,7 @@ executables:
     dependencies:
       - async
       - containers
+      - filepath
       - http-types
       - managed
       - optparse-applicative

--- a/src/Oscoin/CLI/KeyStore.hs
+++ b/src/Oscoin/CLI/KeyStore.hs
@@ -5,25 +5,17 @@
 -- deterimine the directory to store keys in.
 module Oscoin.CLI.KeyStore
     ( MonadKeyStore(..)
-    , KeyStoreError(..)
     ) where
 
 import           Oscoin.Crypto
 import           Oscoin.Prelude
-import qualified Prelude
 
 import qualified Oscoin.Crypto.Hash as Crypto
 import qualified Oscoin.Crypto.PubKey as Crypto
-import qualified Oscoin.Crypto.PubKey.RealWorld as Crypto.RealWorld
+import qualified Oscoin.Crypto.PubKey.FileStore as Crypto
 
-import           Codec.Serialise
-                 (DeserialiseFailure, deserialiseOrFail, serialise)
-import           Control.Monad.Except (liftEither)
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as LBS
 import           System.Directory
 import           System.FilePath
-import           System.IO.Error (isDoesNotExistError)
 
 
 class (Crypto.HasHashing c, Monad m) => MonadKeyStore c m | m -> c where
@@ -55,67 +47,17 @@ getConfigPath :: MonadIO m => Maybe FilePath -> m FilePath
 getConfigPath Nothing         = liftIO . getXdgDirectory XdgConfig $ "oscoin"
 getConfigPath (Just userPath) = pure userPath
 
-getSecretKeyPath :: Maybe FilePath -> IO FilePath
-getSecretKeyPath mbFilePath = flip (</>) "id.key" <$> getConfigPath mbFilePath
-
-getPublicKeyPath :: Maybe FilePath -> IO FilePath
-getPublicKeyPath mbFilePath = flip (</>) "id.pub" <$> getConfigPath mbFilePath
-
-ensureConfigDir :: MonadIO m => Maybe FilePath -> m ()
-ensureConfigDir mbUserPath = do
-    configDir <- getConfigPath mbUserPath
-    liftIO $ createDirectoryIfMissing True configDir
-
-data KeyStoreError =
-    -- | Key file at specified path doesn't exist.
-      KeyNotFound FilePath
-    -- | A key couldn't be deserialised correctly. The first
-    -- argument is the path to the key on disk.
-    | KeyDeserialisationFailure FilePath DeserialiseFailure
-
-instance Show KeyStoreError where
-    show = \case
-        KeyNotFound configPath ->
-            "Key file doesn't exist: " <> configPath
-
-        KeyDeserialisationFailure configPath cborError ->
-            mconcat [ "Loading the key from "
-                    , configPath
-                    , " failed. The reason was: "
-                    , show cborError
-                    ]
-
-instance Exception KeyStoreError
-
 instance MonadKeyStore Crypto (ReaderT (Maybe FilePath) IO) where
     keysPath = ask
-    writeKeyPair (pk, sk) =  do
+    writeKeyPair keyPair =  do
         mbUserPath <- keysPath
-        ensureConfigDir mbUserPath
-        liftIO $ do
-            skPath <- getSecretKeyPath mbUserPath
-            LBS.writeFile skPath $ Crypto.RealWorld.serialisePrivateKey sk
-            pkPath <- getPublicKeyPath mbUserPath
-            LBS.writeFile pkPath $ serialise pk
+        keyDir <- getConfigPath mbUserPath
+        liftIO $ createDirectoryIfMissing True keyDir
+        let keyPrefix = keyDir </> "id"
+        Crypto.writeKeyPair keyPrefix keyPair
 
     readKeyPair = do
         mbUserPath <- keysPath
-        liftIO $ do
-            skPath <- getSecretKeyPath mbUserPath
-            pkPath <- getPublicKeyPath mbUserPath
-            keys   <-
-                runExceptT $ liftA2 (,)
-                    (readFileLbs pkPath >>=
-                        liftEither
-                            . first (KeyDeserialisationFailure pkPath)
-                            . deserialiseOrFail)
-                    (readFileLbs skPath >>=
-                        liftEither
-                            . first (KeyDeserialisationFailure skPath)
-                            . Crypto.RealWorld.deserialisePrivateKey)
-            either throwM pure keys
-      where
-        readFileLbs path = ExceptT $
-            map (first . const $ KeyNotFound path)
-                . tryJust (guard . isDoesNotExistError)
-                $ LBS.fromStrict <$> BS.readFile path
+        keyDir <- getConfigPath mbUserPath
+        let keyPrefix = keyDir </> "id"
+        Crypto.readKeyPair keyPrefix

--- a/src/Oscoin/Crypto/PubKey.hs
+++ b/src/Oscoin/Crypto/PubKey.hs
@@ -43,7 +43,10 @@ deriving instance (Ord (Signature c), Ord msg) => Ord (Signed c msg)
  Digital signatures - signing and verifying things
 ------------------------------------------------------------------------------}
 
-class (Eq (Signature c), Eq (PublicKey c)) => HasDigitalSignature c where
+class ( Eq (Signature c)
+      , Eq (PublicKey c)
+      , Eq (PrivateKey c)
+      ) => HasDigitalSignature c where
     data family PublicKey c :: *
     data family PrivateKey c :: *
     data family Signature c :: *

--- a/src/Oscoin/Crypto/PubKey/FileStore.hs
+++ b/src/Oscoin/Crypto/PubKey/FileStore.hs
@@ -1,0 +1,88 @@
+-- | This module provides the 'writeKeyPair' and 'readKeyPair'
+-- functions to read and write real world 'Crypto' keypairs to disk.
+module Oscoin.Crypto.PubKey.FileStore
+    ( writeKeyPair
+    , readKeyPair
+    , ReadKeyError(..)
+    ) where
+
+import           Oscoin.Prelude
+
+import           Oscoin.Crypto (Crypto)
+import qualified Oscoin.Crypto.PubKey as Crypto
+import qualified Oscoin.Crypto.PubKey.RealWorld as Crypto.RealWorld
+
+import           Codec.Serialise
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import           System.Directory
+import           System.FilePath
+import           System.IO.Error (isDoesNotExistError)
+
+
+-- | Read a keypair from disk. See 'writeKeyPair' about how the path
+-- parameter determines the key location. May raise 'ReadKeyError'.
+readKeyPair :: (MonadIO m) => FilePath -> m (Crypto.KeyPair Crypto)
+readKeyPair keysPathPrefix = liftIO $ do
+    let (pkPath, skPath) = keyPaths keysPathPrefix
+    pk <- readKeyFile deserialiseOrFail pkPath
+    sk <- readKeyFile Crypto.RealWorld.deserialisePrivateKey skPath
+    pure (pk ,sk)
+  where
+    readKeyFile customDeserialiseOrFail path = do
+        contents <- readFileLbs path
+        case customDeserialiseOrFail contents of
+            Left err  -> throw $ KeyDeserialisationFailure path err
+            Right key -> pure key
+    readFileLbs path = do
+        contentsE <- tryJust (guard . isDoesNotExistError) $ BS.readFile path
+        case contentsE of
+            Left _         -> throw $ KeyNotFound path
+            Right contents -> pure $ LBS.fromStrict contents
+
+
+data ReadKeyError =
+    -- | Key file at specified path doesn't exist.
+      KeyNotFound FilePath
+    -- | A key couldn't be deserialised correctly. The first
+    -- argument is the path to the key on disk.
+    | KeyDeserialisationFailure FilePath DeserialiseFailure
+    deriving (Eq, Show)
+
+instance Exception ReadKeyError where
+    displayException = \case
+        KeyNotFound configPath ->
+            "Key file doesn't exist: " <> configPath
+
+        KeyDeserialisationFailure configPath cborError ->
+            mconcat [ "Loading the key from "
+                    , configPath
+                    , " failed. The reason was: "
+                    , show cborError
+                    ]
+
+
+-- | Write a keypair to disk at the given location. The public key path
+-- is obtained by appending @".pub"@ to the given path and the private
+-- key path is obtained by appending @".id"@.
+writeKeyPair :: (MonadIO m) => FilePath -> Crypto.KeyPair Crypto -> m ()
+writeKeyPair keysPathPrefix (pk, sk) = liftIO $ do
+    let keyDir = takeDirectory keysPathPrefix
+    let (pkPath, skPath) = keyPaths keysPathPrefix
+    createDirectoryIfMissing True keyDir
+    LBS.writeFile pkPath $ serialise pk
+    LBS.writeFile skPath $ Crypto.RealWorld.serialisePrivateKey sk
+
+-- Internal -------------------------------------------------------
+
+-- | Given a key path prefix returns the paths of the public key and
+-- private key.
+--
+-- >>> keyPaths "foo/bar"
+-- ("foo/bar.pub", "foo/bar.key")
+--
+keyPaths :: FilePath -> (FilePath, FilePath)
+keyPaths keysPathPrefix =
+    ( keysPathPrefix <> ".pub"
+    , keysPathPrefix <> ".key"
+    )

--- a/src/Oscoin/Crypto/PubKey/Internal.hs
+++ b/src/Oscoin/Crypto/PubKey/Internal.hs
@@ -29,3 +29,4 @@ deriving instance Generic (PK c k)
 -- implementing the 'HasDigitalSignature' instance in 'PubKey.RealWorld'.
 -- Use the abstract PublicKey/PrivateKey instead.
 newtype SK k = SK k
+    deriving (Eq)

--- a/src/Oscoin/Crypto/PubKey/Mock.hs
+++ b/src/Oscoin/Crypto/PubKey/Mock.hs
@@ -30,6 +30,7 @@ instance HasDigitalSignature MockCrypto where
     newtype PublicKey MockCrypto =
         MockPK (PK MockCrypto MockKey) deriving (Eq, Ord)
     newtype PrivateKey MockCrypto = MockSK (SK (MockKey, [Word8]))
+        deriving (Eq)
 
     newtype Signature MockCrypto =
         MockSignature [Word8] deriving (Eq, Show, Ord)

--- a/src/Oscoin/Crypto/PubKey/RealWorld.hs
+++ b/src/Oscoin/Crypto/PubKey/RealWorld.hs
@@ -32,7 +32,7 @@ instance HasDigitalSignature Crypto where
     newtype PublicKey Crypto =
         PublicKey (PK Crypto Ed25519.PublicKey) deriving (Show, Eq, Ord)
 
-    data PrivateKey Crypto = PrivateKey (SK Ed25519.SecretKey)
+    data PrivateKey Crypto = PrivateKey (SK Ed25519.SecretKey) deriving (Eq)
 
     data Signature Crypto =
         Signature Ed25519.Signature deriving Show

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -24,6 +24,7 @@ import qualified Test.Oscoin.Crypto.Blockchain.GeneratorsTest
 import qualified Test.Oscoin.Crypto.Blockchain.Genesis
 import qualified Test.Oscoin.Crypto.Hash
 import qualified Test.Oscoin.Crypto.PubKey
+import qualified Test.Oscoin.Crypto.PubKey.FileStore
 import qualified Test.Oscoin.Data.OscoinTx
 import qualified Test.Oscoin.Node.Mempool
 import qualified Test.Oscoin.Node.Options
@@ -95,6 +96,7 @@ main = do
                     , Test.Oscoin.Configuration.tests
                     , Test.Oscoin.Crypto.Blockchain.Eval.tests crypto
                     , Test.Oscoin.Crypto.Blockchain.GeneratorsTest.tests crypto
+                    , Test.Oscoin.Crypto.PubKey.FileStore.tests
                     , Test.Oscoin.Data.OscoinTx.tests crypto
                     , Test.Oscoin.Node.Mempool.tests crypto
                     , Test.Oscoin.Node.Options.tests crypto

--- a/test/Test/Oscoin/Crypto/PubKey/FileStore.hs
+++ b/test/Test/Oscoin/Crypto/PubKey/FileStore.hs
@@ -1,0 +1,40 @@
+module Test.Oscoin.Crypto.PubKey.FileStore
+    ( tests
+    ) where
+
+import           Oscoin.Prelude
+
+import           Oscoin.Crypto.PubKey.FileStore
+import           Test.Oscoin.Crypto.PubKey.Gen
+
+import           System.FilePath
+import           System.IO.Temp
+
+import           Hedgehog
+import           Test.Tasty
+import           Test.Tasty.Hedgehog
+
+tests :: TestTree
+tests = testGroup "Test.Oscoin.Crypto.PubKey.FileStore"
+    [ testProperty "prop_writeReadTripping" $ prop_writeReadTripping
+    , testProperty "prop_keyNotFoundError" $ prop_keyNotFoundError
+    ]
+
+prop_writeReadTripping :: Property
+prop_writeReadTripping = property $ do
+    kp <- forAllWith (const "<keypair>") genKeyPair
+    kp' <- liftIO $ withSystemTempDirectory "oscoin-test" $ \tmpdir -> do
+        let keyPrefix = tmpdir </> "id"
+        writeKeyPair keyPrefix kp
+        readKeyPair keyPrefix
+    -- We don't use '(===)' because private keys don't have a 'Show'
+    -- instance.
+    assert $ kp == kp'
+
+prop_keyNotFoundError :: Property
+prop_keyNotFoundError = property $ do
+    (result, keyPrefix) <- liftIO $ withSystemTempDirectory "oscoin-test" $ \tmpdir -> do
+        let keyPrefix = tmpdir </> "id"
+        result <- try $ readKeyPair keyPrefix
+        pure (result, keyPrefix)
+    void result === Left (KeyNotFound $ keyPrefix <> ".pub")


### PR DESCRIPTION
We extract the functionality to read and write key paris to disk from `Oscoin.CLI.KeyStore` into `Oscoin.Crypto.PubKey.FileStore`. This makes this functionality easier to use since we are providing just functions instead of an MTL-style type class.

This is a necessary step towards having separate key management for the node keys and the account keys (#578).