### PR TITLE
Start the miner only after first sync finishes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist-newstyle
 dist
 .ghc.environment*
 blockstore.db
+stack.yaml.lock

--- a/src/Oscoin/Protocol/Sync/RealWorld.hs
+++ b/src/Oscoin/Protocol/Sync/RealWorld.hs
@@ -247,11 +247,11 @@ syncNode
     -- first time.
     -> SyncT c tx s m ()
 syncNode onReady = do
-    lift . onReady =<< catchingSyncErrors (syncUntil (\_ _ _ -> False))
+    lift . onReady =<< catchingSyncErrors (syncUntil (isDone . scNu))
     forever $ do
-        void $ catchingSyncErrors sync
         -- Throttle each iteration of the algorithm by 30 seconds.
         liftIO $ threadDelay 30000000
+        void $ catchingSyncErrors sync
   where
       catchingSyncErrors action =
           (Right <$> action) `catchError`


### PR DESCRIPTION
Fix #628. 

This PR extends the `sync` interface for the `RealWorld` implementation with an `onReady` callback of type `Either SyncError (LocalTip c tx s, RemoteTip c tx s) -> m ()` which will be called once the node completed the first (mandatory) sync round.

The use of `Either` in the callback ensure that in case of errors (for example if the node is isolated) the miner will be started anyway, and the error propagated to the callback which then can deal with it (or ignore it).

At the moment in `exe/Main.hs` we are not doing anything with the result of the sync process, but future PR might capitalise on this by using the local & remote tips in interesting ways.