### PR TITLE
Remove errors from block evaluator

### DIFF
--- a/src/Oscoin/API/Types.hs
+++ b/src/Oscoin/API/Types.hs
@@ -9,7 +9,6 @@ module Oscoin.API.Types
     ) where
 
 import           Oscoin.Crypto.Blockchain.Block (BlockHash)
-import           Oscoin.Crypto.Blockchain.Eval (EvalError)
 import           Oscoin.Crypto.Hash (HasHashing, Hash, Hashed)
 import           Oscoin.Data.Tx.Abstract
 import           Oscoin.Prelude
@@ -41,7 +40,7 @@ data TxLookupResponse c tx = TxLookupResponse
     -- ^ Hash of the transaction.
     , txBlockHash     :: Maybe (BlockHash c)
     -- ^ @BlockHash@ of the 'Block' in which the transaction was included.
-    , txOutput        :: Maybe (Either EvalError (TxOutput c tx))
+    , txOutput        :: Maybe (TxOutput c tx)
     -- ^ Output of the transaction if it was evaluated. If the
     -- evaluation was successful the transaction is included in the
     -- block 'txBlockHash'.

--- a/src/Oscoin/Telemetry.hs
+++ b/src/Oscoin/Telemetry.hs
@@ -42,7 +42,6 @@ import qualified Network.Gossip.Plumtree as Gossip.EBT
 
 import qualified Oscoin.Consensus.Types as Consensus
 import           Oscoin.Crypto.Blockchain.Block (prettyDifficulty)
-import qualified Oscoin.Crypto.Blockchain.Eval as Eval
 import           Oscoin.Crypto.Hash (formatHash, formatHashed)
 import qualified Oscoin.Crypto.Hash as Crypto
 import           Oscoin.Crypto.PubKey (PublicKey)
@@ -123,11 +122,6 @@ emit Handle{..} evt = withLogger $ GHC.withFrozenCallStack $ do
                          (fmtBlockHash % " " % fmtValidationError)
                          blockHash
                          validationError
-        BlockEvaluationFailedEvent blockHash evalError ->
-            Log.errM "block failed evaluation"
-                     (fmtBlockHash % " " % ferror Eval.fromEvalError)
-                     blockHash
-                     evalError
         DifficultyAdjustedEvent newDifficulty previousDifficulty ->
             let fmt = ftag "new" % stext % " "
                     % ftag "old" % stext % " "
@@ -464,9 +458,6 @@ toActions = \case
     BlockValidationFailedEvent _ validationError -> [
         CounterIncrease "oscoin.blocks_failed_validation.total" $
             validationErrorToLabels validationError
-     ]
-    BlockEvaluationFailedEvent _ _evalError -> [
-        CounterIncrease "oscoin.blocks_failed_evaluation.total" noLabels
      ]
     -- NOTE(adn) If we find it useful, we could include also separate counters
     -- for how many times the difficulty increased or decreased.

--- a/src/Oscoin/Telemetry/Events.hs
+++ b/src/Oscoin/Telemetry/Events.hs
@@ -6,7 +6,6 @@ import           Oscoin.Prelude
 
 import qualified Oscoin.Consensus.Types as Consensus
 import           Oscoin.Crypto.Blockchain.Block.Difficulty (Difficulty)
-import qualified Oscoin.Crypto.Blockchain.Eval as Eval
 import           Oscoin.Crypto.Hash (HasHashing, Hash, Hashable, Hashed)
 import           Oscoin.Crypto.PubKey (PublicKey)
 import qualified Oscoin.P2P.Trace as P2P (Traceable)
@@ -55,11 +54,6 @@ data NotableEvent where
     BlockValidationFailedEvent :: forall c. (Buildable (Hash c), HasHashing c)
                                => Hash c
                                -> Consensus.ValidationError c
-                               -> NotableEvent
-    -- | Triggered every time a 'Block' fails to evaluate.
-    BlockEvaluationFailedEvent :: forall c. (Buildable (Hash c), HasHashing c)
-                               => Hash c
-                               -> Eval.EvalError
                                -> NotableEvent
     -- | Triggered when the 'Difficulty' is adjusted. The first argument is
     -- the new difficulty, the second the (now) previous one.

--- a/test/Oscoin/Test/HTTP/Helpers.hs
+++ b/test/Oscoin/Test/HTTP/Helpers.hs
@@ -171,7 +171,7 @@ withNode emptyTxOutput validateTx seal NodeState{..} k = do
         pure mp
 
     blkStore@(blockStoreReader, _) <- newBlockStoreIO (blocks' blockstoreState)
-    let dummyEvalBlock _ txs s = (map (\_ -> Right emptyTxOutput) txs, s)
+    let dummyEvalBlock _ txs s = (map (const emptyTxOutput) txs, s)
     ledger <- Ledger.newFromBlockStoreIO dummyEvalBlock blockStoreReader statestoreState
     runProtocol (\_ _ -> Right ()) blockScore metrics blkStore config $ \dispatchBlock ->
         Node.withNode

--- a/test/Test/Oscoin/API.hs
+++ b/test/Test/Oscoin/API.hs
@@ -75,7 +75,7 @@ tests Dict = testGroup "Test.Oscoin.API"
                     { txHash = Crypto.hash tx
                     , txBlockHash = Just (blockHash blk)
                     , txConfirmations = 6
-                    , txOutput = Just (Right [])
+                    , txOutput = Just []
                     , txPayload = tx
                     }
             response @?= API.Ok expected

--- a/test/Test/Oscoin/DummyLedger.hs
+++ b/test/Test/Oscoin/DummyLedger.hs
@@ -52,4 +52,4 @@ type DummyOutput = DummyTx
 
 -- | Prepends the transaction to the state and output the transaction.
 dummyEvalBlock :: Evaluator c DummyState DummyTx DummyOutput
-dummyEvalBlock _beneficiary txs st = (map Right txs, reverse txs <> st )
+dummyEvalBlock _beneficiary txs st = (txs, reverse txs <> st )

--- a/test/Test/Oscoin/Storage/Ledger.hs
+++ b/test/Test/Oscoin/Storage/Ledger.hs
@@ -66,7 +66,7 @@ prop_lookupReceipt Dict = property $ do
 
     receiptTx receipt === Crypto.hash tx
     receiptTxBlock receipt === blockHash blk
-    receiptTxOutput receipt === Right tx
+    receiptTxOutput receipt === tx
 
 
 -- Checks that a block created with 'Ledger.buildNextBlock' satisfies


### PR DESCRIPTION
Errors are encoded in the transaction output. We change the `Evaluator` type accordingly.