### PR TITLE
Decouple legacy tx output from oscoin tx output

### DIFF
--- a/src/Oscoin/Data/Tx.hs
+++ b/src/Oscoin/Data/Tx.hs
@@ -4,6 +4,7 @@ module Oscoin.Data.Tx where
 import           Oscoin.Prelude
 
 import           Oscoin.Crypto.Blockchain.Block (BlockHash)
+import           Oscoin.Crypto.Blockchain.Eval (Evaluator)
 import           Oscoin.Crypto.Hash
 import qualified Oscoin.Crypto.Hash as Crypto
 import           Oscoin.Crypto.PubKey
@@ -17,11 +18,10 @@ import           Control.Monad.Fail (fail)
 import           Data.ByteArray (ByteArrayAccess)
 import qualified Data.Map as Map
 
-import qualified Oscoin.Data.OscoinTx as OscoinTx
 import           Oscoin.Data.Query
 
 
-type instance TxOutput c (Tx c) = OscoinTx.TxOutput
+type instance TxOutput c (Tx c) = DummyPayload
 type instance TxState c (Tx c) = LegacyTxState
 
 newtype LegacyTxState = LegacyTxState (Map ByteString ByteString)
@@ -123,3 +123,9 @@ validateTx Tx{..} =
     if verify txPubKey txMessage
     then Right ()
     else Left TxInvalidSignature
+
+
+evaluateBlock :: Evaluator c LegacyTxState (Tx c) DummyPayload
+evaluateBlock _beneficiary txs st = first reverse $ foldl' go ([], st) txs
+  where
+    go (output, st') tx = (txMessageContent tx : output, st')

--- a/src/Oscoin/Data/Tx.hs
+++ b/src/Oscoin/Data/Tx.hs
@@ -27,6 +27,9 @@ type instance TxState c (Tx c) = LegacyTxState
 newtype LegacyTxState = LegacyTxState (Map ByteString ByteString)
     deriving (Show, Eq, Semigroup, Monoid)
 
+emptyState :: LegacyTxState
+emptyState = LegacyTxState mempty
+
 instance HasHashing c => Hashable c LegacyTxState where
     hash (LegacyTxState st) = toHashed . fromHashed . hashSerial $ st
 

--- a/test/Test/Oscoin/Protocol/Sync.hs
+++ b/test/Test/Oscoin/Protocol/Sync.hs
@@ -546,7 +546,7 @@ spinUpNode
 spinUpNode Dict tokens (peer, peerChain) = (\a -> link a >> pure a) =<<
     async (do
         let initialState = nodeState mempty peerChain emptyState
-        withNode mempty validateTx Nakamoto.emptyPoW initialState $ \hdl ->
+        withNode evaluateBlock validateTx Nakamoto.emptyPoW initialState $ \hdl ->
             API.runApi' noLogger
                         (atomically $ writeTBQueue tokens ())
                         (API.api identity)


### PR DESCRIPTION
To make it easier to change `TxOutput` from `OscoinTx` we decouple it from `TxOutput` from `Tx` (the legacy tx) by changing the `TxOutput` type family instance. This change has some repercussions and requires us adapt `withNode` from `Oscoin.Test.HTTP.Helpers`.

This in turn would require us to run the sync tests with the OscoinTx evaluator. Since this evaluator does not yet exist we opt for running the sync tests with the legacy tx. This requires a switch to the memory block store.