### PR TITLE
GCE: fix log source

### DIFF
--- a/src/Oscoin/Deployment/Internal/GCE.hs
+++ b/src/Oscoin/Deployment/Internal/GCE.hs
@@ -155,7 +155,7 @@ cloudConfig (max 1 . min 8 -> numLocalDisks) containers =
             . plainTextFileContents $ Text.unlines
                 [ "<source>"
                 , "  @type systemd"
-                , "  match [{\"CONTAINER_NAME\": \"" <> container <> "\"}]"
+                , "  filters [{\"CONTAINER_NAME\": \"" <> container <> "\"}]"
                 , "  <storage>"
                 , "    @type local"
                 , "    persistent true"


### PR DESCRIPTION
Apparently, the fluentd version which comes with COS doesn't understand `match` (yet), and just silently ignores the source.

Note that there is at least one builtin rule which may cause log records to be shipped multiple times: any journal message with severity >= warning will end up `logName=projects/[PROJECT]/logs/cos_journal_warning`.