### PR TITLE
Make 'Client' polymorphic in tx

### DIFF
--- a/src/Oscoin/API/Client.hs
+++ b/src/Oscoin/API/Client.hs
@@ -7,23 +7,16 @@ module Oscoin.API.Client
 import           Oscoin.Prelude
 
 import           Oscoin.API.Types
-import           Oscoin.Crypto.Hash (Hashed)
 import           Oscoin.Data.Tx
 
 data Client c m = Client
     { submitTransaction :: Tx c -> m (Result (TxSubmitResponse c (Tx c)))
-
-    -- | Returns an error result if a transaction with the given hash
-    -- was not found.
-    , getTransaction :: Hashed c (Tx c) -> m (Result (TxLookupResponse c (Tx c)))
-
-    , getState :: ByteString -> m (Maybe ByteString)
+    , getState          :: ByteString -> m (Maybe ByteString)
     }
 
 
 hoistClient :: (forall a. m a -> n a) -> Client c m -> Client c n
 hoistClient natTrsf client = Client
     { submitTransaction = natTrsf . submitTransaction client
-    , getTransaction = natTrsf . getTransaction client
     , getState = natTrsf . getState client
     }

--- a/src/Oscoin/API/Client.hs
+++ b/src/Oscoin/API/Client.hs
@@ -7,15 +7,14 @@ module Oscoin.API.Client
 import           Oscoin.Prelude
 
 import           Oscoin.API.Types
-import           Oscoin.Data.Tx
 
