### PR TITLE
Short hash parsing and serialising

### DIFF
--- a/src/Oscoin/Crypto/Hash/Mock.hs
+++ b/src/Oscoin/Crypto/Hash/Mock.hs
@@ -16,6 +16,7 @@ import           Codec.Serialise
 import           Crypto.Data.Auth.Tree.Class (MerkleHash(..))
 import           Data.Aeson hiding (decode, encode)
 import           Data.Aeson.Types (typeMismatch)
+import qualified Data.Binary as Binary
 import           Data.ByteArray (ByteArrayAccess(..), convert)
 import           Data.ByteArray.Orphans ()
 import qualified Data.ByteString as BS
@@ -62,11 +63,6 @@ instance HasHashing MockCrypto where
     zeroShortHash = ShortHash zeroHash
 
     toShortHash = ShortHash
-
-    parseShortHash t =
-        case readMaybe . T.unpack $ t of
-          Just w64 -> pure $ ShortHash $ FnvHash (FnvHash64 w64)
-          Nothing  -> Nothing
 
     compactHash (FnvHash (FnvHash64 w64)) = BS.take 7
                                           . BaseN.encodedBytes
@@ -159,8 +155,9 @@ instance MerkleHash (Hash MockCrypto) where
 instance Buildable (Hash MockCrypto) where
     build (FnvHash (FnvHash64 w64)) = F.bprint F.build w64
 
-instance Buildable (ShortHash MockCrypto) where
-    build (ShortHash h) = build h
+instance Binary.Binary (ShortHash MockCrypto) where
+    put = notImplemented
+    get = notImplemented
 
 instance Sql.ToField (Hash MockCrypto) where
     toField (FnvHash (FnvHash64 w64)) = Sql.SQLText . T.pack . show $ w64

--- a/src/Oscoin/Crypto/Hash/RealWorld.hs
+++ b/src/Oscoin/Crypto/Hash/RealWorld.hs
@@ -18,6 +18,7 @@ import qualified Crypto.Data.Auth.Tree.Cryptonite as Cryptonite
 import           Crypto.Hash (Blake2b_256(..), Digest, RIPEMD160(..))
 import qualified Crypto.Hash as Crypto
 import           Data.Aeson (FromJSON(..), ToJSON(..), withText)
+import qualified Data.Binary as Binary
 import           Data.ByteArray (ByteArrayAccess, convert)
 import qualified Data.ByteArray as ByteArray
 import qualified Data.ByteString as BS
@@ -66,12 +67,6 @@ instance HasHashing Crypto where
 
     hashAlgorithm = Blake2b_256
 
-    parseShortHash t = do
-        t' <- T.stripPrefix "0x" t
-        case BaseN.decodeAtBaseEither BaseN.Base16 (encodeUtf8 t') of
-            Left _  -> Nothing
-            Right h -> ShortHash <$> Crypto.digestFromByteString h
-
     toShortHash h = ShortHash
                   . Crypto.hash @ByteString @RIPEMD160
                   . ByteArray.convert @(Crypto.Digest (HashAlgorithm Crypto)) @ByteString
@@ -107,6 +102,10 @@ instance Hashable Crypto Word8 where
 instance (ByteArrayAccess a) => Hashable Crypto (Maybe a) where
     hash (Just x) = toHashed . Hash $ Crypto.hash x
     hash Nothing  = toHashed $ zeroHash
+
+instance Binary.Binary (ShortHash Crypto) where
+    put = notImplemented
+    get = notImplemented
 
 {------------------------------------------------------------------------------
   Serialisation instances


### PR DESCRIPTION
The account CLI needs to display and parse human readable short hashes (account IDs). To make this easy I propose a couple of changes.

Currently, the `HasHashing` class provides a method to parse a short hash from `Text`. A partial inverse of this function only exists as `formatShortHash` which returns a formatter and `show`. It is not clear that these functions are inverse to each other and this is nowhere enforced.

I propose to decouple the byte representation of a short hash from the human readable representation (encoding) of those bytes. In particular `parseShortHash` is removed from the `HasHashing` type class and replaced with a `Binary (ShortHash c)` constraint.

This has the additional advantage that the encoding is independent of the type class. We also make it easier to implement different polymorphic encoding/decoding functions for short hashes in the future

The same approach could be adapted for `Hash`, too.

Todo

- [ ] Test tripping
- [ ] Implement `Binary` instances