-data Client c m = Client
-    { submitTransaction :: Tx c -> m (Result (TxSubmitResponse c (Tx c)))
+data Client c tx m = Client
+    { submitTransaction :: tx -> m (Result (TxSubmitResponse c tx))
     , getState          :: ByteString -> m (Maybe ByteString)
     }
 
 
-hoistClient :: (forall a. m a -> n a) -> Client c m -> Client c n
+hoistClient :: (forall a. m a -> n a) -> Client c tx m -> Client c tx n
 hoistClient natTrsf client = Client
     { submitTransaction = natTrsf . submitTransaction client
     , getState = natTrsf . getState client

--- a/src/Oscoin/API/Client/HTTP.hs
+++ b/src/Oscoin/API/Client/HTTP.hs
@@ -15,7 +15,6 @@ import           Oscoin.Prelude hiding (get)
 
 import           Oscoin.API.Client
 import           Oscoin.Crypto.Hash (Hash)
-import           Oscoin.Crypto.PubKey (PublicKey, Signature)
 
 import           Codec.Serialise
 import qualified Data.ByteString.BaseN as BaseN
@@ -26,13 +25,12 @@ import           Network.HTTP.Types.Status
 
 createNetworkHttpClient
     :: ( Serialise (Hash c)
-       , Serialise (PublicKey c)
-       , Serialise (Signature c)
+       , Serialise tx
        , MonadIO m
        , MonadThrow m
        , MonadIO n
        )
-    => Text -> n (Client c m)
+    => Text -> n (Client c tx m)
 createNetworkHttpClient uri = liftIO $ do
     manager <- Client.newManager Client.defaultManagerSettings
     baseRequest <- Client.parseRequest (toS uri)
@@ -58,11 +56,10 @@ data Response = Response
 -- requests.
 httpClientFromRequest
     :: ( Serialise (Hash c)
-       , Serialise (PublicKey c)
-       , Serialise (Signature c)
+       , Serialise tx
        , MonadThrow m
        )
-    => (Request -> m Response) -> Client c m
+    => (Request -> m Response) -> Client c tx m
 httpClientFromRequest httpRequest = Client{..}
     where
         submitTransaction tx =

--- a/src/Oscoin/API/Client/HTTP.hs
+++ b/src/Oscoin/API/Client/HTTP.hs
@@ -14,22 +14,18 @@ module Oscoin.API.Client.HTTP
 import           Oscoin.Prelude hiding (get)
 
 import           Oscoin.API.Client
-import           Oscoin.Crypto.Blockchain.Block (BlockHash)
-import           Oscoin.Crypto.Hash (Hash, fromHashed)
+import           Oscoin.Crypto.Hash (Hash)
 import           Oscoin.Crypto.PubKey (PublicKey, Signature)
 
 import           Codec.Serialise
 import qualified Data.ByteString.BaseN as BaseN
-import           Formatting.Buildable (Buildable)
 import qualified Network.HTTP.Client as Client
 import           Network.HTTP.Types.Header
 import           Network.HTTP.Types.Method
 import           Network.HTTP.Types.Status
-import           Web.HttpApiData (toUrlPiece)
 
 createNetworkHttpClient
-    :: ( Buildable (Hash c)
-       , Serialise (BlockHash c)
+    :: ( Serialise (Hash c)
        , Serialise (PublicKey c)
        , Serialise (Signature c)
        , MonadIO m
@@ -61,8 +57,7 @@ data Response = Response
 -- | Make a 'Client' from a function executing the underlying HTTP
 -- requests.
 httpClientFromRequest
-    :: ( Buildable (Hash c)
-       , Serialise (BlockHash c)
+    :: ( Serialise (Hash c)
        , Serialise (PublicKey c)
        , Serialise (Signature c)
        , MonadThrow m
@@ -72,9 +67,6 @@ httpClientFromRequest httpRequest = Client{..}
     where
         submitTransaction tx =
             post httpRequest "/transactions" tx
-
-        getTransaction txId =
-            get httpRequest $ "/transactions/" <> toUrlPiece (fromHashed txId)
 
         getState key =
             get httpRequest $ "/state/" <> toS (BaseN.encodedBytes $ BaseN.encodeBase16 key)

--- a/src/Oscoin/API/HTTP.hs
+++ b/src/Oscoin/API/HTTP.hs
@@ -8,7 +8,6 @@ import           Oscoin.Prelude hiding (get)
 
 import           Oscoin.Crypto (Crypto)
 import           Oscoin.Crypto.Blockchain.Block (BlockHash, SealedBlock)
-import           Oscoin.Crypto.Hash (toHashed)
 import qualified Oscoin.Crypto.Hash as Crypto
 import           Oscoin.Crypto.Hash.RealWorld ()
 import           Oscoin.Crypto.PubKey.RealWorld ()
@@ -103,10 +102,6 @@ api mdlware = do
     -- /transactions ----------------------------------------------------------
 
     post "transactions" Handlers.submitTransaction
-
-    -- /transactions/:id ------------------------------------------------------
-
-    get ("transactions" <//> var) (Handlers.getTransaction . toHashed)
 
     -- /state/:key ------------------------------------------------------------
 

--- a/src/Oscoin/API/Types.hs
+++ b/src/Oscoin/API/Types.hs
@@ -1,20 +1,16 @@
 {-# LANGUAGE UndecidableInstances #-}
 module Oscoin.API.Types
     ( Result(..)
-    , TxLookupResponse(..)
     , isOk
     , isErr
     , resultToEither
     , TxSubmitResponse(..)
     ) where
 
-import           Oscoin.Crypto.Blockchain.Block (BlockHash)
-import           Oscoin.Crypto.Hash (HasHashing, Hash, Hashed)
-import           Oscoin.Data.Tx.Abstract
+import           Oscoin.Crypto.Hash (Hash, Hashed)
 import           Oscoin.Prelude
 
 import qualified Codec.Serialise as Serial
-import           Numeric.Natural
 
 data Result a =
       Ok  a
@@ -33,39 +29,6 @@ isErr = not . isOk
 resultToEither :: Result a -> Either Text a
 resultToEither (Ok a ) = Right a
 resultToEither (Err t) = Left t
-
--- | Response type of a transaction lookup API operation.
-data TxLookupResponse c tx = TxLookupResponse
-    { txHash          :: Hashed c tx
-    -- ^ Hash of the transaction.
-    , txBlockHash     :: Maybe (BlockHash c)
-    -- ^ @BlockHash@ of the 'Block' in which the transaction was included.
-    , txOutput        :: Maybe (TxOutput c tx)
-    -- ^ Output of the transaction if it was evaluated. If the
-    -- evaluation was successful the transaction is included in the
-    -- block 'txBlockHash'.
-    , txConfirmations :: Natural
-    -- ^ Block depth of the 'Block' in which the transaction was included,
-    -- which is the number of blocks from the tip up until, and including,
-    -- the 'Block' referenced by 'txBlockHash'.
-    , txPayload       :: tx
-    -- ^ The transaction itself.
-    } deriving (Generic)
-
-deriving instance ( HasHashing c
-                  , Show (Hash c)
-                  , Show tx
-                  , Show (TxOutput c tx)
-                  ) => Show (TxLookupResponse c tx)
-deriving instance ( Eq (Hash c)
-                  , Eq tx
-                  , Eq (TxOutput c tx)
-                  ) => Eq (TxLookupResponse c tx)
-
-instance ( Serial.Serialise (Hash c)
-         , Serial.Serialise tx
-         , Serial.Serialise (TxOutput c tx)
-         ) => Serial.Serialise (TxLookupResponse c tx)
 
 -- | A transaction receipt. Contains the hashed transaction.
 newtype TxSubmitResponse c tx = TxSubmitResponse (Hashed c tx)

--- a/src/Oscoin/CLI/Command.hs
+++ b/src/Oscoin/CLI/Command.hs
@@ -8,7 +8,6 @@ module Oscoin.CLI.Command
 import           Oscoin.Prelude
 
 import qualified Crypto.Data.Auth.Tree.Class as AuthTree
-import qualified Oscoin.API.Client as API
 import           Oscoin.CLI.KeyStore
 import           Oscoin.Crypto.Blockchain.Block
 import           Oscoin.Crypto.Blockchain.Genesis (createGenesisParameters)
@@ -33,8 +32,6 @@ class (MonadRandom m, MonadKeyStore c m) => MonadCLI c m where
     putLine :: Text -> m ()
     -- | Get the current time
     getTime :: m Timestamp
-
-    getClient :: m (API.Client c m)
 
 data Result
     = ResultOk

--- a/test/Oscoin/Test/API/HTTP/TestClient.hs
+++ b/test/Oscoin/Test/API/HTTP/TestClient.hs
@@ -14,7 +14,7 @@ module Oscoin.Test.API.HTTP.TestClient
     , session
     ) where
 
-import           Oscoin.Prelude hiding (get)
+import           Oscoin.Prelude
 
 import           Oscoin.API.Client
 import           Oscoin.API.Client.HTTP
@@ -27,7 +27,7 @@ import qualified Network.Wai as Wai
 import qualified Network.Wai.Test as Wai
 
 
-session :: (IsCrypto c) => Client c (Session c (Tx c) DummySeal)
+session :: (IsCrypto c) => Client c (Tx c) (Session c (Tx c) DummySeal)
 session = httpClientFromRequest makeWaiRequest
 
 makeWaiRequest :: Request -> Session c (Tx c) DummySeal Response

--- a/test/Oscoin/Test/CLI/Helpers.hs
+++ b/test/Oscoin/Test/CLI/Helpers.hs
@@ -91,7 +91,6 @@ instance IsCrypto c => MonadCLI c (TestCommandRunner c) where
     putLine t     = putStr (t <> "\n")
     putString t   = modify $ \s -> s { commandOutput = commandOutput s <> t }
     getTime       = pure Time.epoch
-    getClient     = panic "Test client not implemented"
 
 
 instance MonadRandom (TestCommandRunner c) where


### PR DESCRIPTION
Before, the `Client` interface was fixed to the legacy transaction type. To make the Ledger API work with OcoinTx (#549) we make it polymorphic in the transaction type.

To make this easier we include the following refactorings in separate commits:

* Remove API client from CLI. It is currently unused. We are also not going to build on `MonadCLI` for the account CLI that will use the client.
* We remove `getTransaction` from the node’s HTTP API. The endpoint in its current is not needed for anything. It also does not match the specification of that endpoint documented in the specs. Instead of carrying this dead weight around we are removing it. This was briefly discussed with and okayed by @cloudhead.